### PR TITLE
OCPKUEUE-590: Add observability for invalid TLS cipher suites

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -477,7 +477,8 @@ func (c *TargetConfigReconciler) sync(ctx context.Context, syncCtx factory.SyncC
 			klog.Warningf("Failed to fetch TLS profile from APIServer CR: %v - will retry", err)
 			return err
 		}
-		tlsOpts, err = tlsprofile.TLSOptionsFromProfile(clusterProfile)
+		var unmappedCiphers []string
+		tlsOpts, unmappedCiphers, err = tlsprofile.TLSOptionsFromProfile(clusterProfile)
 		if err != nil {
 			klog.Errorf("Unsupported TLS profile: %v", err)
 			c.eventRecorder.Eventf("UnsupportedTLSProfile", "%v", err)
@@ -488,6 +489,10 @@ func (c *TargetConfigReconciler) sync(ctx context.Context, syncCtx factory.SyncC
 				return statusErr
 			}
 			return nil
+		}
+		if len(unmappedCiphers) > 0 {
+			klog.Warningf("The following TLS cipher suites from the APIServer CR could not be mapped to IANA format and were excluded from the Kueue configuration: %v", unmappedCiphers)
+			c.eventRecorder.Warningf("InvalidTLSCipherSuites", "The following TLS cipher suites from the APIServer CR could not be mapped and were excluded: %v", unmappedCiphers)
 		}
 		if tlsOpts != nil {
 			klog.Infof("TLS Options - MinVersion: %s, CipherSuites: %v", tlsOpts.MinVersion, tlsOpts.CipherSuites)

--- a/pkg/tlsprofile/tlsprofile.go
+++ b/pkg/tlsprofile/tlsprofile.go
@@ -40,12 +40,13 @@ func FetchAPIServerTLSProfile(ctx context.Context, client configclient.Interface
 // TLSOptionsFromProfile resolves an OpenShift TLSSecurityProfile to kueue TLSOptions.
 // If profile is nil, the Intermediate profile is used as the default.
 // Cipher suites are converted from OpenSSL names to IANA format.
-// Returns an error if the profile uses a TLS version below 1.2, which is not
-// supported by Kueue.
-func TLSOptionsFromProfile(profile *configv1.TLSSecurityProfile) (*configapi.TLSOptions, error) {
+// Returns the TLS options, a list of cipher suite names that could not be mapped
+// to IANA format (unmapped ciphers), and an error if the profile uses a TLS
+// version below 1.2, which is not supported by Kueue.
+func TLSOptionsFromProfile(profile *configv1.TLSSecurityProfile) (*configapi.TLSOptions, []string, error) {
 	profileSpec, err := getProfileSpec(profile)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if profileSpec.MinTLSVersion == configv1.VersionTLS10 || profileSpec.MinTLSVersion == configv1.VersionTLS11 {
@@ -53,7 +54,7 @@ func TLSOptionsFromProfile(profile *configv1.TLSSecurityProfile) (*configapi.TLS
 		if profile != nil {
 			profileType = string(profile.Type)
 		}
-		return nil, fmt.Errorf("TLS profile %q uses minimum version %s which is not supported by Kueue (minimum supported: VersionTLS12)", profileType, profileSpec.MinTLSVersion)
+		return nil, nil, fmt.Errorf("TLS profile %q uses minimum version %s which is not supported by Kueue (minimum supported: VersionTLS12)", profileType, profileSpec.MinTLSVersion)
 	}
 
 	opts := &configapi.TLSOptions{
@@ -62,11 +63,26 @@ func TLSOptionsFromProfile(profile *configv1.TLSSecurityProfile) (*configapi.TLS
 
 	// TLS 1.3 cipher suites are not configurable in Go's crypto/tls.
 	// Only set cipher suites for TLS 1.2 and below.
+	var unmappedCiphers []string
 	if profileSpec.MinTLSVersion != configv1.VersionTLS13 {
 		opts.CipherSuites = crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers)
+		unmappedCiphers = findUnmappedCiphers(profileSpec.Ciphers)
 	}
 
-	return opts, nil
+	return opts, unmappedCiphers, nil
+}
+
+// findUnmappedCiphers returns cipher suite names from the input that cannot be
+// mapped from OpenSSL to IANA format. It identifies each cipher individually by
+// checking whether OpenSSLToIANACipherSuites produces a result for it.
+func findUnmappedCiphers(ciphers []string) []string {
+	var unmapped []string
+	for _, c := range ciphers {
+		if mapped := crypto.OpenSSLToIANACipherSuites([]string{c}); len(mapped) == 0 {
+			unmapped = append(unmapped, c)
+		}
+	}
+	return unmapped
 }
 
 // getProfileSpec resolves a TLSSecurityProfile to its TLSProfileSpec.

--- a/pkg/tlsprofile/tlsprofile_test.go
+++ b/pkg/tlsprofile/tlsprofile_test.go
@@ -24,11 +24,12 @@ import (
 
 func TestTLSOptionsFromProfile(t *testing.T) {
 	tests := []struct {
-		name               string
-		profile            *configv1.TLSSecurityProfile
-		expectedMinVersion string
-		expectCiphers      bool
-		expectError        bool
+		name                    string
+		profile                 *configv1.TLSSecurityProfile
+		expectedMinVersion      string
+		expectCiphers           bool
+		expectError             bool
+		expectedUnmappedCiphers []string
 	}{
 		{
 			name:               "nil profile defaults to Intermediate",
@@ -83,6 +84,40 @@ func TestTLSOptionsFromProfile(t *testing.T) {
 			expectCiphers:      false,
 		},
 		{
+			name: "Custom profile with invalid ciphers reports unmapped",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers: []string{
+							"ECDHE-RSA-AES128-GCM-SHA256",
+							"TLS_ALICE_POLY1305_SHA256",
+							"INVALID-CIPHER",
+						},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+			expectedMinVersion:      "VersionTLS12",
+			expectCiphers:           true,
+			expectedUnmappedCiphers: []string{"TLS_ALICE_POLY1305_SHA256", "INVALID-CIPHER"},
+		},
+		{
+			name: "Custom profile with all invalid ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"BOGUS-CIPHER-1", "BOGUS-CIPHER-2"},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+			expectedMinVersion:      "VersionTLS12",
+			expectCiphers:           false,
+			expectedUnmappedCiphers: []string{"BOGUS-CIPHER-1", "BOGUS-CIPHER-2"},
+		},
+		{
 			name: "Old profile returns error (TLS 1.0 unsupported)",
 			profile: &configv1.TLSSecurityProfile{
 				Type: configv1.TLSProfileOldType,
@@ -134,7 +169,7 @@ func TestTLSOptionsFromProfile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			opts, err := TLSOptionsFromProfile(tt.profile)
+			opts, unmappedCiphers, err := TLSOptionsFromProfile(tt.profile)
 			if tt.expectError {
 				if err == nil {
 					t.Fatal("expected error but got nil")
@@ -155,6 +190,15 @@ func TestTLSOptionsFromProfile(t *testing.T) {
 			}
 			if !tt.expectCiphers && len(opts.CipherSuites) != 0 {
 				t.Errorf("expected empty CipherSuites for TLS 1.3, got %v", opts.CipherSuites)
+			}
+			if len(tt.expectedUnmappedCiphers) != len(unmappedCiphers) {
+				t.Errorf("expected %d unmapped ciphers, got %d: %v", len(tt.expectedUnmappedCiphers), len(unmappedCiphers), unmappedCiphers)
+			} else {
+				for i, expected := range tt.expectedUnmappedCiphers {
+					if unmappedCiphers[i] != expected {
+						t.Errorf("expected unmapped cipher %d to be %q, got %q", i, expected, unmappedCiphers[i])
+					}
+				}
 			}
 		})
 	}

--- a/test/e2e/e2e_tls_profile_test.go
+++ b/test/e2e/e2e_tls_profile_test.go
@@ -79,7 +79,7 @@ var _ = Describe("TLS Security Profile", Label("tls-profile"), Ordered, func() {
 	When("the default Intermediate TLS profile is configured", func() {
 		It("should have Intermediate TLS settings in the initial operand ConfigMap", func(ctx context.Context) {
 			By("Verifying the initial ConfigMap captured in BeforeAll contains Intermediate TLS settings")
-			expectedTLSOpts, err := tlsprofile.TLSOptionsFromProfile(nil)
+			expectedTLSOpts, _, err := tlsprofile.TLSOptionsFromProfile(nil)
 			Expect(err).NotTo(HaveOccurred(), "failed to resolve default TLS profile")
 
 			tlsOpts, err := extractTLSOptions(initialConfigMapData)
@@ -305,6 +305,82 @@ var _ = Describe("TLS Security Profile", Label("tls-profile"), Ordered, func() {
 				return nil
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(),
 				"operand ConfigMap should contain Custom TLS settings")
+		})
+	})
+
+	When("the cluster TLS profile is set to Custom with invalid cipher suites", func() {
+		It("should emit an InvalidTLSCipherSuites warning event for unmapped ciphers", func(ctx context.Context) {
+			if isHyperShift {
+				Skip("APIServer TLS profile mutation is not supported on HyperShift clusters")
+			}
+
+			By("Setting APIServer TLS profile to Custom with a mix of valid and invalid ciphers")
+			customProfile := &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers: []string{
+							"ECDHE-RSA-AES128-GCM-SHA256",
+							"TLS_ALICE_POLY1305_SHA256",
+							"INVALID-CIPHER",
+						},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			}
+			err := updateAPIServerTLSProfile(ctx, configClient, customProfile)
+			Expect(err).NotTo(HaveOccurred(), "failed to set Custom TLS profile with invalid ciphers")
+
+			By("Waiting for the operand ConfigMap to contain only the valid cipher")
+			Eventually(func() error {
+				configMap, err := kubeClient.CoreV1().ConfigMaps(testutils.OperatorNamespace).Get(
+					ctx, "kueue-manager-config", metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to get ConfigMap: %w", err)
+				}
+
+				configData, ok := configMap.Data["controller_manager_config.yaml"]
+				if !ok {
+					return fmt.Errorf("controller_manager_config.yaml key not found in ConfigMap")
+				}
+
+				tlsOpts, err := extractTLSOptions(configData)
+				if err != nil {
+					return fmt.Errorf("failed to extract TLS options: %w", err)
+				}
+
+				if tlsOpts == nil {
+					return fmt.Errorf("TLS options not found in operand ConfigMap")
+				}
+
+				// Only the valid cipher should be present
+				if len(tlsOpts.CipherSuites) != 1 {
+					return fmt.Errorf("expected 1 cipher suite (only valid ones), got %d: %v",
+						len(tlsOpts.CipherSuites), tlsOpts.CipherSuites)
+				}
+
+				return nil
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(),
+				"operand ConfigMap should contain only valid cipher suites")
+
+			By("Verifying that an InvalidTLSCipherSuites warning event was emitted")
+			Eventually(func() error {
+				events, err := kubeClient.CoreV1().Events(testutils.OperatorNamespace).List(ctx, metav1.ListOptions{
+					FieldSelector: "reason=InvalidTLSCipherSuites",
+				})
+				if err != nil {
+					return fmt.Errorf("failed to list events: %w", err)
+				}
+
+				for _, event := range events.Items {
+					if event.Type == "Warning" && event.Reason == "InvalidTLSCipherSuites" {
+						klog.Infof("Found expected warning event: reason=%s, message=%s", event.Reason, event.Message)
+						return nil
+					}
+				}
+				return fmt.Errorf("no InvalidTLSCipherSuites warning event found in namespace %s", testutils.OperatorNamespace)
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(),
+				"operator should emit InvalidTLSCipherSuites warning event for unmapped ciphers")
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- When a Custom TLS profile in the APIServer CR contains cipher suites that cannot be mapped from OpenSSL to IANA format, the operator now detects them and emits a `Warning` log and Kubernetes Warning event (`InvalidTLSCipherSuites`) listing the excluded ciphers.
- Previously these ciphers were silently dropped, making it hard for administrators to understand why the running TLS configuration differed from the requested intent.
- Adds unit tests for unmapped cipher detection and an e2e test verifying the warning event is emitted.

## Changes
- `pkg/tlsprofile/tlsprofile.go`: `TLSOptionsFromProfile` now returns unmapped cipher names alongside TLS options. Added `findUnmappedCiphers()` helper.
- `pkg/operator/target_config_reconciler.go`: Emits `klog.Warningf` and a `Warning` Kubernetes event when unmapped ciphers are detected.
- `pkg/tlsprofile/tlsprofile_test.go`: Added test cases for invalid/unmapped cipher detection.
- `test/e2e/e2e_tls_profile_test.go`: Added e2e test verifying the `InvalidTLSCipherSuites` warning event is emitted when invalid ciphers are configured.

## Test plan
- [x] Unit tests pass (`go test ./pkg/tlsprofile/...`)
- [x] Full build passes (`go build ./...`)
- [x] e2e test: Set Custom TLS profile with invalid ciphers, verify only valid ciphers in ConfigMap and `InvalidTLSCipherSuites` warning event emitted

JIRA: https://redhat.atlassian.net/browse/OCPKUEUE-590

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI (Claude Code by Anthropic).