### PR TITLE
update bundle and use latest images

### DIFF
--- a/bundle/manifests/kueue-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kueue-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-07-15T01:52:59Z"
+    createdAt: "2025-08-14T18:25:23Z"
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     console.openshift.io/operator-monitoring-default: "true"
@@ -46,7 +46,7 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-kueue-operator
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
-  name: kueue-operator.v1.0.0
+  name: kueue-operator.v1.1.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -232,7 +232,7 @@ spec:
                       - name: OPERATOR_NAME
                         value: openshift-kueue-operator
                       - name: RELATED_IMAGE_OPERAND_IMAGE
-                        value: registry.redhat.io/kueue/kueue-rhel9@sha256:73390c4d95bacb5b4d96eac7f82e76fbba4161beb1220e5a4924fdef3e3a8e01
+                        value: registry.redhat.io/kueue/kueue-rhel9@sha256:8b8dba33cda9023d9797755c773935fd53ca366a48f8825a282682ddc0476ac9
                     image: registry.redhat.io/kueue/kueue-rhel9-operator@sha256:8f9b4167355b6dcbd1fc6ebc159973dd50e88e4b7cf9f046da0f27afebcefe2e
                     imagePullPolicy: Always
                     name: openshift-kueue-operator
@@ -296,9 +296,9 @@ spec:
     name: Red Hat, Inc
     url: https://github.com/openshift/kueue-operator
   relatedImages:
-    - image: registry.redhat.io/kueue/kueue-rhel9@sha256:73390c4d95bacb5b4d96eac7f82e76fbba4161beb1220e5a4924fdef3e3a8e01
+    - image: registry.redhat.io/kueue/kueue-rhel9@sha256:8b8dba33cda9023d9797755c773935fd53ca366a48f8825a282682ddc0476ac9
       name: operand-image
     - name: must-gather
       image: registry.redhat.io/kueue/kueue-must-gather-rhel9@sha256:eb731aa0b54736df84b894238537715111dcd76721795d704628ac3bdfcb658d
-  version: 1.0.0
+  version: 1.1.0
   minKubeVersion: 1.28.0


### PR DESCRIPTION
It looks like bundles pick the latest push to main and not bundle on the PR.

In #https://github.com/openshift/kueue-operator/pull/515 I am seeing that the bundle is stale and the images are not what I expect.

To get the bundle in sync, I am going to merge the bundle first and then I'll merge the Makefile changes.

We will see if this passes CI.