### PR TITLE
use all-pods for oc logs deployment

### DIFF
--- a/hack/wait-for-kueue-leader-election.sh
+++ b/hack/wait-for-kueue-leader-election.sh
@@ -31,7 +31,7 @@ while true; do
   fi
   
   # Check logs for leader election messages
-  if oc logs deployment/kueue-controller-manager -n openshift-kueue-operator --tail=-1 2>/dev/null | grep "successfully acquired lease"; then
+  if oc logs deployment/kueue-controller-manager -n openshift-kueue-operator --tail=-1 --all-pods=true 2>/dev/null | grep "successfully acquired lease"; then
     ELAPSED=$((CURRENT_TIME - START_TIME))
     echo "SUCCESS: Leader election detected in kueue-controller-manager logs after ${ELAPSED} seconds"
     exit 0


### PR DESCRIPTION
We have a flake in our CI with lease detection. `oc logs deployment` will grab the first pod and gets its logs.

Sometimes that pod gets the lease while other times a different pod gets the lease.

We will grab all the logs on all pods for this deployment and search for lease acquired.

ex:
```  
# Return snapshot logs from all pods in the deployment nginx
  kubectl logs deployment/nginx --all-pods=true
```