### PR TITLE
Potentially fix "should allow to label pod and job with default localqueue after they're created"

### DIFF
--- a/test/e2e/e2e_local_queue_defaulting_test.go
+++ b/test/e2e/e2e_local_queue_defaulting_test.go
@@ -138,6 +138,17 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 			By("Creating a new job without localQueue")
 			err := kueueClient.KueueV1beta1().LocalQueues(ns.Name).Delete(ctx, testutils.DefaultLocalQueueName, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() error {
+				_, err := kueueClient.KueueV1beta1().LocalQueues(ns.Namespace).Get(ctx, testutils.DefaultLocalQueueName, metav1.GetOptions{})
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				return fmt.Errorf("localqueue %s/%s still exists: %w", ns.Name, testutils.DefaultLocalQueueName, err)
+			}, testutils.DeletionTime, testutils.DeletionPoll).Should(Succeed(), fmt.Sprintf("LocalQueue %s/%s was not cleaned up", ns.Name, testutils.DefaultLocalQueueName))
+
+			By("Creating a new job without localQueue")
+
+			Expect(err).NotTo(HaveOccurred())
 			jobWithoutQueue := builder.NewJobWithoutQueue()
 			createdJobWithoutQueue, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, jobWithoutQueue, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
I'm seeing a flake in "should allow to label pod and job with default localqueue after they're created" where there is an error in deletion of the local queue.

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_kueue-operator/1132/pull-ci-openshift-kueue-operator-main-test-e2e-4-18/1993750755021950976/build-log.txt

```
  {"level":"Level(-2)","ts":"2025-11-26T19:10:08.082417341Z","logger":"localqueue-reconciler","caller":"core/localqueue_controller.go:221","msg":"LocalQueue delete event","localQueue":{"name":"default","namespace":"e2e-kueue-5zgxc"}}
  2025/11/26 19:10:08 http: TLS handshake error from 10.130.0.2:58798: EOF
  {"level":"error","ts":"2025-11-26T19:10:08.093087795Z","caller":"controller/controller.go:474","msg":"Reconciler error","controller":"localqueue_controller","namespace":"e2e-kueue-5zgxc","name":"default","reconcileID":"8a1b3dc6-1b3a-42f9-91da-ebe63f4bb495","error":"Operation cannot be fulfilled on localqueues.kueue.x-k8s.io \"default\": StorageError: invalid object, Code: 4, Key: /kubernetes.io/kueue.x-k8s.io/localqueues/e2e-kueue-5zgxc/default, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: 65407d83-d8c6-48dd-baa1-ba7bdcded2f3, UID in object meta: ","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/workspace/upstream/kueue/src/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:474\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/workspace/upstream/kueue/src/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/workspace/upstream/kueue/src/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:296"}

```

For some reason, the deletion has an error. The deletion registers so I am curious if we make sure deletion occurs this would deflake this test.