### PR TITLE
serialize all tests and see if that helps with flakiness

### DIFF
--- a/test/e2e/e2e_local_queue_defaulting_test.go
+++ b/test/e2e/e2e_local_queue_defaulting_test.go
@@ -40,7 +40,7 @@ var (
 	defaultLocalQueueClean func()
 )
 
-var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, func() {
+var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Serial, Ordered, func() {
 	BeforeAll(func() {
 		Expect(deployOperand()).To(Succeed(), "operand deployment should not fail")
 	})

--- a/test/e2e/e2e_operator_test.go
+++ b/test/e2e/e2e_operator_test.go
@@ -78,10 +78,7 @@ func findKueuePods(list *corev1.PodList) []*corev1.Pod {
 	return pods
 }
 
-var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
-	// AfterEach(func() {
-	// 	Expect(kubeClient.CoreV1().Namespaces().Delete(context.TODO(), namespace, metav1.DeleteOptions{})).To(Succeed())
-	// })
+var _ = Describe("Kueue Operator", Label("operator"), Serial, Ordered, func() {
 	When("installs", func() {
 		It("operator pods should be ready", func() {
 			Eventually(func() error {

--- a/test/e2e/e2e_visibility_on_demand_test.go
+++ b/test/e2e/e2e_visibility_on_demand_test.go
@@ -35,7 +35,7 @@ const (
 	priorityName = "kueue-visibility"
 )
 
-var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, func() {
+var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Serial, Ordered, func() {
 	BeforeAll(func() {
 		Expect(deployOperand()).To(Succeed(), "operand deployment should not fail")
 	})


### PR DESCRIPTION
Discussing with @rphillips, we should really run all these tests sequentially.

Different files run in parallel it seems and this can cause flakiness.

Let's run all tests serially and see if that helps flakes.