### PR TITLE
pkg: disable HierarchialCohorts featuregate

### DIFF
--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -133,5 +133,10 @@ func defaultKueueConfigurationTemplate(kueueCfg kueue.KueueConfiguration) *confi
 		InternalCertManagement: &configapi.InternalCertManagement{
 			Enable: ptr.To(false),
 		},
+		// Disable the HierarchicalCohorts feature gate by default.
+		// related to https://github.com/kubernetes-sigs/kueue/issues/4869
+		FeatureGates: map[string]bool{
+			"HierarchialCohorts": false,
+		},
 	}
 }

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -49,6 +49,8 @@ controller:
     Pod: 5
     ResourceFlavor.kueue.x-k8s.io: 1
     Workload.kueue.x-k8s.io: 5
+featureGates:
+  HierarchialCohorts: false
 health:
   healthProbeBindAddress: :8081
 integrations:
@@ -93,6 +95,8 @@ controller:
     Pod: 5
     ResourceFlavor.kueue.x-k8s.io: 1
     Workload.kueue.x-k8s.io: 5
+featureGates:
+  HierarchialCohorts: false
 health:
   healthProbeBindAddress: :8081
 integrations:
@@ -140,6 +144,8 @@ controller:
     Pod: 5
     ResourceFlavor.kueue.x-k8s.io: 1
     Workload.kueue.x-k8s.io: 5
+featureGates:
+  HierarchialCohorts: false
 health:
   healthProbeBindAddress: :8081
 integrations:


### PR DESCRIPTION
This is required to avoid seeing this issue in the kueue-controller-manager logs:
```sh
{"level":"error","ts":"2025-04-10T20:32:54.80835478Z","logger":"controller-runtime.source.EventHandler","caller":"source/kind.go:71","msg":"if kind is a CRD, it should be installed before calling Start","kind":"Cohort.kueue.x-k8s.io","error":"no matches for kind \"Cohort\" in version \"kueue.x-k8s.io/v1alpha1\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1.1\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/source/kind.go:71\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/source/kind.go:64"}
```