### PR TITLE
add latest tag for on push images

### DIFF
--- a/.tekton/kueue-bundle-dev-main-push.yaml
+++ b/.tekton/kueue-bundle-dev-main-push.yaml
@@ -524,6 +524,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+          - latest
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/kueue-bundle-main-push.yaml
+++ b/.tekton/kueue-bundle-main-push.yaml
@@ -470,6 +470,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+          - latest
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/kueue-must-gather-main-push.yaml
+++ b/.tekton/kueue-must-gather-main-push.yaml
@@ -496,6 +496,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+          - latest
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/kueue-operand-main-push.yaml
+++ b/.tekton/kueue-operand-main-push.yaml
@@ -561,6 +561,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+          - latest
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/kueue-operator-main-push.yaml
+++ b/.tekton/kueue-operator-main-push.yaml
@@ -500,6 +500,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+          - latest
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
This will add a "latest" tag for images that have been build from main.  It will allow people to more easily find the latest builds for testing.  Will  not be testable until after it is merged.  Nothing changes for pull-request builds.