### PR TITLE
konflux: change operator builds to not build on upstream/kueue/src

### DIFF
--- a/.tekton/kueue-operator-main-pull-request.yaml
+++ b/.tekton/kueue-operator-main-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && files.all.exists(path, !path.matches('bundle/|bundle.Dockerfile|bundle.developer.Dockerfile|.tekton/kueue-bundle-*|must-gather/|.tekton/kueue-must-gather-*|related_images.json|related_images.developer.json|bundle/manifests/kueue-operator.clusterserviceversion.yaml'))
+      == "main" && files.all.exists(path, !path.matches('upstream/kueue/src|bundle/|bundle.Dockerfile|bundle.developer.Dockerfile|.tekton/kueue-bundle-*|must-gather/|.tekton/kueue-must-gather-*|related_images.json|related_images.developer.json|bundle/manifests/kueue-operator.clusterserviceversion.yaml'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: kueue-operator-main

--- a/.tekton/kueue-operator-main-push.yaml
+++ b/.tekton/kueue-operator-main-push.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && files.all.exists(path, !path.matches('bundle/|bundle.Dockerfile|.tekton/kueue-bundle-*|bundle.developer.Dockerfile|must-gather/|.tekton/kueue-must-gather-*|related_images.json|related_images.developer.json|bundle/manifests/kueue-operator.clusterserviceversion.yaml'))
+      == "main" && files.all.exists(path, !path.matches('upstream/kueue/src|bundle/|bundle.Dockerfile|.tekton/kueue-bundle-*|bundle.developer.Dockerfile|must-gather/|.tekton/kueue-must-gather-*|related_images.json|related_images.developer.json|bundle/manifests/kueue-operator.clusterserviceversion.yaml'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: kueue-operator-main


### PR DESCRIPTION
This PR tweaks the operator build to not build with changes in upstream/kueue/src. The operand will build with changes in upstream/kueue/src, and then nudge the operator.