### PR TITLE
Fix Tekton must-gather push pipeline CEL expression logic

### DIFF
--- a/.tekton/kueue-must-gather-1-0-pull-request.yaml
+++ b/.tekton/kueue-must-gather-1-0-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-1.0" && files.all.exists(path, path.matches('must-gather/|must-gather/Dockerfile|.tekton/kueue-must-gather-*'))
+      == "release-1.0" && files.all.exists(path, path.matches('must-gather/|must-gather/Dockerfile'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: kueue-operator-1-0

--- a/.tekton/kueue-must-gather-1-0-push.yaml
+++ b/.tekton/kueue-must-gather-1-0-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-1.0" && files.all.exists(path, path.matches('must-gather/|must-gather/Dockerfile|.tekton/kueue-must-gather-*'))
+      == "release-1.0" && files.all.exists(path, path.matches('must-gather/|must-gather/Dockerfile'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: kueue-operator-1-0


### PR DESCRIPTION
The CEL expression in the pipelinesascode.tekton.dev/on-cel-expression annotation for the must-gather push pipeline was incorrectly matching files that should have been excluded. This update corrects the logic to properly filter relevant files, ensuring the pipeline only triggers when appropriate changes are made.

- Fixes a typo in the file matching logic
- Ensures must-gather pipeline triggers as intended on release-1.0

Resolves #434.