### PR TITLE
test: use internal registry image for disconnected clusters

### DIFF
--- a/test/e2e/testutils/builders.go
+++ b/test/e2e/testutils/builders.go
@@ -26,14 +26,16 @@ import (
 )
 
 type TestResourceBuilder struct {
-	namespace string
-	queueName string
+	namespace      string
+	queueName      string
+	containerImage string
 }
 
 func NewTestResourceBuilder(namespace, queueName string) *TestResourceBuilder {
 	return &TestResourceBuilder{
-		namespace: namespace,
-		queueName: queueName,
+		namespace:      namespace,
+		queueName:      queueName,
+		containerImage: GetContainerImageForWorkloads(),
 	}
 }
 
@@ -57,7 +59,7 @@ func (b *TestResourceBuilder) NewPod() *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:    "test-container",
-					Image:   "busybox",
+					Image:   b.containerImage,
 					Command: []string{"sh", "-c", "echo Hello Kueue; sleep 3600"},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -119,7 +121,7 @@ func (b *TestResourceBuilder) NewStatefulSet() *appsv1.StatefulSet {
 					Containers: []corev1.Container{
 						{
 							Name:    "test-container",
-							Image:   "busybox",
+							Image:   b.containerImage,
 							Command: []string{"sh", "-c", "sleep 3600"},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
@@ -164,7 +166,7 @@ func (b *TestResourceBuilder) NewDeployment() *appsv1.Deployment {
 					Containers: []corev1.Container{
 						{
 							Name:    "test-container",
-							Image:   "busybox",
+							Image:   b.containerImage,
 							Command: []string{"sh", "-c", "sleep 3600"},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{


### PR DESCRIPTION
I was hitting this issue while running the e2e testsuite in a disconnected cluster.
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/66357/rehearse-66357-pull-ci-openshift-kueue-operator-release-1.0-test-e2e-disconnected/1942404961056854016/artifacts/test-e2e-disconnected/e2e-kueue/build-log.txt

The pod was in a pending state bc it was trying to pull the image from internet.