### PR TITLE
bump kueue to 1.3.0

### DIFF
--- a/Dockerfile.kueue
+++ b/Dockerfile.kueue
@@ -33,8 +33,8 @@ LABEL summary="Kueue is a set of APIs and controller for job queueing. \
 LABEL io.k8s.display-name="Kueue"
 LABEL io.openshift.tags="openshift,operand,kueue"
 LABEL distribution-scope="public"
-LABEL version="1.2.0"
-LABEL release="1.2.0"
+LABEL version="1.3.0"
+LABEL release="1.3.0"
 
 # Licenses
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GO_BUILD_FLAGS :=-tags strictfipsruntime
 
 IMAGE_REGISTRY ?=registry.svc.ci.openshift.org
 
-OPERATOR_VERSION ?= 1.2.0
+OPERATOR_VERSION ?= 1.3.0
 OPERATOR_SDK_VERSION ?= v1.37.0
 # These are targets for pushing images
 OPERATOR_IMAGE ?= registry.redhat.io/kueue/kueue-rhel9-operator:latest

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -29,7 +29,7 @@ LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 LABEL io.k8s.display-name="Red Hat build of Kueue Operator bundle"
 LABEL io.k8s.description="This is a bundle for the Red Hat build of Kueue Operator"
 LABEL com.redhat.component="kueue-operator-bundle"
-LABEL com.redhat.openshift.versions="v4.18-v4.19"
+LABEL com.redhat.openshift.versions="v4.18-v4.19-v4.20-v4.21"
 LABEL name="kueue-operator-rhel9-operator-bundle"
 LABEL summary="kueue-operator-bundle"
 LABEL url="https://github.com/openshift/kueue-operator"
@@ -38,8 +38,8 @@ LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="openshift,kueue-operator-bundle"
 LABEL description="kueue-operator-bundle"
 LABEL distribution-scope="public"
-LABEL release=1.2.0
-LABEL version=1.2.0
+LABEL release=1.3.0
+LABEL version=1.3.0
 
 LABEL maintainer="Node team, <aos-node@redhat.com>"
 

--- a/bundle.developer.Dockerfile
+++ b/bundle.developer.Dockerfile
@@ -29,7 +29,7 @@ LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 LABEL io.k8s.display-name="Red Hat build of Kueue Operator bundle"
 LABEL io.k8s.description="This is a bundle for the Red Hat build of Kueue Operator"
 LABEL com.redhat.component="kueue-operator-bundle"
-LABEL com.redhat.openshift.versions="v4.18-v4.19"
+LABEL com.redhat.openshift.versions="v4.18-v4.19-v4.20-v4.21"
 LABEL name="kueue-operator-rhel9-operator-bundle"
 LABEL summary="kueue-operator-bundle"
 LABEL url="https://github.com/openshift/kueue-operator"
@@ -38,8 +38,8 @@ LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="openshift,kueue-operator-bundle"
 LABEL description="kueue-operator-bundle"
 LABEL distribution-scope="public"
-LABEL release=1.2.0
-LABEL version=1.2.0
+LABEL release=1.3.0
+LABEL version=1.3.0
 
 LABEL maintainer="Node team, <aos-node@redhat.com>"
 

--- a/bundle/manifests/kueue-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kueue-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
       ]
     capabilities: Basic Install
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2025-11-14T19:51:19Z"
+    createdAt: "2025-11-26T18:49:00Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -50,7 +50,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: kueue-operator.v1.2.0
+  name: kueue-operator.v1.3.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -336,4 +336,4 @@ spec:
     name: operand-image
   - image: registry.redhat.io/kueue/kueue-must-gather-rhel9:latest
     name: must-gather
-  version: 1.2.0
+  version: 1.3.0

--- a/deploy/base-csv/kueue-operator.clusterserviceversion.yaml
+++ b/deploy/base-csv/kueue-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-kueue-operator
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
-  name: kueue-operator.v1.1.0
+  name: kueue-operator.v1.3.0
   namespace: placeholder
   labels:
     operatorframework.io/arch.amd64: supported
@@ -69,5 +69,5 @@ spec:
       name: operand-image
     - name: must-gather
       image: registry.redhat.io/kueue/kueue-must-gather-rhel9@latest
-  version: 1.2.0
+  version: 1.3.0
   minKubeVersion: 1.28.0


### PR DESCRIPTION
Prepare kueue for 1.3.

Main branch is now tracking 0.15 so its really meant for 1.3.0