### PR TITLE
Update Kueue install mode to OwnNamespace

### DIFF
--- a/bundle/manifests/kueue-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kueue-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
       ]
     capabilities: Basic Install
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2025-10-08T16:12:38Z"
+    createdAt: "2025-10-10T18:52:49Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -305,13 +305,13 @@ spec:
         serviceAccountName: openshift-kueue-operator
     strategy: deployment
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - kueue-operator

--- a/deploy/base-csv/kueue-operator.clusterserviceversion.yaml
+++ b/deploy/base-csv/kueue-operator.clusterserviceversion.yaml
@@ -44,13 +44,13 @@ spec:
       mediatype: "image/png"
   install:
   installModes:
-    - supported: false
+    - supported: true
       type: OwnNamespace
     - supported: false
       type: SingleNamespace
     - supported: false
       type: MultiNamespace
-    - supported: true
+    - supported: false
       type: AllNamespaces
   keywords:
     - kueue-operator


### PR DESCRIPTION
Right now the CSV permissions are "promoted" to ClusterRoles when the operator is installed with AllNamespaces mode, so let's avoid having a clusterRole and role being created for the same resource, as an example network policy.
Also, our operator does not need to watch events on all namespaces, so let's change it to OwnNamespace.

