### PR TITLE
Set default value for OPERATOR_SDK_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ GO_BUILD_FLAGS :=-tags strictfipsruntime
 IMAGE_REGISTRY ?=registry.svc.ci.openshift.org
 
 OPERATOR_VERSION ?= 0.2.1
+OPERATOR_SDK_VERSION ?= v1.37.0
 # These are targets for pushing images
 OPERATOR_IMAGE ?= mustchange
 BUNDLE_IMAGE ?= mustchange


### PR DESCRIPTION
The bundle manifests are currently built using v1.37.0, so let's set the default value of OPERATOR_SDK_VERSION to that value to avoid the manifests having the builder annotation modified.