### PR TITLE
OCPNODE-3306: Add `ManagedJobsNamespaceSelector` to Kueue configuration

### DIFF
--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -178,6 +178,9 @@ func defaultKueueConfigurationTemplate(kueueCfg kueue.KueueConfiguration) *confi
 			// apiserver is insecure.
 			"VisibilityOnDemand": false,
 		},
+		ManagedJobsNamespaceSelector: &v1.LabelSelector{
+			MatchLabels: map[string]string{"kueue.openshift.io/managed": "true"},
+		},
 		ManageJobsWithoutQueueName: buildManagedJobsWithoutQueueName(kueueCfg.WorkloadManagement),
 		WaitForPodsReady:           buildWaitForPodsReady(kueueCfg.GangScheduling),
 		FairSharing:                buildFairSharing(kueueCfg.Preemption),

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -71,6 +71,9 @@ leaderElection:
   resourceNamespace: ""
   retryPeriod: 0s
 manageJobsWithoutQueueName: false
+managedJobsNamespaceSelector:
+  matchLabels:
+    kueue.openshift.io/managed: "true"
 metrics:
   bindAddress: :8443
   enableClusterQueueResources: true
@@ -130,6 +133,9 @@ leaderElection:
   resourceNamespace: ""
   retryPeriod: 0s
 manageJobsWithoutQueueName: false
+managedJobsNamespaceSelector:
+  matchLabels:
+    kueue.openshift.io/managed: "true"
 metrics:
   bindAddress: :8443
   enableClusterQueueResources: true
@@ -188,6 +194,9 @@ leaderElection:
   resourceNamespace: ""
   retryPeriod: 0s
 manageJobsWithoutQueueName: true
+managedJobsNamespaceSelector:
+  matchLabels:
+    kueue.openshift.io/managed: "true"
 metrics:
   bindAddress: :8443
   enableClusterQueueResources: true
@@ -243,6 +252,9 @@ leaderElection:
   resourceNamespace: ""
   retryPeriod: 0s
 manageJobsWithoutQueueName: false
+managedJobsNamespaceSelector:
+  matchLabels:
+    kueue.openshift.io/managed: "true"
 metrics:
   bindAddress: :8443
   enableClusterQueueResources: true
@@ -303,6 +315,9 @@ leaderElection:
   resourceNamespace: ""
   retryPeriod: 0s
 manageJobsWithoutQueueName: false
+managedJobsNamespaceSelector:
+  matchLabels:
+    kueue.openshift.io/managed: "true"
 metrics:
   bindAddress: :8443
   enableClusterQueueResources: true


### PR DESCRIPTION
When using `labelPolicy` with `None` value, the `managedJobsWithoutQueueName` is enabled, consequently any job that doesn't have the kueue label set will still be managed by Kueue. To reduce the scope of affected jobs this commits set the `ManagedJobsNamespaceSelector` to only select the namespaces with label `kueue.openshift.io/managed=true`.