### PR TITLE
replace on-cel-expression with specific annotations

### DIFF
--- a/.tekton/kueue-bundle-pull-request.yaml
+++ b/.tekton/kueue-bundle-pull-request.yaml
@@ -8,7 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[bundle/***, .tekton/kueue-bundle-pull-request.yaml, bundle.Dockerfile]"
   creationTimestamp:
   labels:

--- a/.tekton/kueue-fbc-418-pull-request.yaml
+++ b/.tekton/kueue-fbc-418-pull-request.yaml
@@ -8,7 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[fbc/***, .tekton/kueue-fbc-418-pull-request.yaml]"
   creationTimestamp: null
   labels:

--- a/.tekton/kueue-operator-pull-request.yaml
+++ b/.tekton/kueue-operator-pull-request.yaml
@@ -8,7 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change-ignore: "[bundle/***, .tekton/kueue-bundle-pull-request.yaml, bundle.Dockerfile, fbc/***, .tekton/kueue-fbc-418-pull-request.yaml]"
   creationTimestamp:
   labels:


### PR DESCRIPTION
 From Pipeline as Code docs:

"You still need to specify the event type and target branch. If you have a CEL expression the on-path-change-ignore annotation will be ignored."

So need to replace on-cel-expression with the simpler on-target-branch and on-event annotations to allow on-path-change and on-path-change-ignore to work.  Currently they do nothing according to the docs.