### PR TITLE
fix auto merge for dockerfiles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,7 +36,7 @@
     "packageRules": [
       {
         "matchFileNames": [
-          "Dockerfile.*",
+          "Dockerfile*",
           "*.Dockerfile"
         ],
         "automerge": true,


### PR DESCRIPTION
Use regexp to catch Dockerfile.* and Dockerfile.

