### PR TITLE
update pod concurrency to 20 due to perf-scale findings

### DIFF
--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -155,7 +155,7 @@ func defaultKueueConfigurationTemplate(kueueCfg kueue.KueueConfiguration) *confi
 			Controller: &configapi.ControllerConfigurationSpec{
 				GroupKindConcurrency: map[string]int{
 					"Job.batch":                     5,
-					"Pod":                           5,
+					"Pod":                           20,
 					"Workload.kueue.x-k8s.io":       5,
 					"LocalQueue.kueue.x-k8s.io":     1,
 					"ClusterQueue.kueue.x-k8s.io":   1,

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -49,7 +49,7 @@ controller:
     ClusterQueue.kueue.x-k8s.io: 1
     Job.batch: 5
     LocalQueue.kueue.x-k8s.io: 1
-    Pod: 5
+    Pod: 20
     ResourceFlavor.kueue.x-k8s.io: 1
     Workload.kueue.x-k8s.io: 5
 fairSharing:
@@ -112,7 +112,7 @@ controller:
     ClusterQueue.kueue.x-k8s.io: 1
     Job.batch: 5
     LocalQueue.kueue.x-k8s.io: 1
-    Pod: 5
+    Pod: 20
     ResourceFlavor.kueue.x-k8s.io: 1
     Workload.kueue.x-k8s.io: 5
 fairSharing:
@@ -175,7 +175,7 @@ controller:
     ClusterQueue.kueue.x-k8s.io: 1
     Job.batch: 5
     LocalQueue.kueue.x-k8s.io: 1
-    Pod: 5
+    Pod: 20
     ResourceFlavor.kueue.x-k8s.io: 1
     Workload.kueue.x-k8s.io: 5
 fairSharing:
@@ -235,7 +235,7 @@ controller:
     ClusterQueue.kueue.x-k8s.io: 1
     Job.batch: 5
     LocalQueue.kueue.x-k8s.io: 1
-    Pod: 5
+    Pod: 20
     ResourceFlavor.kueue.x-k8s.io: 1
     Workload.kueue.x-k8s.io: 5
 fairSharing:
@@ -301,7 +301,7 @@ controller:
     ClusterQueue.kueue.x-k8s.io: 1
     Job.batch: 5
     LocalQueue.kueue.x-k8s.io: 1
-    Pod: 5
+    Pod: 20
     ResourceFlavor.kueue.x-k8s.io: 1
     Workload.kueue.x-k8s.io: 5
 fairSharing:


### PR DESCRIPTION
Based on perf-scale, @rsevilla87 found much better results with 20 pod concurrency. I see no reason why not to bump to that.