### PR TITLE
use CEL expression to limit fbc konflux jobs to just changes to fbc

### DIFF
--- a/.tekton/kueue-bundle-pull-request.yaml
+++ b/.tekton/kueue-bundle-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-path-change: "[bundle/***, .tekton/kueue-bundle-pull-request.yaml, bundle.Dockerfile]"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: kueue-operator

--- a/.tekton/kueue-fbc-418-pull-request.yaml
+++ b/.tekton/kueue-fbc-418-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-path-change: "[fbc/***, .tekton/kueue-fbc-418-pull-request.yaml]"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: kueue-fbc-418

--- a/.tekton/kueue-operator-pull-request.yaml
+++ b/.tekton/kueue-operator-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-path-change-ignore: "[bundle/***, .tekton/kueue-bundle-pull-request.yaml, bundle.Dockerfile, fbc/***, .tekton/kueue-fbc-418-pull-request.yaml]"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: kueue-operator


### PR DESCRIPTION
This should only run bundle jobs on changes to bundle files, fbc jobs on changes to fbc files, and operator jobs on all other changes.  Testing is a bit tricky as there are many combinations of changes that need to work and this PR only covers one.  All jobs are running as expected since files for all three images changed.  The plan would be to merge and then check other PRs and make sure the right jobs are running.  If not we fix them or just revert this.