### PR TITLE
Remove unecessary env vars from e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ wait-for-cert-manager:
 	done
 
 .PHONY: e2e-ci-test
-e2e-ci-test: get-kueue-image wait-for-image get-kueue-must-gather-image deploy-cert-manager ginkgo
+e2e-ci-test: get-kueue-must-gather-image deploy-cert-manager ginkgo
 	@echo "Running operator e2e tests..."
 	@KUEUE_IMAGE=$$(cat .kueue_image); \
 	export KUEUE_IMAGE; \

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package e2e
 
 import (
-	"os"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2/reporters"
@@ -29,10 +28,8 @@ import (
 )
 
 var (
-	operatorImage = ""
-	kueueImage    = ""
-	kubeClient    *kubernetes.Clientset
-	clients       *testutils.TestClients
+	kubeClient *kubernetes.Clientset
+	clients    *testutils.TestClients
 )
 
 // Run e2e tests using the Ginkgo runner.
@@ -50,7 +47,5 @@ func TestE2E(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	clients = testutils.NewTestClients()
-	operatorImage = os.Getenv("OPERATOR_IMAGE")
-	kueueImage = os.Getenv("KUEUE_IMAGE")
 	kubeClient = clients.KubeClient
 })


### PR DESCRIPTION
As we're using the bundle for the e2e tests we don't need to set the `OPERATOR_IMAGE` and `KUEUE_IMAGE` anymore.