### PR TITLE
Manually sync operator image in the Bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ test-e2e: ginkgo
 regen-crd:
 	go run ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen crd paths=./pkg/apis/kueueoperator/v1/... output:crd:dir=./manifests
 	cp manifests/kueue.openshift.io_kueues.yaml deploy/crd/kueue-operator.crd.yaml
-	cp deploy/crd/kueue-operator.crd.yaml test/e2e/bindata/assets/00_kueue-operator.crd.yaml
 
 .PHONY: generate
 generate: manifests code-gen generate-clients

--- a/bundle/manifests/kueue-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kueue-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-07-02T19:30:21Z"
+    createdAt: "2025-07-15T01:52:59Z"
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     console.openshift.io/operator-monitoring-default: "true"
@@ -233,7 +233,7 @@ spec:
                         value: openshift-kueue-operator
                       - name: RELATED_IMAGE_OPERAND_IMAGE
                         value: registry.redhat.io/kueue/kueue-rhel9@sha256:73390c4d95bacb5b4d96eac7f82e76fbba4161beb1220e5a4924fdef3e3a8e01
-                    image: registry.redhat.io/kueue/kueue-rhel9-operator@sha256:fbb70e58b6d9f3b2cee31d824cb799069f1a48e9bf9ea3d6436dfc287e94036b
+                    image: registry.redhat.io/kueue/kueue-rhel9-operator@sha256:b3a031c63c485f60c365fe2f078d61bf4904ad72d494891a08ba7c5d79709523
                     imagePullPolicy: Always
                     name: openshift-kueue-operator
                     ports:


### PR DESCRIPTION
This commit manually syncs the operator image in the bundle
to make sure our periodic jobs use the latest operator code
avaialable. This fix is needed while we work on identifying
what is wrong with the nudges. It also removes an unnecessary
file that is created when generating the bundle.