### PR TITLE
Fix clusterRole clean up

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -621,7 +621,7 @@ func (c *TargetConfigReconciler) cleanUpClusterRoles(ctx context.Context) error 
 	}
 
 	for _, role := range clusterRoleList.Items {
-		if !strings.Contains(role.Name, "kueue") || strings.Contains(role.Name, "kueue-operator") {
+		if !strings.Contains(role.Name, "kueue") || strings.Contains(role.Name, "kueue-operator") || strings.Contains(role.Name, "openshift.io") {
 			continue
 		}
 


### PR DESCRIPTION
We shouldn't be deleting cluster roles
that are meant for the operator and not
the operand, even if they get recreated.
This commit fixes the issue by skipping
the clean up of any cluster role that
has openshift.io in the name.