### PR TITLE
bumps main to upstream main branch (what will be 0.14)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "upstream/kueue/src"]
 	path = upstream/kueue/src
 	url = https://github.com/kubernetes-sigs/kueue.git
-	branch = release-0.12
+	branch = main

--- a/.snyk
+++ b/.snyk
@@ -3,6 +3,9 @@
 # https://docs.snyk.io/snyk-cli/commands/ignore
 exclude:
   global:
+    # sync generation script
+    - hack/sync_manifests.py
+    # upstream ignores
     - upstream/kueue/src/hack/internal/tools/**
     # Disable kueue-viz as openshift does not support.
     - upstream/kueue/src/cmd/experimental/kueue-viz/**

--- a/bindata/assets/kueue-operator/crds/crd-admissionchecks.kueue.x-k8s.io.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-admissionchecks.kueue.x-k8s.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: kueue

--- a/bindata/assets/kueue-operator/crds/crd-clusterqueues.kueue.x-k8s.io.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-clusterqueues.kueue.x-k8s.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: kueue
@@ -750,7 +750,8 @@ spec:
                 description: |-
                   PendingWorkloadsStatus contains the information exposed about the current
                   status of the pending workloads in the cluster queue.
-                  Deprecated: This field will be removed on v1beta2, use VisibilityOnDemand
+                  Deprecated: This field is no longer effective since v0.14.0, which means Kueue no longer stores and updates information.
+                  You can migrate to VisibilityOnDemand
                   (https://kueue.sigs.k8s.io/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/)
                   instead.
                 properties:

--- a/bindata/assets/kueue-operator/crds/crd-cohorts.kueue.x-k8s.io.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-cohorts.kueue.x-k8s.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: kueue
@@ -18,7 +18,7 @@ spec:
     singular: cohort
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - name: v1beta1
     schema:
       openAPIV3Schema:
         description: |-
@@ -73,9 +73,9 @@ spec:
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                 type: object
-              parent:
+              parentName:
                 description: |-
-                  Parent references the name of the Cohort's parent, if
+                  ParentName references the name of the Cohort's parent, if
                   any. It satisfies one of three cases:
                   1) Unset. This Cohort is the root of its Cohort tree.
                   2) References a non-existent Cohort. We use default Cohort (no borrowing/lending limits).
@@ -96,6 +96,13 @@ spec:
                   Resources. Each Resource and each Flavor may only form part
                   of one ResourceGroup.  There may be up to 16 ResourceGroups
                   within a Cohort.
+
+                  Please note that nominalQuota defined at the Cohort level
+                  represents additional resources on top of those defined by
+                  ClusterQueues within the Cohort. The Cohort's nominalQuota
+                  may be thought of as a shared pool for the ClusterQueues
+                  within it. Additionally, this quota may also be lent out to
+                  parent Cohort(s), subject to LendingLimit.
 
                   BorrowingLimit limits how much members of this Cohort
                   subtree can borrow from the parent subtree.

--- a/bindata/assets/kueue-operator/crds/crd-localqueues.kueue.x-k8s.io.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-localqueues.kueue.x-k8s.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: kueue

--- a/bindata/assets/kueue-operator/crds/crd-multikueueclusters.kueue.x-k8s.io.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-multikueueclusters.kueue.x-k8s.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: kueue

--- a/bindata/assets/kueue-operator/crds/crd-multikueueconfigs.kueue.x-k8s.io.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-multikueueconfigs.kueue.x-k8s.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: kueue

--- a/bindata/assets/kueue-operator/crds/crd-provisioningrequestconfigs.kueue.x-k8s.io.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-provisioningrequestconfigs.kueue.x-k8s.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: kueue

--- a/bindata/assets/kueue-operator/crds/crd-resourceflavors.kueue.x-k8s.io.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-resourceflavors.kueue.x-k8s.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: kueue

--- a/bindata/assets/kueue-operator/crds/crd-topologies.kueue.x-k8s.io.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-topologies.kueue.x-k8s.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: kueue
@@ -63,7 +63,7 @@ spec:
                   required:
                   - nodeLabel
                   type: object
-                maxItems: 8
+                maxItems: 16
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic

--- a/bindata/assets/kueue-operator/crds/crd-workloadpriorityclasses.kueue.x-k8s.io.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-workloadpriorityclasses.kueue.x-k8s.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: kueue

--- a/bindata/assets/kueue-operator/crds/crd-workloads.kueue.x-k8s.io.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-workloads.kueue.x-k8s.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: kueue
@@ -461,7 +461,6 @@ spec:
                                                   pod labels will be ignored. The default value is empty.
                                                   The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                   Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                 items:
                                                   type: string
                                                 type: array
@@ -476,7 +475,6 @@ spec:
                                                   pod labels will be ignored. The default value is empty.
                                                   The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                   Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                 items:
                                                   type: string
                                                 type: array
@@ -646,7 +644,6 @@ spec:
                                               pod labels will be ignored. The default value is empty.
                                               The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                               Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -661,7 +658,6 @@ spec:
                                               pod labels will be ignored. The default value is empty.
                                               The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                               Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -830,7 +826,6 @@ spec:
                                                   pod labels will be ignored. The default value is empty.
                                                   The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                   Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                 items:
                                                   type: string
                                                 type: array
@@ -845,7 +840,6 @@ spec:
                                                   pod labels will be ignored. The default value is empty.
                                                   The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                   Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                 items:
                                                   type: string
                                                 type: array
@@ -1015,7 +1009,6 @@ spec:
                                               pod labels will be ignored. The default value is empty.
                                               The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                               Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -1030,7 +1023,6 @@ spec:
                                               pod labels will be ignored. The default value is empty.
                                               The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                               Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -1297,7 +1289,7 @@ spec:
                                       Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
-                                        of a set of ConfigMaps
+                                        of a set of ConfigMaps or Secrets
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
@@ -1318,9 +1310,9 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         prefix:
-                                          description: An optional identifier to prepend
-                                            to each key in the ConfigMap. Must be
-                                            a C_IDENTIFIER.
+                                          description: Optional text to prepend to
+                                            the name of each environment variable.
+                                            Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
@@ -1594,6 +1586,12 @@ spec:
                                             - port
                                             type: object
                                         type: object
+                                      stopSignal:
+                                        description: |-
+                                          StopSignal defines which signal will be sent to a container when it is being stopped.
+                                          If not specified, the default is defined by the container runtime in use.
+                                          StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                        type: string
                                     type: object
                                   livenessProbe:
                                     description: |-
@@ -2828,7 +2826,7 @@ spec:
                                       Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
-                                        of a set of ConfigMaps
+                                        of a set of ConfigMaps or Secrets
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
@@ -2849,9 +2847,9 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         prefix:
-                                          description: An optional identifier to prepend
-                                            to each key in the ConfigMap. Must be
-                                            a C_IDENTIFIER.
+                                          description: Optional text to prepend to
+                                            the name of each environment variable.
+                                            Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
@@ -3122,6 +3120,12 @@ spec:
                                             - port
                                             type: object
                                         type: object
+                                      stopSignal:
+                                        description: |-
+                                          StopSignal defines which signal will be sent to a container when it is being stopped.
+                                          If not specified, the default is defined by the container runtime in use.
+                                          StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                        type: string
                                     type: object
                                   livenessProbe:
                                     description: Probes are not allowed for ephemeral
@@ -4178,7 +4182,7 @@ spec:
                                 Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
                                 The resourceRequirements of an init container are taken into account during scheduling
                                 by finding the highest request/limit for each resource type, and then using the max of
-                                of that value or the sum of the normal containers. Limits are applied to init containers
+                                that value or the sum of the normal containers. Limits are applied to init containers
                                 in a similar fashion.
                                 Init containers cannot currently be added or removed.
                                 Cannot be updated.
@@ -4356,7 +4360,7 @@ spec:
                                       Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
-                                        of a set of ConfigMaps
+                                        of a set of ConfigMaps or Secrets
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
@@ -4377,9 +4381,9 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         prefix:
-                                          description: An optional identifier to prepend
-                                            to each key in the ConfigMap. Must be
-                                            a C_IDENTIFIER.
+                                          description: Optional text to prepend to
+                                            the name of each environment variable.
+                                            Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
@@ -4653,6 +4657,12 @@ spec:
                                             - port
                                             type: object
                                         type: object
+                                      stopSignal:
+                                        description: |-
+                                          StopSignal defines which signal will be sent to a container when it is being stopped.
+                                          If not specified, the default is defined by the container runtime in use.
+                                          StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                        type: string
                                     type: object
                                   livenessProbe:
                                     description: |-
@@ -6374,7 +6384,6 @@ spec:
                                       - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                                       If this value is nil, the behavior is equivalent to the Honor policy.
-                                      This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                     type: string
                                   nodeTaintsPolicy:
                                     description: |-
@@ -6385,7 +6394,6 @@ spec:
                                       - Ignore: node taints are ignored. All nodes are included.
 
                                       If this value is nil, the behavior is equivalent to the Ignore policy.
-                                      This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                     type: string
                                   topologyKey:
                                     description: |-
@@ -7391,7 +7399,7 @@ spec:
                                       The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                       The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
                                       The volume will be mounted read-only (ro) and non-executable files (noexec).
-                                      Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                                      Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                       The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                     properties:
                                       pullPolicy:
@@ -8295,6 +8303,23 @@ spec:
                             - JobSet: kubernetes.io/job-completion-index (inherited from Job)
                             - Kubeflow: training.kubeflow.org/replica-index
                           type: string
+                        podSetGroupName:
+                          description: |-
+                            PodSetGroupName indicates the name of the group of PodSets to which this PodSet belongs to.
+                            PodSets with the same `PodSetGroupName` should be assigned the same ResourceFlavor
+                          type: string
+                        podSetSliceRequiredTopology:
+                          description: |-
+                            PodSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as
+                            indicated by the `kueue.x-k8s.io/podset-slice-required-topology` annotation.
+                          type: string
+                        podSetSliceSize:
+                          description: |-
+                            PodSetSliceSize indicates the size of a subgroup of pods in a PodSet for which
+                            Kueue finds a requested topology domain on a level defined
+                            in `kueue.x-k8s.io/podset-slice-required-topology` annotation.
+                          format: int32
+                          type: integer
                         preferred:
                           description: |-
                             preferred indicates the topology level preferred by the PodSet, as
@@ -8692,6 +8717,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
+              clusterName:
+                description: |-
+                  clusterName is the name of the cluster where the workload is actually assigned.
+                  This field is reset after the Workload is evicted.
+                type: string
               conditions:
                 description: |-
                   conditions hold the latest available observations of the Workload
@@ -8761,6 +8791,26 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              nodesToReplace:
+                description: |-
+                  nodesToReplace holds the names of failed nodes running at least one pod of this workload
+                  when Topology-Aware Scheduling is used. This field should not be set by the users.
+                  It indicates Kueue's scheduler is searching for replacements of the failed nodes.
+                  Requires enabling the TASFaliedNodReplacement feature gate.
+                items:
+                  type: string
+                type: array
+              nominatedClusterNames:
+                description: |-
+                  nominatedClusterNames specifies the list of cluster names that have been nominated for scheduling.
+                  This field is mutually exclusive with the `.status.clusterName` field, and is reset when
+                  `status.clusterName` is set.
+                  This field is optional.
+                items:
+                  type: string
+                maxItems: 10
+                type: array
+                x-kubernetes-list-type: atomic
               reclaimablePods:
                 description: |-
                   reclaimablePods keeps track of the number pods within a podset for which
@@ -8882,6 +8932,14 @@ spec:
                     x-kubernetes-list-type: map
                 type: object
             type: object
+            x-kubernetes-validations:
+            - message: clusterName is immutable once set
+              rule: '!has(oldSelf.clusterName) || !has(self.clusterName) || oldSelf.clusterName
+                == self.clusterName'
+            - message: clusterName and nominatedClusterNames are mutually exclusive
+              rule: '!has(self.clusterName) || (!has(self.nominatedClusterNames) ||
+                (has(self.nominatedClusterNames) && size(self.nominatedClusterNames)
+                == 0))'
         type: object
         x-kubernetes-validations:
         - message: podSetAssignments must have the same number of podSets as the spec

--- a/bindata/assets/kueue-operator/validatingwebhook.yaml
+++ b/bindata/assets/kueue-operator/validatingwebhook.yaml
@@ -354,14 +354,14 @@ webhooks:
     service:
       name: kueue-webhook-service
       namespace: openshift-kueue-operator
-      path: /validate-kueue-x-k8s-io-v1alpha1-cohort
+      path: /validate-kueue-x-k8s-io-v1beta1-cohort
   failurePolicy: Fail
   name: vcohort.kb.io
   rules:
   - apiGroups:
     - kueue.x-k8s.io
     apiVersions:
-    - v1alpha1
+    - v1beta1
     operations:
     - CREATE
     - UPDATE

--- a/hack/run-locally.sh
+++ b/hack/run-locally.sh
@@ -22,7 +22,7 @@ function setup_operator_env() {
 	# library-go controller needs to write stuff here
 	if [[ ! -w "/var/run/secrets" ]]; then
 		echo "Need /var/run/secrets to be writable, please execute"
-		echo sudo /bin/bash -c "'mkdir -p /var/run/secrets && chown ${USER} /var/run/secrets'"
+		echo sudo /usr/bin/env bash -c "'mkdir -p /var/run/secrets && chown ${USER} /var/run/secrets'"
 	fi
 
 	mkdir -p /var/run/secrets/kubernetes.io/serviceaccount/

--- a/hack/sync_manifests.py
+++ b/hack/sync_manifests.py
@@ -1,7 +1,12 @@
+#!/usr/bin/env -S uv run --with pyyaml --with requests
 import os
 import yaml
 import requests
-import sys
+import argparse
+import subprocess
+
+from pathlib import Path
+
 
 # Custom YAML dumper to preserve multi-line strings in block style, respect double quotes, and handle boolean-like strings.
 def string_representer(dumper, data):
@@ -19,7 +24,9 @@ def string_representer(dumper, data):
         return dumper.represent_scalar("tag:yaml.org,2002:str", data, style='"')
     return dumper.represent_scalar("tag:yaml.org,2002:str", data)
 
+
 yaml.add_representer(str, string_representer)
+
 
 # Get the latest version of Kueue.
 def fetch_latest_version():
@@ -36,175 +43,264 @@ def fetch_latest_version():
         exit(1)
 
 
-if len(sys.argv) > 1:
-    version = sys.argv[1]
-else:
-    version = fetch_latest_version()
+def main():
+    parser = argparse.ArgumentParser(
+        description="Sync Kueue manifests to the operator bindata directory"
+    )
+    parser.add_argument(
+        "version",
+        nargs="?",
+        type=str,
+        help="Kueue version to sync (e.g., 0.7.1). If not provided, fetches the latest version.",
+    )
+    parser.add_argument(
+        "--bindata-dir",
+        default="bindata/assets/kueue-operator",
+        type=Path,
+        help="Directory to store the processed manifests (default: bindata/assets/kueue-operator)",
+    )
+    parser.add_argument(
+        "--src-dir",
+        type=Path,
+        help="Path to kustomize source directory. If provided, runs kustomize to generate manifests instead of downloading from web.",
+    )
 
-print(f"Using Kueue version: {version}")
+    args = parser.parse_args()
 
-# Define directories
-bindata_dir = "bindata/assets/kueue-operator"
-manifests_url = f"https://github.com/kubernetes-sigs/kueue/releases/download/v{version}/manifests.yaml"
-input_file = f"manifests.yaml"
+    if args.src_dir and args.version:
+        print("Warning: --src-dir specified, ignoring version argument")
 
-# Download manifests.yaml.
-print(f"Downloading manifests.yaml from {manifests_url} ...")
-response = requests.get(manifests_url)
-if response.status_code != 200:
-    raise RuntimeError(f"Failed to download manifests.yaml (HTTP {response.status_code})")
-
-with open(input_file, "wb") as f:
-    f.write(response.content)
-
-# Read and split YAML file.
-try:
-    with open(input_file, "r") as f:
-        docs = list(yaml.safe_load_all(f))
-except yaml.YAMLError as e:
-    print(f"Failed to parse YAML file: {e}")
-    exit(1)
-
-# Define a mapping of 'kind' to filenames.
-file_map = {
-    "CustomResourceDefinition": "crd",
-    "ClusterRole": "clusterrole",
-    "ClusterRoleBinding": "clusterrolebinding",
-    "APIService": "apiservice",
-    "ValidatingWebhookConfiguration": "validatingwebhook",
-    "MutatingWebhookConfiguration": "mutatingwebhook",
-    "Service": "service",
-    "Role": "role",
-    "RoleBinding": "rolebinding",
-    "ServiceAccount": "serviceaccount",
-    "Deployment": "deployment",
-    "Secret": "secret",
-}
-
-# Resources that need namespace updates (excluding Secret)
-namespace_updates = ["Deployment", "Service", "ServiceAccount"]
-
-# Clean up names for RoleBinding, ClusterRoleBinding, Role, Service, and ClusterRole
-def clean_name(name, kind):
-    # Remove 'kueue-' prefix from the name
-    if kind in ["RoleBinding", "ClusterRoleBinding", "Role", "Service", "ClusterRole"]:
-        name = name.replace("kueue-", "")
-    # Remove suffixes for specific kinds
-    if kind in ["RoleBinding", "ClusterRoleBinding"]:
-        name = name.replace("-rolebinding", "").replace("-binding", "")
-    elif kind == "Role":
-        name = name.replace("-role", "")
-    return name
-
-# Organize manifests for output
-separated_manifests = {}
-allowed_kinds = set(file_map.keys())  # Process only these kinds
-
-for doc in docs:
-    if not isinstance(doc, dict) or "kind" not in doc:
-        continue  # Skip invalid or empty YAML docs
-
-    kind = doc["kind"]
-    if kind not in allowed_kinds:
-        continue  # Skip unrelated kinds
-
-    # For Validating and Mutating webhook configurations, update namespace selectors and clientConfig.
-    if kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]:
-        if "webhooks" in doc:
-            for webhook in doc["webhooks"]:
-                # Update namespaceSelector match expressions.
-                ns_selector = webhook.get("namespaceSelector")
-                if ns_selector is not None and "matchExpressions" in ns_selector:
-                    for expr in ns_selector["matchExpressions"]:
-                        if expr.get("key") == "kubernetes.io/metadata.name" and expr.get("operator") == "NotIn":
-                            expr["values"] = [
-                                "openshift-kueue-operator" if v == "kueue-system" else v 
-                                for v in expr.get("values", [])
-                            ]
-                # Update clientConfig service namespace.
-                client_config = webhook.get("clientConfig", {})
-                service_config = client_config.get("service", {})
-                if service_config.get("namespace") == "kueue-system":
-                    service_config["namespace"] = "openshift-kueue-operator"
-    
-    # Update namespace for specific resources (excluding Secret).
-    if kind in namespace_updates and "metadata" in doc:
-        doc["metadata"]["namespace"] = "openshift-kueue-operator"
-
-    # Parametrize the image field in Deployment.
-    if kind == "Deployment" and doc["metadata"]["name"] == "kueue-controller-manager":
-        for container in doc["spec"]["template"]["spec"]["containers"]:
-            if container["name"] == "manager":
-                container["image"] = "${IMAGE}"
-
-    # Add label for network policy for deployment
-    if kind == "Deployment" and doc["metadata"]["name"] == "kueue-controller-manager":
-        doc["spec"]["template"]["metadata"]["labels"]["app.openshift.io/name"] = "kueue"
-
-    # Store files in `bindata/assets/kueue-operator/`
-    base_filename = file_map[kind]
-    if base_filename not in separated_manifests:
-        separated_manifests[base_filename] = []
-
-    separated_manifests[base_filename].append(doc)
-
-def write_yaml_if_changed(bindata_file, doc, add_header=False):
-    # Read existing file content if it exists.
-    existing_content = ""
-    if os.path.exists(bindata_file):
-        with open(bindata_file, "r") as f:
-            existing_content = f.read()
-
-    # Generate new content.
-    new_content = yaml.dump(doc, default_flow_style=False)
-    if add_header:
-        new_content = "---\n" + new_content
-
-    # Write the new content only if it has changed.
-    if new_content != existing_content:
-        print(f"Writing {bindata_file}...")
-        with open(bindata_file, "w") as f:
-            f.write(new_content)
+    if args.src_dir:
+        version = "local"
+        print(f"Using local kustomize source from: {args.src_dir}")
+    elif args.version:
+        version = args.version
     else:
-        print(f"Skipping {bindata_file} as content has not changed.")
+        version = fetch_latest_version()
 
-# Write YAML files to bindata directory.
-for base_filename, content in separated_manifests.items():
-    for i, doc in enumerate(content):
-        # Skip creating crd.yaml in bindata/assets/kueue-operator/
-        if base_filename == "crd":
-            continue
+    print(f"Using Kueue version: {version}")
 
-        # Handle RoleBinding, ClusterRoleBinding, Role, Service, and ClusterRole naming.
-        if base_filename in ["rolebinding", "clusterrolebinding", "role", "service", "clusterrole"]:
-            name = doc["metadata"]["name"]
-            name = clean_name(name, doc["kind"])
-            if base_filename == "service":
-                # Remove 'service-' prefix for Service resources.
-                bindata_file = os.path.join(bindata_dir, f"{name}.yaml")
-            elif base_filename == "clusterrole":
-                # Write ClusterRole files to the clusterrole directory.
-                bindata_file = os.path.join(bindata_dir, "clusterroles", f"clusterrole-{name}.yaml")
-            else:
-                bindata_file = os.path.join(bindata_dir, f"{base_filename}-{name}.yaml")
+    # Define directories
+    bindata_dir = args.bindata_dir
+    input_file = "manifests.yaml"
+
+    if args.src_dir:
+        # Generate manifests using kustomize
+        print(f"Running kustomize build on {args.src_dir} ...")
+        try:
+            result = subprocess.run(
+                ["kustomize", "build", args.src_dir],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            with open(input_file, "w") as f:
+                f.write(result.stdout)
+        except subprocess.CalledProcessError as e:
+            print(f"Failed to run kustomize: {e}")
+            print(f"stderr: {e.stderr}")
+            exit(1)
+        except FileNotFoundError:
+            print("Error: kustomize command not found. Please install kustomize.")
+            exit(1)
+    else:
+        # Download manifests.yaml from web
+        manifests_url = f"https://github.com/kubernetes-sigs/kueue/releases/download/v{version}/manifests.yaml"
+        print(f"Downloading manifests.yaml from {manifests_url} ...")
+        response = requests.get(manifests_url)
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Failed to download manifests.yaml (HTTP {response.status_code})"
+            )
+
+        with open(input_file, "wb") as f:
+            f.write(response.content)
+
+    # Read and split YAML file.
+    try:
+        with open(input_file, "r") as f:
+            docs = list(yaml.safe_load_all(f))
+    except yaml.YAMLError as e:
+        print(f"Failed to parse YAML file: {e}")
+        exit(1)
+
+    # Define a mapping of 'kind' to filenames.
+    file_map = {
+        "CustomResourceDefinition": "crd",
+        "ClusterRole": "clusterrole",
+        "ClusterRoleBinding": "clusterrolebinding",
+        "APIService": "apiservice",
+        "ValidatingWebhookConfiguration": "validatingwebhook",
+        "MutatingWebhookConfiguration": "mutatingwebhook",
+        "Service": "service",
+        "Role": "role",
+        "RoleBinding": "rolebinding",
+        "ServiceAccount": "serviceaccount",
+        "Deployment": "deployment",
+        "Secret": "secret",
+    }
+
+    # Resources that need namespace updates (excluding Secret)
+    namespace_updates = ["Deployment", "Service", "ServiceAccount"]
+
+    # Clean up names for RoleBinding, ClusterRoleBinding, Role, Service, and ClusterRole
+    def clean_name(name, kind):
+        # Remove 'kueue-' prefix from the name
+        if kind in [
+            "RoleBinding",
+            "ClusterRoleBinding",
+            "Role",
+            "Service",
+            "ClusterRole",
+        ]:
+            name = name.replace("kueue-", "")
+        # Remove suffixes for specific kinds
+        if kind in ["RoleBinding", "ClusterRoleBinding"]:
+            name = name.replace("-rolebinding", "").replace("-binding", "")
+        elif kind == "Role":
+            name = name.replace("-role", "")
+        return name
+
+    # Organize manifests for output
+    separated_manifests = {}
+    allowed_kinds = set(file_map.keys())  # Process only these kinds
+
+    for doc in docs:
+        if not isinstance(doc, dict) or "kind" not in doc:
+            continue  # Skip invalid or empty YAML docs
+
+        kind = doc["kind"]
+        if kind not in allowed_kinds:
+            continue  # Skip unrelated kinds
+
+        # For Validating and Mutating webhook configurations, update namespace selectors and clientConfig.
+        if kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]:
+            if "webhooks" in doc:
+                for webhook in doc["webhooks"]:
+                    # Update namespaceSelector match expressions.
+                    ns_selector = webhook.get("namespaceSelector")
+                    if ns_selector is not None and "matchExpressions" in ns_selector:
+                        for expr in ns_selector["matchExpressions"]:
+                            if (
+                                expr.get("key") == "kubernetes.io/metadata.name"
+                                and expr.get("operator") == "NotIn"
+                            ):
+                                expr["values"] = [
+                                    "openshift-kueue-operator"
+                                    if v == "kueue-system"
+                                    else v
+                                    for v in expr.get("values", [])
+                                ]
+                    # Update clientConfig service namespace.
+                    client_config = webhook.get("clientConfig", {})
+                    service_config = client_config.get("service", {})
+                    if service_config.get("namespace") == "kueue-system":
+                        service_config["namespace"] = "openshift-kueue-operator"
+
+        # Update namespace for specific resources (excluding Secret).
+        if kind in namespace_updates and "metadata" in doc:
+            doc["metadata"]["namespace"] = "openshift-kueue-operator"
+
+        # Parametrize the image field in Deployment.
+        if (
+            kind == "Deployment"
+            and doc["metadata"]["name"] == "kueue-controller-manager"
+        ):
+            for container in doc["spec"]["template"]["spec"]["containers"]:
+                if container["name"] == "manager":
+                    container["image"] = "${IMAGE}"
+
+        # Add label for network policy for deployment
+        if (
+            kind == "Deployment"
+            and doc["metadata"]["name"] == "kueue-controller-manager"
+        ):
+            doc["spec"]["template"]["metadata"]["labels"]["app.openshift.io/name"] = (
+                "kueue"
+            )
+
+        # Store files in `bindata/assets/kueue-operator/`
+        base_filename = file_map[kind]
+        if base_filename not in separated_manifests:
+            separated_manifests[base_filename] = []
+
+        separated_manifests[base_filename].append(doc)
+
+    def write_yaml_if_changed(bindata_file, doc, add_header=False):
+        # Read existing file content if it exists.
+        existing_content = ""
+        if os.path.exists(bindata_file):
+            with open(bindata_file, "r") as f:
+                existing_content = f.read()
+
+        # Generate new content.
+        new_content = yaml.dump(doc, default_flow_style=False)
+        if add_header:
+            new_content = "---\n" + new_content
+
+        # Write the new content only if it has changed.
+        if new_content != existing_content:
+            print(f"Writing {bindata_file}...")
+            with open(bindata_file, "w") as f:
+                f.write(new_content)
         else:
-            bindata_file = os.path.join(bindata_dir, f"{base_filename}.yaml")
+            print(f"Skipping {bindata_file} as content has not changed.")
 
-        write_yaml_if_changed(bindata_file, doc, add_header=base_filename in ["clusterrole", "crd"])
-
-# Break ClusterRole and CRD into separate files.
-for base_filename, content in separated_manifests.items():
-    if base_filename in ["clusterrole", "crd"]:
+    # Write YAML files to bindata directory.
+    for base_filename, content in separated_manifests.items():
         for i, doc in enumerate(content):
-            name = doc["metadata"]["name"]
-            name = clean_name(name, doc["kind"])
-            if base_filename == "clusterrole":
-                bindata_file = os.path.join(bindata_dir, "clusterroles", f"clusterrole-{name}.yaml")
+            # Skip creating crd.yaml in bindata/assets/kueue-operator/
+            if base_filename == "crd":
+                continue
+
+            # Handle RoleBinding, ClusterRoleBinding, Role, Service, and ClusterRole naming.
+            if base_filename in [
+                "rolebinding",
+                "clusterrolebinding",
+                "role",
+                "service",
+                "clusterrole",
+            ]:
+                name = doc["metadata"]["name"]
+                name = clean_name(name, doc["kind"])
+                if base_filename == "service":
+                    # Remove 'service-' prefix for Service resources.
+                    bindata_file = os.path.join(bindata_dir, f"{name}.yaml")
+                elif base_filename == "clusterrole":
+                    # Write ClusterRole files to the clusterrole directory.
+                    bindata_file = os.path.join(
+                        bindata_dir, "clusterroles", f"clusterrole-{name}.yaml"
+                    )
+                else:
+                    bindata_file = os.path.join(
+                        bindata_dir, f"{base_filename}-{name}.yaml"
+                    )
             else:
-                bindata_file = os.path.join(bindata_dir, "crds", f"crd-{name}.yaml")
+                bindata_file = os.path.join(bindata_dir, f"{base_filename}.yaml")
 
-            write_yaml_if_changed(bindata_file, doc, add_header=True)
+            write_yaml_if_changed(
+                bindata_file, doc, add_header=base_filename in ["clusterrole", "crd"]
+            )
 
-# Delete manifests.yaml after processing.
-os.remove(input_file)
-print(f"Processing complete. YAML manifests saved in {bindata_dir}/")
+    # Break ClusterRole and CRD into separate files.
+    for base_filename, content in separated_manifests.items():
+        if base_filename in ["clusterrole", "crd"]:
+            for i, doc in enumerate(content):
+                name = doc["metadata"]["name"]
+                name = clean_name(name, doc["kind"])
+                if base_filename == "clusterrole":
+                    bindata_file = os.path.join(
+                        bindata_dir, "clusterroles", f"clusterrole-{name}.yaml"
+                    )
+                else:
+                    bindata_file = os.path.join(bindata_dir, "crds", f"crd-{name}.yaml")
+
+                write_yaml_if_changed(bindata_file, doc, add_header=True)
+
+    # Delete manifests.yaml after processing.
+    os.remove(input_file)
+    print(f"Processing complete. YAML manifests saved in {bindata_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
   "commitMessageSuffix": "{{baseBranch}}",
   "git-submodules": {
     "enabled": true,
-    "schedule": "* 4 * * 1-5",
+    "schedule": "* 4 * * 2",
     "packageRules": [
       {
         "matchUpdateTypes": [


### PR DESCRIPTION
* Bumps the upstream gitsubmodule to track the upstream main branch
* Changes hack/sync_manifests.py to have a main function and supports (optionally) syncing manifests from the gitsubmdule
* Syncs the CRDs from the upstream main branch
* Updates the README with new functionality
* Changes renovate git submodule update to run only on Tuesdays. This will prevent churn everyday with upstream changes.