### PR TITLE
OCPNODE-3449: Remove assets generated during the e2e test

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -22,14 +22,16 @@ import (
 	"github.com/onsi/ginkgo/v2/reporters"
 	"github.com/openshift/kueue-operator/test/e2e/testutils"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var (
-	kubeClient *kubernetes.Clientset
-	clients    *testutils.TestClients
+	kubeClient    *kubernetes.Clientset
+	genericClient client.Client
+	clients       *testutils.TestClients
 )
 
 // Run e2e tests using the Ginkgo runner.
@@ -48,4 +50,5 @@ func TestE2E(t *testing.T) {
 var _ = BeforeSuite(func() {
 	clients = testutils.NewTestClients()
 	kubeClient = clients.KubeClient
+	genericClient = clients.GenericClient
 })

--- a/test/e2e/testutils/client.go
+++ b/test/e2e/testutils/client.go
@@ -27,10 +27,12 @@ import (
 	"k8s.io/klog/v2"
 
 	kueueclient "github.com/openshift/kueue-operator/pkg/generated/clientset/versioned"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	upstreamkueueclient "sigs.k8s.io/kueue/client-go/clientset/versioned"
 )
 
 type TestClients struct {
+	GenericClient       client.Client
 	KubeClient          *kubernetes.Clientset
 	APIExtClient        *apiextv1.ApiextensionsV1Client
 	KueueClient         *kueueclient.Clientset
@@ -47,6 +49,7 @@ func NewTestClients() *TestClients {
 	}
 
 	return &TestClients{
+		GenericClient:       getGenericClient(config),
 		KubeClient:          getKubeClient(config),
 		APIExtClient:        getAPIExtClient(config),
 		KueueClient:         getKueueClient(config),
@@ -76,6 +79,14 @@ func getKueueClient(config *rest.Config) *kueueclient.Clientset {
 	client, err := kueueclient.NewForConfig(config)
 	if err != nil {
 		klog.Fatalf("Unable to build kueue client: %v", err)
+	}
+	return client
+}
+
+func getGenericClient(config *rest.Config) client.Client {
+	client, err := client.New(config, client.Options{})
+	if err != nil {
+		klog.Fatalf("Unable to build generic kubernetes client: %v", err)
 	}
 	return client
 }


### PR DESCRIPTION
Even though we already have a destroy of namespace
where k8s assets are created, there is not wait for
all the assets to be properly cleaned up. After triggering
deletion of namespace we already proceed to the next
test scenario which is of deleting Kueue instance.
This can leave some CRDs behind if some k8s assets
were not yet fully cleaned up, and even when we recreate
the Kueue instance in the following test scenario,
this CRD will eventually get deleted.
This commit adds defer clean ups to assets generated
in the e2e test to ensure no leftovers are left by the
OCP e2e suite that could affect other suites that run after it.