### PR TITLE
OCPKUEUE-535 - Remove skip for 'Should unsuspend a job and set nodeSelectors' test

### DIFF
--- a/upstream/kueue/e2e-test-ocp.sh
+++ b/upstream/kueue/e2e-test-ocp.sh
@@ -41,8 +41,6 @@ function allow_privileged_access {
 }
 
 skips=(
-  # This job is having difficult scheduling in OCP.
-  "Should unsuspend a job and set nodeSelectors"
   "StatefulSet created with WorkloadPriorityClass"
   "LeaderWorkerSet created with WorkloadPriorityClass"
 )


### PR DESCRIPTION
This PR is part of the API Promotion Feature Verification Tests for [OCPKUEUE-509](https://issues.redhat.com/browse/OCPKUEUE-509).

Changes I am re-enabling the Should unsuspend a job and set nodeSelectors test routine. It was previously skipped due to flakiness.

Testing Strategy Local runs showed a ~20% failure rate. I am re-introducing this to CI to gather a larger data set on its stability. If the failure rate remains high in the CI environment, we will reconsider keeping these tests in the suite.