### PR TITLE
OCPKUEUE-341:Split operator and operator test into two suites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ go.work.sum
 # env file
 .env
 .envrc
+
+# ginkgo tests results
+report.xml

--- a/Makefile
+++ b/Makefile
@@ -38,13 +38,13 @@ $(call verify-golang-versions,Dockerfile)
 
 $(call add-crd-gen,kueueoperator,./pkg/apis/kueueoperator/v1,./manifests/,./manifests/)
 
-.PHONY: test-e2e
-test-e2e: ginkgo
-	${GINKGO} --label-filter="!disruptive" -v ./test/e2e/...
+.PHONY: test-e2e-operator
+test-e2e-operator: ginkgo
+	${GINKGO} -v ./test/e2e/operator
 
-.PHONY: test-e2e-disruptive
-test-e2e-disruptive: ginkgo
-	${GINKGO} --label-filter="disruptive" -v ./test/e2e/...
+.PHONY: test-e2e-operand
+test-e2e-operand: ginkgo
+	${GINKGO} -v ./test/e2e/operand
 
 regen-crd:
 	go run ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen crd paths=./pkg/apis/kueueoperator/v1/... output:crd:dir=./manifests
@@ -210,14 +210,17 @@ wait-for-cert-manager:
 	done
 
 .PHONY: e2e-ci-test
-e2e-ci-test: ginkgo
-	@echo "Running operator e2e tests..."
-	$(GINKGO) --label-filter="!disruptive" --junit-report=report.xml --no-color -v ./test/e2e/...
+e2e-ci-test: e2e-ci-operator-test
 
-.PHONY: e2e-ci-test-disruptive
-e2e-ci-test-disruptive: ginkgo
+.PHONY: e2e-ci-operator-test
+e2e-ci-operator-test: ginkgo
+	@echo "Running operator e2e tests..."
+	$(GINKGO) --junit-report=report.xml --no-color -v ./test/e2e/operator/
+
+.PHONY: e2e-ci-operand-test
+e2e-ci-operand-test: ginkgo
 	@echo "Running operator e2e tests disuptive..."
-	$(GINKGO) --label-filter="disruptive" --junit-report=report.xml --no-color -v ./test/e2e/...
+	$(GINKGO) --junit-report=report.xml --no-color -v ./test/e2e/operand/
 
 .PHONY: e2e-upstream-test
 e2e-upstream-test: ginkgo

--- a/test/e2e/operand/e2e_local_queue_defaulting_test.go
+++ b/test/e2e/operand/e2e_local_queue_defaulting_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package operand
 
 import (
 	"context"

--- a/test/e2e/operand/e2e_metrics_test.go
+++ b/test/e2e/operand/e2e_metrics_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package operand
 
 import (
 	"bytes"

--- a/test/e2e/operand/e2e_suite_test.go
+++ b/test/e2e/operand/e2e_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package operand
 
 import (
 	"fmt"
@@ -43,10 +43,9 @@ var (
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	config, _ := GinkgoConfiguration()
-	config.ParallelProcess = 1
 	if config.DryRun {
-		GinkgoWriter.Printf("Starting kueue operator suite [DryRun]\n")
-		report := PreviewSpecs("E2E Suite", config)
+		GinkgoWriter.Printf("Starting kueue operand suite [DryRun]\n")
+		report := PreviewSpecs("Operand E2E Suite", config)
 		for _, sr := range report.SpecReports {
 			if sr.State == types.SpecStateSkipped {
 				continue
@@ -58,8 +57,8 @@ func TestE2E(t *testing.T) {
 			}
 		}
 	} else {
-		GinkgoWriter.Printf("Starting kueue operator suite\n")
-		RunSpecs(t, "e2e suite", config)
+		GinkgoWriter.Printf("Starting kueue operand suite\n")
+		RunSpecs(t, "Operand E2E Suite", config)
 	}
 }
 

--- a/test/e2e/operand/e2e_visibility_on_demand_test.go
+++ b/test/e2e/operand/e2e_visibility_on_demand_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package operand
 
 import (
 	"context"

--- a/test/e2e/operator/e2e_operator_suite_test.go
+++ b/test/e2e/operator/e2e_operator_suite_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operator
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/openshift/kueue-operator/test/e2e/testutils"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	visibilityv1beta1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/visibility/v1beta1"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	kubeClient       *kubernetes.Clientset
+	genericClient    client.Client
+	clients          *testutils.TestClients
+	visibilityClient visibilityv1beta1.VisibilityV1beta1Interface
+	err              error
+)
+
+// Run e2e tests using the Ginkgo runner.
+func TestOperator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	config, _ := GinkgoConfiguration()
+	if config.DryRun {
+		GinkgoWriter.Printf("Starting kueue operator suite [DryRun]\n")
+		report := PreviewSpecs("Operator E2E Suite", config)
+		for _, sr := range report.SpecReports {
+			if sr.State == types.SpecStateSkipped {
+				continue
+			}
+			if len(sr.Labels()) > 0 {
+				GinkgoWriter.Printf("%s [labels: %s]\n", sr.FullText(), strings.Join(sr.Labels(), ", "))
+			} else {
+				GinkgoWriter.Printf("%s\n", sr.FullText())
+			}
+		}
+	} else {
+		GinkgoWriter.Printf("Starting kueue operator suite\n")
+		RunSpecs(t, "Operator E2E suite", config)
+	}
+}
+
+var _ = BeforeSuite(func() {
+	clients = testutils.NewTestClients()
+	kubeClient = clients.KubeClient
+	genericClient = clients.GenericClient
+
+	visibilityClient, err = testutils.GetVisibilityClient(fmt.Sprintf("system:serviceaccount:%s:default", testutils.OperatorNamespace))
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/test/e2e/operator/e2e_operator_test.go
+++ b/test/e2e/operator/e2e_operator_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/kueue-operator/test/e2e/testutils"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/klog/v2"
+	//+kubebuilder:scaffold:imports
+)
+
+var _ = Describe("Kueue Operator", func() {
+	When("installing", func() {
+		BeforeEach(func() {
+			//operator-sdk run bundle instead of installing it before the tests
+		})
+
+		AfterEach(func() {
+			// 	Expect(kubeClient.CoreV1().Namespaces().Delete(context.TODO(), namespace, metav1.DeleteOptions{})).To(Succeed())
+		})
+
+		It("operator pods should be ready", Label("day-zero"), func() {
+			Eventually(func() error {
+				ctx := context.TODO()
+				podItems, err := kubeClient.CoreV1().Pods(testutils.OperatorNamespace).List(ctx, metav1.ListOptions{})
+				if err != nil {
+					klog.Errorf("Unable to list pods: %v", err)
+					return nil
+				}
+				for _, pod := range podItems.Items {
+					if !strings.HasPrefix(pod.Name, testutils.OperatorNamespace+"-") {
+						continue
+					}
+					klog.Infof("Checking pod: %v, phase: %v, deletionTS: %v\n", pod.Name, pod.Status.Phase, pod.GetDeletionTimestamp())
+					if pod.Status.Phase == corev1.PodRunning && pod.GetDeletionTimestamp() == nil && pod.Status.ContainerStatuses[0].Ready {
+						return nil
+					}
+				}
+				return fmt.Errorf("pod is not ready")
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "operator pod failed to be ready")
+		})
+
+	})
+
+	When("deleting", func() {
+
+	})
+
+	When("reinstalling", func() {
+
+	})
+
+	When("upgrading", func() {
+
+	})
+})

--- a/upstream/kueue/e2e-test-ocp.sh
+++ b/upstream/kueue/e2e-test-ocp.sh
@@ -87,6 +87,7 @@ allow_privileged_access
 
 $GINKGO $GINKGO_ARGS \
   --skip="${GINKGO_SKIP_PATTERN}" \
+  --no-color \
   --junit-report=junit.xml \
   --json-report=e2e.json \
   --output-dir="$ARTIFACTS" \


### PR DESCRIPTION
Having to separate suites will make it easier to run create prow jobs for the two different test suites.  A follow up PR will be needed to update prow jobs to run operator and operand jobs separately.  Right now it is just running the operator tests so CI signal is less significant until all the operand tests are running again.