### PR TITLE
add run-locally script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+kueue-operator
 
 # Test binary, built with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ on the Kueue release policy.
 1. Run `operator sdk run bundle --namespace OPERATOR_NAMESPACE ${BUNDLE_IMAGE}`
 to deploy operator to OPERATOR_NAMESPACE
 
+### Local Development
+
+1. make
+
+1. `oc apply -f deploy/`
+
+1. `oc apply -f deploy/crd`
+
+1. hack/run-locally.sh
+
+1. Optionally run `oc apply -f deploy/examples/job.yaml`
+
 ## Sample CR
 
 ```yaml

--- a/hack/run-locally.sh
+++ b/hack/run-locally.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# run-locally.sh is some scaffolding around running a local instance of the
+# network operator with the installer.
+# See HACKING.md
+
+set -o errexit
+set -o nounset
+
+if [[ -n "${HACK_MINIMIZE:-}" ]]; then
+	echo "HACK_MINIMIZE set! This is only for development, and the installer will likely not succeed."
+	echo "You will still be left with a reasonably functional cluster."
+	echo ""
+fi
+
+function run_vs_existing_cluster {
+	echo "Attaching to already running cluster..."
+	wait_for_cluster
+}
+
+function setup_operator_env() {
+	# library-go controller needs to write stuff here
+	if [[ ! -w "/var/run/secrets" ]]; then
+		echo "Need /var/run/secrets to be writable, please execute"
+		echo sudo /bin/bash -c "'mkdir -p /var/run/secrets && chown ${USER} /var/run/secrets'"
+	fi
+
+	mkdir -p /var/run/secrets/kubernetes.io/serviceaccount/
+	echo -n "openshift-kueue-operator" >/var/run/secrets/kubernetes.io/serviceaccount/namespace
+}
+
+function print_usage() {
+	>&2 echo "Usage: $0 [options]
+
+$0 runs against an existing cluster using the specific '-k' option.
+
+The following environment variables are honored:
+ - KUBECONFIG: the kubeconfig pointing to the existing cluster 
+"
+}
+
+EXPORT_ENV_ONLY=false
+WAIT_FOR_MANIFEST_UPDATES="${WAIT_FOR_MANIFEST_UPDATES:-}"
+KUBECONFIG="${KUBECONFIG:-}"
+
+while getopts "e?m:k:n:w" opt; do
+	case $opt in
+	e) EXPORT_ENV_ONLY=true ;;
+	k) KUBECONFIG="${OPTARG}" ;;
+	w)
+		WAIT_FOR_MANIFEST_UPDATES=1
+		;;
+	*)
+		print_usage
+		exit 2
+		;;
+	esac
+done
+
+if [[ -z "$(which oc 2>/dev/null || exit 0)" ]]; then
+	echo "error: could not find 'oc' in PATH" >&2
+	exit 1
+fi
+
+setup_operator_env
+
+./kueue-operator operator --kubeconfig "${KUBECONFIG}"


### PR DESCRIPTION
This PR creates a script so we can hack on the operator locally.

1. make
1. `oc apply -f deploy/`
1. `oc apply -f deploy/crd`
1. `hack/run-locally.sh`
1. Optionally run `oc apply -f deploy/examples/job.yaml`