### PR TITLE
add operator image back to csv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,14 +78,11 @@ get-kueue-image:
 	@rm -f .kueue_commit_id
 
 .PHONY: bundle-generate
-bundle-generate: operator-sdk regen-crd manifests get-kueue-image
-	@KUEUE_IMAGE=$$(cat .kueue_image); \
+bundle-generate: operator-sdk regen-crd manifests
 	hack/update-deploy-files.sh ${OPERATOR_IMAGE} $$KUEUE_IMAGE
 	${OPERATOR_SDK} generate bundle --input-dir deploy/ --version ${OPERATOR_VERSION}
-	@KUEUE_IMAGE=$$(cat .kueue_image); \
 	hack/revert-deploy-files.sh ${OPERATOR_IMAGE} $$KUEUE_IMAGE
 	hack/preserve-bundle-labels.sh
-	@rm -f .kueue_image
 
 .PHONY: deploy-ocp
 deploy-ocp: get-kueue-image

--- a/bundle/manifests/kueue-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kueue-operator.clusterserviceversion.yaml
@@ -98,7 +98,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-04-17T14:58:26Z"
+    createdAt: "2025-04-24T20:32:48Z"
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     console.openshift.io/operator-monitoring-default: "true"
@@ -301,7 +301,8 @@ spec:
                 - name: OPERATOR_NAME
                   value: openshift-kueue-operator
                 - name: RELATED_IMAGE_OPERAND_IMAGE
-                  value: registry.redhat.io/kueue-tech-preview/kueue-rhel9@sha256:ec6688b483a2919d10d7ff6876f559c7b98961c6da425d80a653f0fe55db684d
+                  value: registry.redhat.io/kueue-tech-preview/kueue-rhel9@sha256:d0d6c34952e3d60be62fe7add33aa7ae2b0ac5c1bd2592e319f4cc28b2a2783e
+                image: registry.redhat.io/kueue-tech-preview/kueue-rhel9-operator@sha256:5907fe80c145291ba6a574e907306a885b00e1993a3315a4315b96a2a274c37c
                 imagePullPolicy: Always
                 name: openshift-kueue-operator
                 ports:
@@ -348,7 +349,7 @@ spec:
     name: Red Hat, Inc
     url: https://github.com/openshift/kueue-operator
   relatedImages:
-  - image: registry.redhat.io/kueue-tech-preview/kueue-rhel9@sha256:ec6688b483a2919d10d7ff6876f559c7b98961c6da425d80a653f0fe55db684d
+  - image: registry.redhat.io/kueue-tech-preview/kueue-rhel9@sha256:d0d6c34952e3d60be62fe7add33aa7ae2b0ac5c1bd2592e319f4cc28b2a2783e
     name: operand-image
   version: 0.0.1
   minKubeVersion: 1.28.0

--- a/hack/preserve-bundle-labels.sh
+++ b/hack/preserve-bundle-labels.sh
@@ -76,7 +76,7 @@ sed -i 's|name: Provider Name|name: Red Hat, Inc|' "${CSV_FILE}"
 sed -i 's|url: https://your.domain|url: https://github.com/openshift/kueue-operator|' "${CSV_FILE}"
 
 # Fix relatedImages entry.
-sed -i "/relatedImages:/{n;s|image:.*|image: ${KUEUE_OPERAND_IMAGE}|;n;s|name:.*|name: operand-image|}" "${CSV_FILE}"
+# sed -i "/relatedImages:/{n;s|image:.*|image: ${KUEUE_OPERAND_IMAGE}|;n;s|name:.*|name: operand-image|}" "${CSV_FILE}"
 
 # Add/update minKubeVersion.
 if ! grep -q "minKubeVersion" "${CSV_FILE}"; then


### PR DESCRIPTION
Bundle generation process was adding the wrong image urls for the operator and operand.  These must be the prod repos (registry.redhat.io) and use digests.  This is required because the bundle is not rebuilt on release.  A consequence of this is that you need to use a mirror set to test with the bundle.    