### PR TITLE
test/e2e: don't install cr if already exists

### DIFF
--- a/test/e2e/e2e_operator_test.go
+++ b/test/e2e/e2e_operator_test.go
@@ -918,6 +918,13 @@ func deployOperator() error {
 	ctx, cancelFnc := context.WithCancel(context.TODO())
 	defer cancelFnc()
 
+	// Check if Kueue CR already exists for the disconnected use case.
+	_, err := ssClient.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
+	if err == nil {
+		klog.Infof("Kueue CR 'cluster' already exists, skipping creation")
+		return nil
+	}
+
 	assets := []struct {
 		path           string
 		readerAndApply func(objBytes []byte) error


### PR DESCRIPTION
This is required for running e2e tests on the disconnected clusters where we already apply the CR.