### PR TITLE
[WIP] - Add Codecov integration for unit test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ $(call verify-golang-versions,Dockerfile)
 
 $(call add-crd-gen,kueueoperator,./pkg/apis/kueueoperator/v1,./manifests/,./manifests/)
 
+.PHONY: coverage
+coverage: ## Run unit tests with coverage and upload to Codecov
+	hack/codecov.sh
+
 .PHONY: test-e2e
 test-e2e: ginkgo
 	${GINKGO} --keep-going --flake-attempts=3 --label-filter="!disruptive" -v ./test/e2e/...

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,33 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+        base: auto
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "vendor/"
+  - "upstream/"
+  - "bindata/"
+  - "**/*_test.go"
+  - "test/"
+  - "hack/"
+  - "pkg/generated/"
+  - "**/zz_generated.*.go"
+  - "cmd/"
+  - "bundle/"
+  - "manifests/"
+
+github_checks:
+  annotations: true

--- a/hack/codecov.sh
+++ b/hack/codecov.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Running unit tests with coverage..."
+
+# Generate coverage report using the same test scope as current `make test`
+# This aligns with GO_TEST_PACKAGES=./pkg/... in the Makefile
+go test -mod=vendor -race -coverprofile=coverage.out -covermode=atomic ./pkg/...
+
+echo "Coverage report generated: coverage.out"
+
+# Only upload to Codecov if token is provided (for CI environments)
+if [[ -n "${CODECOV_TOKEN:-}" ]]; then
+    echo "Uploading coverage to Codecov..."
+
+    # Download Codecov CLI (more reliable than codecov-action in Prow)
+    # Detect platform and download appropriate binary
+    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+    case "$OS" in
+        linux*)
+            CODECOV_URL="https://cli.codecov.io/latest/linux/codecov"
+            ;;
+        darwin*)
+            CODECOV_URL="https://cli.codecov.io/latest/macos/codecov"
+            ;;
+        *)
+            echo "Unsupported OS: $OS"
+            exit 1
+            ;;
+    esac
+
+    curl -Os "$CODECOV_URL"
+    chmod +x codecov
+
+    # Upload with unit-tests flag for proper categorization
+    ./codecov upload-process \
+        --token "${CODECOV_TOKEN}" \
+        --slug "openshift/kueue-operator" \
+        --flag unit-tests \
+        --file coverage.out \
+        --branch "${PULL_BASE_REF:-main}"
+
+    echo "Coverage uploaded successfully!"
+else
+    echo "CODECOV_TOKEN not provided, skipping upload (local development)"
+fi


### PR DESCRIPTION
The Code Coverage Working Group—one of the four Quality WGs established earlier this year—is focused on identifying testing gaps to improve overall project reliability.

This PR serves as the first step in that process: configuring the kueue-operator with Codecov. In this initial phase, we are focusing exclusively on unit tests. Measurement for E2E tests will be integrated in a future iteration. 

Changes in this PR:

- Configuration: Added codecov.yml with defined project/patch coverage thresholds and exclusion rules (vendor, upstream, generated, and test directories).
- Automation: Introduced hack/codecov.sh to execute unit tests with coverage profiling and upload results via the Codecov CLI
- Tooling: Added a make coverage Makefile target to provide a consistent entry point for both local development and CI pipelines.

A previous of current results (executed manually), can be checked here: https://app.codecov.io/github/openshift/kueue-operator 