### PR TITLE
generate required files for basic fbc

### DIFF
--- a/fbc/v4.18/Containerfile.catalog
+++ b/fbc/v4.18/Containerfile.catalog
@@ -1,0 +1,21 @@
+# The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM registry.redhat.io/openshift4/ose-operator-registry:v4.18
+
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+COPY catalog/ /configs
+
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+# Core bundle labels.
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=kueue-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.33.1
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/fbc/v4.18/catalog-template.yaml
+++ b/fbc/v4.18/catalog-template.yaml
@@ -1,0 +1,13 @@
+Schema: olm.semver
+GenerateMajorChannels: false
+GenerateMinorChannels: true
+DefaultChannelTypePreference: "minor"
+Candidate:
+  Bundles:
+  - Image: quay.io/redhat-user-workloads/kueue-operator-tenant/kueue-bundle@sha256:77c9f5d061b66f3a496d3ed95757ac60590729aea49fca600f162fbba510cada
+Fast:
+  Bundles:
+  - Image: quay.io/redhat-user-workloads/kueue-operator-tenant/kueue-bundle@sha256:77c9f5d061b66f3a496d3ed95757ac60590729aea49fca600f162fbba510cada
+Stable:
+  Bundles:
+  - Image: quay.io/redhat-user-workloads/kueue-operator-tenant/kueue-bundle@sha256:77c9f5d061b66f3a496d3ed95757ac60590729aea49fca600f162fbba510cada

--- a/fbc/v4.18/catalog/catalog.json
+++ b/fbc/v4.18/catalog/catalog.json
@@ -1,0 +1,149 @@
+{
+    "schema": "olm.package",
+    "name": "kueue-operator",
+    "defaultChannel": "stable-v0.0"
+}
+{
+    "schema": "olm.channel",
+    "name": "candidate-v0.0",
+    "package": "kueue-operator",
+    "entries": [
+        {
+            "name": "kueue-operator.v0.0.1"
+        }
+    ]
+}
+{
+    "schema": "olm.channel",
+    "name": "fast-v0.0",
+    "package": "kueue-operator",
+    "entries": [
+        {
+            "name": "kueue-operator.v0.0.1"
+        }
+    ]
+}
+{
+    "schema": "olm.channel",
+    "name": "stable-v0.0",
+    "package": "kueue-operator",
+    "entries": [
+        {
+            "name": "kueue-operator.v0.0.1"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "kueue-operator.v0.0.1",
+    "package": "kueue-operator",
+    "image": "quay.io/redhat-user-workloads/kueue-operator-tenant/kueue-bundle@sha256:77c9f5d061b66f3a496d3ed95757ac60590729aea49fca600f162fbba510cada",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "operator.openshift.io",
+                "kind": "Kueue",
+                "version": "v1alpha1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "kueue-operator",
+                "version": "0.0.1"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"operator.openshift.io/v1alpha1\",\n    \"kind\": \"Kueue\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\",\n        \"app.kubernetes.io/name\": \"kueue-operator\"\n      },\n      \"name\": \"cluster\",\n      \"namespace\": \"openshift-kueue-operator\"\n    },\n    \"spec\": {\n      \"config\": {\n        \"integrations\": {\n          \"frameworks\": [\n            \"BatchJob\",\n            \"Pod\",\n            \"Deployment\",\n            \"StatefulSet\"\n          ]\n        }\n      },\n      \"managementState\": \"Managed\"\n    }\n  },\n  {\n    \"apiVersion\": \"operator.openshift.io/v1alpha1\",\n    \"kind\": \"Kueue\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\",\n        \"app.kubernetes.io/name\": \"kueue-operator\"\n      },\n      \"name\": \"cluster\",\n      \"namespace\": \"openshift-kueue-operator\"\n    },\n    \"spec\": {\n      \"config\": {\n        \"integrations\": {\n          \"externalFrameworks\": [\n            \"AppWrapper\"\n          ],\n          \"frameworks\": [\n            \"BatchJob\",\n            \"RayJob\",\n            \"RayCluster\"\n          ]\n        }\n      }\n    }\n  }\n]",
+                    "capabilities": "Basic Install",
+                    "console.openshift.io/operator-monitoring-default": "true",
+                    "createdAt": "2025-04-03T17:38:12Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "false",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-kueue-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.33.0",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kueues.operator.openshift.io",
+                            "version": "v1alpha1",
+                            "kind": "Kueue"
+                        }
+                    ]
+                },
+                "description": "Kueue Operator description. TODO.",
+                "displayName": "Kueue Operator",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": true
+                    }
+                ],
+                "keywords": [
+                    "kueue-operator"
+                ],
+                "links": [
+                    {
+                        "name": "Kueue Operator",
+                        "url": "https://github.com/openshift/kueue-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Node team",
+                        "email": "aos-node@redhat.com"
+                    }
+                ],
+                "maturity": "alpha",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat, Inc",
+                    "url": "https://github.com/openshift/kueue-operator"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "operand-image",
+            "image": "quay.io/redhat-user-workloads/kueue-operator-tenant/kubernetes-sigs-kueue@sha256:ec6688b483a2919d10d7ff6876f559c7b98961c6da425d80a653f0fe55db684d"
+        },
+        {
+            "name": "",
+            "image": "quay.io/redhat-user-workloads/kueue-operator-tenant/kueue-bundle@sha256:77c9f5d061b66f3a496d3ed95757ac60590729aea49fca600f162fbba510cada"
+        },
+        {
+            "name": "operator-image",
+            "image": "quay.io/redhat-user-workloads/kueue-operator-tenant/kueue-operator@sha256:d90da026cf2633ee1a02e2f5674808088f5acd0c54c987941ccb39c214842adb"
+        }
+    ]
+}


### PR DESCRIPTION
This just creates the basic files for an FBC for one version.  THis will need to be flushed out with additional options and duplicated to support additional OCP versions

Part of [OCPNODE-3045](https://issues.redhat.com//browse/OCPNODE-3045)