### PR TITLE
add feature gates to config map so one can set them

### DIFF
--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -88,6 +88,7 @@ func defaultKueueConfigurationTemplate(kueueCfg kueue.KueueConfiguration) *confi
 		InternalCertManagement: &configapi.InternalCertManagement{
 			Enable: ptr.To(false),
 		},
-		Resources: kueueCfg.Resources,
+		Resources:    kueueCfg.Resources,
+		FeatureGates: kueueCfg.FeatureGates,
 	}
 }

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -144,6 +144,47 @@ webhook:
 			},
 			wantErr: nil,
 		},
+		"feature gates": {
+			configuration: kueue.KueueConfiguration{
+				FeatureGates: map[string]bool{
+					"LocalQueueMetrics": true,
+				},
+				Integrations: configapi.Integrations{
+					Frameworks: []string{"batch.job"},
+				},
+			},
+			wantCfgMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta1
+controller:
+  groupKindConcurrency:
+    ClusterQueue.kueue.x-k8s.io: 1
+    Job.batch: 5
+    LocalQueue.kueue.x-k8s.io: 1
+    Pod: 5
+    ResourceFlavor.kueue.x-k8s.io: 1
+    Workload.kueue.x-k8s.io: 5
+featureGates:
+  LocalQueueMetrics: true
+health:
+  healthProbeBindAddress: :8081
+integrations:
+  frameworks:
+  - batch.job
+internalCertManagement:
+  enable: false
+kind: Configuration
+manageJobsWithoutQueueName: false
+metrics:
+  bindAddress: :8080
+  enableClusterQueueResources: true
+webhook:
+  port: 9443
+`,
+				},
+			},
+			wantErr: nil,
+		},
 	}
 
 	for desc, tc := range testCases {


### PR DESCRIPTION
Discovered a bug where feature gates are never populated to ConfigMap.

You could reproduce this bug:

```yaml
apiVersion: operator.openshift.io/v1alpha1
kind: Kueue
metadata:
  labels:
    app.kubernetes.io/name: kueue-operator
    app.kubernetes.io/managed-by: kustomize
  name: cluster
  namespace: openshift-kueue-operator
spec:
  config:
    featureGates:
      LocalQueueMetrics: true
    integrations:
      frameworks:
      - "batch/job" 
```

Without this code, Kueue will set feature gates based on their defaults. With this change, one is able to set different feature gates.