### PR TITLE
Use --no-color ginkgo option for upstream e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,9 +227,8 @@ e2e-upstream-test: ginkgo
 	oc apply -f test/e2e/bindata/assets/08_kueue_default.yaml
 	./hack/wait-for-kueue-leader-election.sh
 	@echo "Running e2e tests on OpenShift cluster ($(shell oc whoami --show-server))"
-	mkdir -p "$(ARTIFACT_DIR)"
-	IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(GINKGO_ARGS)" \
-	ARTIFACT_DIR=$(ARTIFACT_DIR) E2E_TARGET_FOLDER="singlecluster" \
+	ARTIFACTS="$(LOCALBIN)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(GINKGO_ARGS) --no-color" \
+	E2E_TARGET_FOLDER="singlecluster" \
 	SKIP_DEPLOY=true \
 	./upstream/kueue/e2e-test-ocp.sh
 

--- a/upstream/kueue/e2e-test-ocp.sh
+++ b/upstream/kueue/e2e-test-ocp.sh
@@ -97,6 +97,5 @@ $GINKGO ${GINKGO_ARGS:-} \
   --output-dir="$ARTIFACT_DIR" \
   --keep-going \
   --flake-attempts=3 \
-  --no-color \
   -v ./upstream/kueue/src/test/e2e/"$E2E_TARGET_FOLDER"/...
 


### PR DESCRIPTION
This PR adds the --no-color option to the ginkgo execution of the upstream e2e  tests.  This makes reading the logs in Prow much easier. 

Verification can be done by looking at the output of a local "make e2e-upstream-test" and the prow logs from Ci jobs to make sure there are no colors or ANSI characters showing up.