### PR TITLE
Clean up e2e targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,8 +223,6 @@ wait-for-cert-manager:
 e2e-ci-test: deploy-cert-manager ginkgo
 	@echo "Running operator e2e tests..."
 	$(GINKGO) -v ./test/e2e/...
-	make run-must || true
-	make undeploy-ocp
 
 .PHONY: e2e-upstream-test
 e2e-upstream-test: get-kueue-image deploy-cert-manager wait-for-cert-manager
@@ -233,8 +231,6 @@ e2e-upstream-test: get-kueue-image deploy-cert-manager wait-for-cert-manager
 	cd $(TEMP_DIR) && KUEUE_NAMESPACE="openshift-kueue-operator" make -f Makefile-test-ocp.mk test-e2e-upstream-ocp
 	@echo "Cleaning up TEMP_DIR: $(TEMP_DIR)"
 	@rm -rf $(TEMP_DIR)
-	make run-must || true
-	make undeploy-ocp
 	@rm -f .kueue_image
 
 .PHONY: e2e-tech-preview-test


### PR DESCRIPTION
If we run undeploy-ocp after each test suite,
we would get kueue assets removed and if another
test suite attempts to run, it would fail. Also,
in CI there is one specific post step to get the
must-gather, so we don't need to run it on each test target. This commit removed the undeploy-ocp and must-gather from the test targets that run on CI.