### PR TITLE
add network policy to isolate pod network traffic

### DIFF
--- a/bindata/assets/kueue-operator/controller-manager-metrics-service.yaml
+++ b/bindata/assets/kueue-operator/controller-manager-metrics-service.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: openshift-kueue-operator
 spec:
   ports:
-  - name: https
+  - name: metrics
     port: 8443
     protocol: TCP
     targetPort: 8443

--- a/bindata/assets/kueue-operator/deployment.yaml
+++ b/bindata/assets/kueue-operator/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: kueue
+        app.openshift.io/name: kueue # for network policies to select this pod
         control-plane: controller-manager
     spec:
       containers:

--- a/bindata/assets/kueue-operator/networkpolicy/allow-egress-api.yaml
+++ b/bindata/assets/kueue-operator/networkpolicy/allow-egress-api.yaml
@@ -1,0 +1,17 @@
+# allow outbound traffic to kube-apiserver
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kueue-allow-egress-kube-apiserver
+  namespace: openshift-kueue-operator
+spec:
+  podSelector:
+    matchLabels:
+      app.openshift.io/name: kueue # applies to both the operator and kueue pod
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 6443  # we can not use a name because it is not on the pod network
+  policyTypes:
+  - Egress
+

--- a/bindata/assets/kueue-operator/networkpolicy/allow-egress-cluster-dns.yaml
+++ b/bindata/assets/kueue-operator/networkpolicy/allow-egress-cluster-dns.yaml
@@ -1,0 +1,25 @@
+# allow traffic to cluster DNS service
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kueue-allow-egress-cluster-dns
+  namespace: openshift-kueue-operator
+spec:
+  podSelector:
+    matchLabels:
+      app.openshift.io/name: kueue # applies to both the operator and kueue pod
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default
+    ports:
+    - protocol: TCP
+      port: dns-tcp
+    - protocol: UDP
+      port: dns
+  policyTypes:
+  - Egress

--- a/bindata/assets/kueue-operator/networkpolicy/allow-ingress-metrics.yaml
+++ b/bindata/assets/kueue-operator/networkpolicy/allow-ingress-metrics.yaml
@@ -1,0 +1,16 @@
+# allow ingress traffic to metrics endpoint
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kueue-allow-ingress-metrics
+  namespace: openshift-kueue-operator
+spec:
+  podSelector:
+    matchLabels:
+      app.openshift.io/name: kueue # applies to both the operator and kueue pod
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: metrics
+  policyTypes:
+  - Ingress

--- a/bindata/assets/kueue-operator/networkpolicy/allow-ingress-visibility.yaml
+++ b/bindata/assets/kueue-operator/networkpolicy/allow-ingress-visibility.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kueue-allow-ingress-visibility
+  namespace: openshift-kueue-operator
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kueue # applies to the kueue pod only
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: visibility
+  policyTypes:
+  - Ingress

--- a/bindata/assets/kueue-operator/networkpolicy/allow-ingress-webhook.yaml
+++ b/bindata/assets/kueue-operator/networkpolicy/allow-ingress-webhook.yaml
@@ -1,0 +1,23 @@
+# allow ingress traffic to the webhook from kube-apiserver
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kueue-allow-ingress-webhook
+  namespace: openshift-kueue-operator
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kueue # applies to the kueue pod only
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-kube-apiserver
+      podSelector:
+        matchLabels:
+          app: openshift-kube-apiserver
+    ports:
+    - protocol: TCP
+      port: webhook-server
+  policyTypes:
+  - Ingress

--- a/bindata/assets/kueue-operator/networkpolicy/deny-all.yaml
+++ b/bindata/assets/kueue-operator/networkpolicy/deny-all.yaml
@@ -1,0 +1,19 @@
+# it's the default deny-all policy, applies to both ingress and egress traffic
+# it matches the kueue pod running in the shared operator namespace.
+
+# TODO: ideally kueue operator should reside in an isolated (not shared with
+# other operators) namespace where the operator has full control of the
+# namespace, this enables the operator to select all pod(s) in the namespace
+# to enforce a namespace-wide deny all policy.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kueue-deny-all
+  namespace: openshift-kueue-operator
+spec:
+  podSelector:
+    matchLabels:
+      app.openshift.io/name: kueue # applies to both the operator and kueue pod
+  policyTypes:
+  - Ingress
+  - Egress

--- a/deploy/02_role.yaml
+++ b/deploy/02_role.yaml
@@ -1,0 +1,18 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-kueue-operator-networking
+  namespace: openshift-kueue-operator
+rules:
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/deploy/03_rolebinding.yaml
+++ b/deploy/03_rolebinding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-kueue-operator-networking
+  namespace: openshift-kueue-operator
+subjects:
+  - kind: ServiceAccount
+    name: openshift-kueue-operator
+    namespace: openshift-kueue-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-kueue-operator-networking

--- a/deploy/07_deployment.yaml
+++ b/deploy/07_deployment.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         name: openshift-kueue-operator
+        app.openshift.io/name: kueue # for network policies to select this pod
     spec:
       securityContext:
         runAsNonRoot: true

--- a/pkg/util/resourceapply/networking.go
+++ b/pkg/util/resourceapply/networking.go
@@ -1,0 +1,74 @@
+package resourceapply
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	networkingclientv1 "k8s.io/client-go/kubernetes/typed/networking/v1"
+
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+
+	"k8s.io/klog/v2"
+)
+
+// TODO: move to library-go
+var (
+	networkingScheme = runtime.NewScheme()
+	networkingCodecs = serializer.NewCodecFactory(networkingScheme)
+)
+
+func init() {
+	if err := networkingv1.AddToScheme(networkingScheme); err != nil {
+		panic(fmt.Errorf("failed to add to scheme: %w", err))
+	}
+}
+
+func ReadNetworkPolicyV1OrDie(bytes []byte) *networkingv1.NetworkPolicy {
+	obj, err := runtime.Decode(networkingCodecs.UniversalDecoder(networkingv1.SchemeGroupVersion), bytes)
+	if err != nil {
+		panic(fmt.Errorf("failed to decode raw bytes into NetworkPolicy object: %w", err))
+	}
+	return obj.(*networkingv1.NetworkPolicy)
+}
+
+// ApplyNetworkPolicy applies the NetworkPolicy object specified in want to the
+// cluster diff is true if there is a diff (between the current object on the
+// cluster and the object specified in want) that needs to be applied.
+func ApplyNetworkPolicy(ctx context.Context, getter networkingclientv1.NetworkPoliciesGetter, recorder events.Recorder, want *networkingv1.NetworkPolicy) (current *networkingv1.NetworkPolicy, diff bool, err error) {
+	client := getter.NetworkPolicies(want.Namespace)
+	current, err = client.Get(ctx, want.Name, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, false, err
+		}
+
+		copy := want.DeepCopy()
+		current, err := client.Create(ctx, resourcemerge.WithCleanLabelsAndAnnotations(copy).(*networkingv1.NetworkPolicy), metav1.CreateOptions{})
+		resourcehelper.ReportCreateEvent(recorder, want, err)
+		return current, false, err
+	}
+
+	copy := current.DeepCopy()
+	resourcemerge.EnsureObjectMeta(&diff, &copy.ObjectMeta, want.ObjectMeta)
+	if !diff && equality.Semantic.DeepEqual(current.Spec, want.Spec) {
+		return current, false, nil
+	}
+
+	copy.Spec = *want.Spec.DeepCopy()
+	if klog.V(2).Enabled() {
+		klog.Infof("NetworkPolicy %q changes: %v", want.Namespace+"/"+want.Name, resourceapply.JSONPatchNoError(current, copy))
+	}
+
+	current, err = client.Update(ctx, copy, metav1.UpdateOptions{})
+	resourcehelper.ReportUpdateEvent(recorder, want, err)
+	return current, true, err
+}

--- a/pkg/util/resourceapply/networking_test.go
+++ b/pkg/util/resourceapply/networking_test.go
@@ -1,0 +1,234 @@
+package resourceapply
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+	clocktesting "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+func TestApplyNetworkPolicy(t *testing.T) {
+	newObject := func() *networkingv1.NetworkPolicy {
+		return &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeIngress,
+					networkingv1.PolicyTypeEgress,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		// current represents what exists on the cluster
+		// desired represents the desired object passed to ApplyNetworkPolicy
+		// expected represents the object on the cluster after ApplyNetworkPolicy returns
+		setup func() (current, desired, expected *networkingv1.NetworkPolicy)
+		// used to mutate the object returned from ApplyNetworkPolicy
+		mutator func(*networkingv1.NetworkPolicy)
+
+		// expectation
+		operations []string
+		diff       bool
+		err        error
+	}{
+		{
+			name: "object does not exist on cluster, should be created",
+			setup: func() (current, desired, expected *networkingv1.NetworkPolicy) {
+				return nil, newObject(), newObject()
+			},
+			diff:       false,
+			operations: []string{"get", "create"},
+		},
+		{
+			name: "object exists on cluster, no change in spec desired, should not call update",
+			setup: func() (current, desired, expected *networkingv1.NetworkPolicy) {
+				return newObject(), newObject(), newObject()
+			},
+			diff:       false,
+			operations: []string{"get"}, // update not expected
+		},
+		{
+			name: "object exists on cluster, desired spec changes, should call update",
+			setup: func() (current, desired, expected *networkingv1.NetworkPolicy) {
+				current, desired = newObject(), newObject()
+				desired.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: ptr.To(corev1.ProtocolTCP),
+								Port:     &intstr.IntOrString{IntVal: 6443},
+							},
+						},
+					},
+				}
+
+				expected = desired.DeepCopy()
+				// resourcemerge.EnsureObjectMeta creates an empty instances, see
+				// https://github.com/openshift/library-go/blob/ac3ba9eb16a23890629f719f3fe11428ad395796/pkg/operator/resource/resourcemerge/object_merger.go#L154-L156
+				expected.Labels = map[string]string{}
+				expected.Annotations = map[string]string{}
+				expected.OwnerReferences = []metav1.OwnerReference{}
+
+				return current, desired, expected
+			},
+			diff:       true,
+			operations: []string{"get", "update"},
+		},
+		{
+			name: "object exists on cluster, desired spec changes, existing labels/annotations/ownerreferences should be preserved",
+			setup: func() (current, desired, expected *networkingv1.NetworkPolicy) {
+				current, desired = newObject(), newObject()
+
+				current.Labels = map[string]string{"key-1": "1"}
+				current.Annotations = map[string]string{"key-2": "2"}
+				current.OwnerReferences = []metav1.OwnerReference{
+					{Name: "foo"},
+				}
+
+				desired.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: ptr.To(corev1.ProtocolTCP),
+								Port:     &intstr.IntOrString{IntVal: 6443},
+							},
+						},
+					},
+				}
+				desired.Labels = map[string]string{"key-3": "3"}
+				desired.Annotations = map[string]string{"key-4": "4"}
+				desired.OwnerReferences = []metav1.OwnerReference{
+					{Name: "bar"},
+				}
+
+				expected = desired.DeepCopy()
+				expected.Labels["key-1"] = "1"
+				expected.Annotations["key-2"] = "2"
+				expected.OwnerReferences = []metav1.OwnerReference{
+					{Name: "foo"},
+					{Name: "bar"},
+				}
+
+				return current, desired, expected
+			},
+			diff:       true,
+			operations: []string{"get", "update"},
+		},
+
+		{
+			name: "object exists on cluster, desired object should be immutable",
+			setup: func() (current, desired, expected *networkingv1.NetworkPolicy) {
+				current, desired = newObject(), newObject()
+				desired.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: ptr.To(corev1.ProtocolTCP),
+								Port:     &intstr.IntOrString{IntVal: 6443},
+							},
+						},
+					},
+				}
+
+				expected = desired.DeepCopy()
+				expected.Labels = map[string]string{}
+				expected.Annotations = map[string]string{}
+				expected.OwnerReferences = []metav1.OwnerReference{}
+
+				return current, desired, expected
+			},
+			mutator: func(p *networkingv1.NetworkPolicy) {
+				// mutate a pointer field that will be shared between the
+				// two objects if DeepCopy is not performed
+				p.Spec.Ingress[0].Ports[0].Port.IntVal = 8443
+			},
+			diff:       true,
+			operations: []string{"get", "update"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			current, desired, expected := test.setup()
+			// make a copy so we can determine if the object in desired
+			// passed to ApplyNetworkPolicy has been mutated
+			desiredCopy := desired.DeepCopy()
+
+			exists := []runtime.Object{}
+			if current != nil {
+				exists = append(exists, current)
+			}
+			client := fake.NewSimpleClientset(exists...)
+			operationsObserved := make([]string, 0)
+			client.PrependReactor("*", "*", func(action ktesting.Action) (bool, runtime.Object, error) {
+				operationsObserved = append(operationsObserved, action.GetVerb())
+				return false, nil, nil
+			})
+
+			recorder := events.NewInMemoryRecorder("test", clocktesting.NewFakePassiveClock(time.Now()))
+			currentGot, diff, err := ApplyNetworkPolicy(context.Background(), client.NetworkingV1(), recorder, desired)
+
+			if want, got := expected, currentGot; !cmp.Equal(want, got) {
+				t.Errorf("expected object to be equal, diff: %s", cmp.Diff(want, got))
+			}
+			if want, got := test.diff, diff; want != got {
+				t.Errorf("expected modified to be: %t, but got: %t", want, got)
+			}
+			if want, got := test.err, err; want != got {
+				t.Errorf("expected err to be: %v, but got: %v", want, got)
+			}
+			if want, got := test.operations, operationsObserved; !cmp.Equal(want, got) {
+				t.Errorf("expected operations to match, diff: %s", cmp.Diff(want, got))
+			}
+
+			// the original spec in the desired object passed to ApplyNetworkPolicy should
+			// be immutable, mutating the object returned from ApplyNetworkPolicy
+			// should never mutate the original object
+			if test.mutator != nil {
+				t.Logf("mutating the object returned from ApplyNetworkPolicy")
+				test.mutator(currentGot)
+				if want, got := desiredCopy, desired; !cmp.Equal(want, got) {
+					t.Errorf("did not expect the object passed to ApplyNetworkPolicy to be mutated, diff: %s", cmp.Diff(want, got))
+				}
+			}
+		})
+	}
+}
+
+func TestReadNetworkPolicyV1OrDie(t *testing.T) {
+	bytes := []byte(`apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kueue-deny-all
+  namespace: openshift-kueue-operator
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kueue
+  policyTypes:
+  - Ingress
+  - Egress`)
+
+	if obj := ReadNetworkPolicyV1OrDie(bytes); obj == nil {
+		t.Errorf("expected a valid object of type: %T", &networkingv1.NetworkPolicy{})
+	}
+}

--- a/test/e2e/bindata/assets/02_role.yaml
+++ b/test/e2e/bindata/assets/02_role.yaml
@@ -1,0 +1,18 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-kueue-operator-networking
+  namespace: openshift-kueue-operator
+rules:
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/test/e2e/bindata/assets/03_rolebinding.yaml
+++ b/test/e2e/bindata/assets/03_rolebinding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-kueue-operator-networking
+  namespace: openshift-kueue-operator
+subjects:
+  - kind: ServiceAccount
+    name: openshift-kueue-operator
+    namespace: openshift-kueue-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-kueue-operator-networking

--- a/test/e2e/bindata/assets/07_deployment.yaml
+++ b/test/e2e/bindata/assets/07_deployment.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         name: openshift-kueue-operator
+        app.openshift.io/name: kueue # for network policies to select this pod
     spec:
       securityContext:
         runAsNonRoot: true

--- a/test/e2e/e2e_operator_test.go
+++ b/test/e2e/e2e_operator_test.go
@@ -693,9 +693,23 @@ func deployOperator() error {
 			},
 		},
 		{
+			path: "assets/02_role.yaml",
+			readerAndApply: func(objBytes []byte) error {
+				_, _, err := resourceapply.ApplyRole(ctx, kubeClient.RbacV1(), eventRecorder, resourceread.ReadRoleV1OrDie(objBytes))
+				return err
+			},
+		},
+		{
 			path: "assets/03_clusterrolebinding.yaml",
 			readerAndApply: func(objBytes []byte) error {
 				_, _, err := resourceapply.ApplyClusterRoleBinding(ctx, kubeClient.RbacV1(), eventRecorder, resourceread.ReadClusterRoleBindingV1OrDie(objBytes))
+				return err
+			},
+		},
+		{
+			path: "assets/03_rolebinding.yaml",
+			readerAndApply: func(objBytes []byte) error {
+				_, _, err := resourceapply.ApplyRoleBinding(ctx, kubeClient.RbacV1(), eventRecorder, resourceread.ReadRoleBindingV1OrDie(objBytes))
 				return err
 			},
 		},


### PR DESCRIPTION
- we assume that the operator namespace is shared with other components or operators, so the policy is limited to the operator pod and the kueue pod (operand) in the shared namespace
- if a policy applies to both the operator and the operand, then we use the label `app.openshift.io/name: kueue`. otherwise, if a policy applies to the operand only then we sue the label `app.kubernetes.io/name: kueue` 
- we introduce a deny-all policy that applies to both ingress and egress traffic for both the operator and the operand
- then we explicitly allow the expected ingress/egress traffic, this includes:
   - outgoing traffic to the kube-apiserver, 
   - egress to cluster DNS service, 
   - ingress traffic to metrics endpoint(s) published by either the operator, or the operand
   - ingress traffic to webhook (for the operand only)
   - ingress traffic to the visibility service (for the operand only)
