### PR TITLE
use prod repos in CSV

### DIFF
--- a/bundle/manifests/kueue-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kueue-operator.clusterserviceversion.yaml
@@ -260,8 +260,8 @@ spec:
                 - name: OPERATOR_NAME
                   value: openshift-kueue-operator
                 - name: RELATED_IMAGE_OPERAND_IMAGE
-                  value: quay.io/redhat-user-workloads/kueue-operator-tenant/kubernetes-sigs-kueue@sha256:ec6688b483a2919d10d7ff6876f559c7b98961c6da425d80a653f0fe55db684d
-                image: quay.io/redhat-user-workloads/kueue-operator-tenant/kueue-operator@sha256:d90da026cf2633ee1a02e2f5674808088f5acd0c54c987941ccb39c214842adb
+                  value: registry.redhat.io/kueue-tech-preview/kueue-rhel9@sha256:ec6688b483a2919d10d7ff6876f559c7b98961c6da425d80a653f0fe55db684d
+                image: registry.redhat.io/kueue-tech-preview/kueue-rhel9-operator@sha256:d90da026cf2633ee1a02e2f5674808088f5acd0c54c987941ccb39c214842adb
                 imagePullPolicy: Always
                 name: openshift-kueue-operator
                 ports:
@@ -308,9 +308,9 @@ spec:
     name: Red Hat, Inc
     url: https://github.com/openshift/kueue-operator
   relatedImages:
-  - image: quay.io/redhat-user-workloads/kueue-operator-tenant/kubernetes-sigs-kueue@sha256:ec6688b483a2919d10d7ff6876f559c7b98961c6da425d80a653f0fe55db684d
+  - image: registry.redhat.io/kueue-tech-preview/kueue-rhel9@sha256:ec6688b483a2919d10d7ff6876f559c7b98961c6da425d80a653f0fe55db684d
     name: operand-image
-  - image: quay.io/redhat-user-workloads/kueue-operator-tenant/kueue-operator@sha256:d90da026cf2633ee1a02e2f5674808088f5acd0c54c987941ccb39c214842adb
+  - image: registry.redhat.io/kueue-tech-preview/kueue-rhel9-operator@sha256:d90da026cf2633ee1a02e2f5674808088f5acd0c54c987941ccb39c214842adb
     name: operator-image
   version: 0.0.1
   minKubeVersion: 1.28.0


### PR DESCRIPTION
We have to use prod repos since that is what will ship.  Internal testing will require the use of a mirror set to point prod repos to quay repos.