### PR TITLE
Do not remove clusterRole created by the bundle

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -717,9 +718,12 @@ func (c *TargetConfigReconciler) cleanUpClusterRoles(ctx context.Context) error 
 		klog.Errorf("Failed to list ClusterRoles: %v", err)
 		return err
 	}
-
+	bundleClusterRoleNames := []string{
+		"kueue-batch-user-role",
+		"kueue-batch-admin-role",
+	}
 	for _, role := range clusterRoleList.Items {
-		if !strings.Contains(role.Name, "kueue") || strings.Contains(role.Name, "kueue-operator") || strings.Contains(role.Name, "openshift.io") {
+		if !strings.Contains(role.Name, "kueue") || strings.Contains(role.Name, "kueue-operator") || strings.Contains(role.Name, "openshift.io") || slices.Contains(bundleClusterRoleNames, role.Name) {
 			continue
 		}
 

--- a/test/e2e/e2e_operator_test.go
+++ b/test/e2e/e2e_operator_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -710,8 +711,12 @@ var _ = Describe("Kueue Operator", Ordered, func() {
 					return fmt.Errorf("Failure on fetching cluster roles: %v", err)
 				}
 				klog.Infof("Verifying removal of Cluster Roles")
+				bundleClusterRoleNames := []string{
+					"kueue-batch-user-role",
+					"kueue-batch-admin-role",
+				}
 				for _, role := range clusterRoles.Items {
-					if strings.Contains(role.Name, "kueue") && !strings.Contains(role.Name, "kueue-operator") && !strings.Contains(role.Name, "openshift.io") {
+					if strings.Contains(role.Name, "kueue") && !strings.Contains(role.Name, "kueue-operator") && !strings.Contains(role.Name, "openshift.io") && !slices.Contains(bundleClusterRoleNames, role.Name) {
 						return fmt.Errorf("ClusterRole %s still exists", role.Name)
 					}
 				}


### PR DESCRIPTION
We shouldn't be deleting clusterRoles that are created with the bundle when the kueue instance is deleted. Otherwise, when the kueue instance is created again this clusterrole won't be present anymore.