### PR TITLE
OCPNODE-3486: Bump operator version for 1.0.1 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GO_BUILD_FLAGS :=-tags strictfipsruntime
 
 IMAGE_REGISTRY ?=registry.svc.ci.openshift.org
 
-OPERATOR_VERSION ?= 1.0.0
+OPERATOR_VERSION ?= 1.0.1
 OPERATOR_SDK_VERSION ?= v1.37.0
 # These are targets for pushing images
 OPERATOR_IMAGE ?= mustchange

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Kueue Operator needs CertManager installed to operate correctly
 
 | ko version   | ocp version         |kueue version  | k8s version | golang |
 | ------------ | ------------------- |---------------| ----------- | ------ |
-| 1.0.0        | 4.19 - 4.20         |0.11.z         | 1.32        | 1.23   |
+| 1.0.0        | 4.18 - 4.19         |0.11.z         | 1.32        | 1.23   |
 
 Kueue releases around 6 times a year.
 For the latest Openshift version, we will take the latest version that was build with that underlying

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -22,8 +22,8 @@ LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="openshift,kueue-operator-bundle"
 LABEL description="kueue-operator-bundle"
 LABEL distribution-scope="public"
-LABEL release=1.0.0
-LABEL version=1.0.0
+LABEL release=1.0.1
+LABEL version=1.0.1
 
 LABEL maintainer="Node team, <aos-node@redhat.com>"
 

--- a/bundle/manifests/kueue-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kueue-operator.clusterserviceversion.yaml
@@ -46,7 +46,7 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-kueue-operator
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
-  name: kueue-operator.v1.0.0
+  name: kueue-operator.v1.0.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -300,5 +300,5 @@ spec:
       name: operand-image
     - name: must-gather
       image: registry.redhat.io/kueue/kueue-must-gather-rhel9@sha256:fb8f940032fe2196ecdd1ceee8d62637994de9b91f467029c864fa54c33a42bf
-  version: 1.0.0
+  version: 1.0.1
   minKubeVersion: 1.28.0

--- a/hack/preserve-bundle-labels.sh
+++ b/hack/preserve-bundle-labels.sh
@@ -29,8 +29,8 @@ LABEL io.openshift.expose-services=\"\"\\
 LABEL io.openshift.tags=\"openshift,kueue-operator-bundle\"\\
 LABEL description=\"kueue-operator-bundle\"\\
 LABEL distribution-scope=\"public\"\\
-LABEL release=1.0.0\\
-LABEL version=1.0.0\\
+LABEL release=1.0.1\\
+LABEL version=1.0.1\\
 \\
 LABEL maintainer=\"Node team, <aos-node@redhat.com>\"" "${DOCKERFILE}"
 
@@ -99,7 +99,7 @@ yq -i '
 
 # Add/update minKubeVersion.
 if ! grep -q "minKubeVersion" "${CSV_FILE}"; then
-  sed -i '/version: 1.0.0/a \  minKubeVersion: 1.28.0' "${CSV_FILE}"
+  sed -i '/version: 1.0.1/a \  minKubeVersion: 1.28.0' "${CSV_FILE}"
 else
   sed -i 's/minKubeVersion:.*/minKubeVersion: 1.28.0/g' "${CSV_FILE}"
 fi


### PR DESCRIPTION
To prepare for the 1.0.1, let's bump the operator version.