### PR TITLE
use on-cel-expression to filter file changes

### DIFF
--- a/.tekton/kueue-bundle-pull-request.yaml
+++ b/.tekton/kueue-bundle-pull-request.yaml
@@ -8,8 +8,10 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
-    pipelinesascode.tekton.dev/on-path-change: "[bundle/***, .tekton/kueue-bundle-pull-request.yaml, bundle.Dockerfile]"
+    pipelinesascode.tekton.dev/on-cel-expression:
+      event == "pull_request" &&
+      target_branch == "main" &&
+      files.all.exists(path, path.matches('bundle/|bundle.Dockerfile|.tekton/kueue-bundle-pull-request.yaml'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: kueue-operator

--- a/.tekton/kueue-fbc-418-pull-request.yaml
+++ b/.tekton/kueue-fbc-418-pull-request.yaml
@@ -8,8 +8,10 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
-    pipelinesascode.tekton.dev/on-path-change: "[fbc/***, .tekton/kueue-fbc-418-pull-request.yaml]"
+    pipelinesascode.tekton.dev/on-cel-expression:
+      event == "pull_request" &&
+      target_branch == "main" &&
+      files.all.exists(path, path.matches('fbc/|.tekton/kueue-fbc-418-pull-request.yaml'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: kueue-fbc-418

--- a/.tekton/kueue-operator-pull-request.yaml
+++ b/.tekton/kueue-operator-pull-request.yaml
@@ -8,8 +8,10 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
-    pipelinesascode.tekton.dev/on-path-change-ignore: "[bundle/***, .tekton/kueue-bundle-pull-request.yaml, bundle.Dockerfile, fbc/***, .tekton/kueue-fbc-418-pull-request.yaml]"
+    pipelinesascode.tekton.dev/on-cel-expression:
+      event == "pull_request" &&
+      target_branch == "main" &&
+      files.all.exists(path, !path.matches('bundle/|bundle.Dockerfile|.tekton/kueue-bundle-pull-request.yaml|fbc/|.tekton/kueue-fbc-418-pull-request.yaml'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: kueue-operator


### PR DESCRIPTION
This change replaces the solution in PR #165. Too many complications with using separate annotations (on-path-change, on-path-change-ignore are incompatible with on-cel-expression).  The only solution is to use on-cel-expression with complicated logic.  Again, this looks like it works on this PR, but will need to check other PRs to make sure the right jobs are running.