### PR TITLE
Update Go toolchain version in Makefile generate-clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ code-gen: ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject
 
 .PHONY: generate-clients
 generate-clients:
-	GO=GO111MODULE=on GOTOOLCHAIN=go1.24.0 GOFLAGS=-mod=readonly hack/update-codegen.sh
+	GO=GO111MODULE=on GOTOOLCHAIN=go1.25.0 GOFLAGS=-mod=readonly hack/update-codegen.sh
 
 .PHONY: get-kueue-must-gather-image
 get-kueue-must-gather-image:


### PR DESCRIPTION
This bumps the Go toolchain version to 1.25. Otherwise, we get failure:
```
go: ../../../go.mod requires go >= 1.25.0 (running go 1.24.0; GOTOOLCHAIN=go1.24.0)
make: *** [Makefile:68: generate-clients] Error 1
```