### PR TITLE
fix typo in HierarchicalCohorts feature gate

### DIFF
--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -173,7 +173,7 @@ func defaultKueueConfigurationTemplate(kueueCfg kueue.KueueConfiguration) *confi
 		FeatureGates: map[string]bool{
 			// Disable the HierarchicalCohorts feature gate by default.
 			// related to https://github.com/kubernetes-sigs/kueue/issues/4869
-			"HierarchialCohorts": false,
+			"HierarchicalCohorts": false,
 			// Disable visibilityOnDemand
 			// apiserver is insecure.
 			"VisibilityOnDemand": false,

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -52,7 +52,7 @@ controller:
 fairSharing:
   enable: false
 featureGates:
-  HierarchialCohorts: false
+  HierarchicalCohorts: false
   VisibilityOnDemand: false
 health:
   healthProbeBindAddress: :8081
@@ -109,7 +109,7 @@ controller:
 fairSharing:
   enable: false
 featureGates:
-  HierarchialCohorts: false
+  HierarchicalCohorts: false
   VisibilityOnDemand: false
 health:
   healthProbeBindAddress: :8081
@@ -169,7 +169,7 @@ fairSharing:
   - LessThanOrEqualToFinalShare
   - LessThanInitialShare
 featureGates:
-  HierarchialCohorts: false
+  HierarchicalCohorts: false
   VisibilityOnDemand: false
 health:
   healthProbeBindAddress: :8081
@@ -220,7 +220,7 @@ controller:
 fairSharing:
   enable: false
 featureGates:
-  HierarchialCohorts: false
+  HierarchicalCohorts: false
   VisibilityOnDemand: false
 health:
   healthProbeBindAddress: :8081
@@ -280,7 +280,7 @@ controller:
 fairSharing:
   enable: false
 featureGates:
-  HierarchialCohorts: false
+  HierarchicalCohorts: false
   VisibilityOnDemand: false
 health:
   healthProbeBindAddress: :8081


### PR DESCRIPTION
kueue v0.11.5 changed the name of this feature gate to fix a typo.

We need to change this feature gate as it is causing kueue to not install when using latest patch from 0.11.5.