### PR TITLE
delete namespace workloads after localqueue

### DIFF
--- a/test/e2e/e2e_operator_test.go
+++ b/test/e2e/e2e_operator_test.go
@@ -385,10 +385,19 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 		AfterAll(func() {
 			ctx := context.TODO()
 			cleanupLocalQueue()
+			deleteNamespace(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testNamespaceWithLabel,
+				},
+			})
+			deleteNamespace(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testNamespaceWithoutLabel,
+				},
+			})
+
 			cleanupClusterQueue()
 			cleanupResourceFlavor()
-			_ = kubeClient.CoreV1().Namespaces().Delete(ctx, testNamespaceWithLabel, metav1.DeleteOptions{})
-			_ = kubeClient.CoreV1().Namespaces().Delete(ctx, testNamespaceWithoutLabel, metav1.DeleteOptions{})
 		})
 
 		It("should suspend jobs only in labeled namespaces when labelPolicy=None", func() {

--- a/test/e2e/e2e_visibility_on_demand_test.go
+++ b/test/e2e/e2e_visibility_on_demand_test.go
@@ -86,9 +86,9 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 		})
 		AfterAll(func(ctx context.Context) {
 			cleanupLocalQueue()
+			deleteNamespace(ctx, ns)
 			cleanupClusterQueue()
 			cleanupResourceFlavor()
-			deleteNamespace(ctx, ns)
 		})
 
 		It("should allow modification of the nominal concurrency shares to 0", func(ctx context.Context) {


### PR DESCRIPTION
Kueue mentions that you must delete workloads in the namespace before you delete cq and rf.

Going to try this and see if this helps with cleanup int ests.