### PR TITLE
Exclude Flakey Tests

### DIFF
--- a/upstream/kueue/e2e-test-ocp.sh
+++ b/upstream/kueue/e2e-test-ocp.sh
@@ -54,15 +54,14 @@ skips=(
         Fair
         # we do not enable this feature in our operator
         TopologyAwareScheduling
-        # relies on particular CPU setup to force pods to not schedule
-        "Failed Pod can be replaced in group"
-        # relies on particular CPU setup
-        "should allow to schedule a group of diverse pods"
-        # relies on particular CPU setup.
-        "StatefulSet created with WorkloadPriorityClass"
-        "LeaderWorkerSet created with WorkloadPriorityClass"
         # For tests that rely on CPU setup, we need to fix upstream to get cpu allocatables from node
         # rather than hardcoding CPU limits.
+        # relies on particular CPU setup to force pods to not schedule
+        "Failed Pod can be replaced in group"
+        "should allow to schedule a group of diverse pods"
+        "StatefulSet created with WorkloadPriorityClass"
+        "LeaderWorkerSet created with WorkloadPriorityClass"
+        "Pod groups when Single CQ"
         # We do not have kueuectl in our operator
         "Kueuectl"
 )


### PR DESCRIPTION
https://github.com/kubernetes-sigs/kueue/blob/main/test/e2e/singlecluster/leaderworkerset_test.go#L688C15-L688C65

This test, like others, is assuming that higher priority workloads won't schedule and lower priority workloads will be able to schedule.

Upstream makes assumptions about the number of CPUs needed in their prow cluster.

Its not entirely clear if the flakes are due to this but we disable similar tests when they rely on "1" cpu with multiple replicas.

