### PR TITLE
add architectures to must-gather image and tweak cel expressions

### DIFF
--- a/.tekton/kueue-bundle-main-pull-request.yaml
+++ b/.tekton/kueue-bundle-main-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && files.all.exists(path, path.matches('bundle/|bundle.Dockerfile|.tekton/kueue-bundle-main-*'))
+      == "main" && files.all.exists(path, path.matches('bundle/|bundle.Dockerfile|.tekton/kueue-bundle-main-*|related_images.json'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: kueue-operator-main

--- a/.tekton/kueue-bundle-main-push.yaml
+++ b/.tekton/kueue-bundle-main-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && files.all.exists(path, path.matches('bundle/|bundle.Dockerfile|.tekton/kueue-bundle-main-*'))
+      == "main" && files.all.exists(path, path.matches('bundle/|bundle.Dockerfile|.tekton/kueue-bundle-main-*|related_images.json'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: kueue-operator-main

--- a/.tekton/kueue-must-gather-main-pull-request.yaml
+++ b/.tekton/kueue-must-gather-main-pull-request.yaml
@@ -31,6 +31,8 @@ spec:
     value:
     - linux/x86_64
     - linux/s390x
+    - linux/arm64
+    - linux/ppc64le
   - name: dockerfile
     value: must-gather/Dockerfile
   pipelineSpec:

--- a/.tekton/kueue-must-gather-main-push.yaml
+++ b/.tekton/kueue-must-gather-main-push.yaml
@@ -30,6 +30,8 @@ spec:
     value:
     - linux/x86_64
     - linux/s390x
+    - linux/arm64
+    - linux/ppc64le
   - name: dockerfile
     value: must-gather/Dockerfile
   pipelineSpec:

--- a/.tekton/kueue-operator-main-pull-request.yaml
+++ b/.tekton/kueue-operator-main-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && files.all.exists(path, !path.matches('bundle/|bundle.Dockerfile|.tekton/kueue-bundle-*|must-gather/|.tekton/kueue-must-gather-*'))
+      == "main" && files.all.exists(path, !path.matches('bundle/|bundle.Dockerfile|.tekton/kueue-bundle-*|must-gather/|.tekton/kueue-must-gather-*|related_images.json|related_images.developer.json'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: kueue-operator-main

--- a/.tekton/kueue-operator-main-push.yaml
+++ b/.tekton/kueue-operator-main-push.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && files.all.exists(path, !path.matches('bundle/|bundle.Dockerfile|.tekton/kueue-bundle-*|must-gather/|.tekton/kueue-must-gather-*'))
+      == "main" && files.all.exists(path, !path.matches('bundle/|bundle.Dockerfile|.tekton/kueue-bundle-*|must-gather/|.tekton/kueue-must-gather-*|related_images.json|related_images.developer.json'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: kueue-operator-main


### PR DESCRIPTION
Title ^ :) 

Also adds related_images.json to the cel expression of the bundle tekton files.
We also do not want the operator to rebuild on related_images.*.json updates (infinite konflux loop). I added the files to the 'ignore' list.