### PR TITLE
allow one to run tests sequentially

### DIFF
--- a/upstream/kueue/e2e-test-ocp.sh
+++ b/upstream/kueue/e2e-test-ocp.sh
@@ -37,13 +37,6 @@ function allow_privileged_access {
     $OC adm policy add-scc-to-group anyuid system:authenticated system:serviceaccounts
 }
 
-function revert_patches_on_exit() {
-	pushd ${SOURCE_DIR} >/dev/null
-	. utils.sh
-	revert_patches
-	popd >/dev/null
-}
-
 skips=(
         # do not deploy AppWrapper in OCP
         AppWrapper
@@ -85,9 +78,6 @@ pushd ${SOURCE_DIR} >/dev/null
 . utils.sh
 apply_patches
 popd >/dev/null
-
-trap revert_patches_on_exit EXIT
-# apply patches
 
 # Label two worker nodes for e2e tests (similar to the Kind setup).
 label_worker_nodes

--- a/upstream/kueue/utils.sh
+++ b/upstream/kueue/utils.sh
@@ -16,20 +16,3 @@ apply_patches() {
   done
 }
 
-revert_patches() {
-  for patch in patch/*.patch; do
-    pushd src >/dev/null
-    # Check if patch can be reverted (is currently applied)
-    if git apply --reverse --check ../$patch 2>/dev/null; then
-      echo "Reverting $patch"
-      git apply -R ../$patch || {
-        echo "Error: Failed to revert $patch"
-        popd >/dev/null
-        return 1
-      }
-    else
-      echo "Skipping $patch (not applied or conflicts)"
-    fi
-    popd >/dev/null
-  done
-}


### PR DESCRIPTION
This allows one to run upstream tests without having to manually unapply the patches.