### PR TITLE
OCPBUGS-82009: Enable ShortWorkloadNames when external frameworks are configured

### DIFF
--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -183,7 +183,7 @@ func buildResources(resources kueue.Resources) *configapi.Resources {
 	}
 }
 
-func buildFeatureGates(resources kueue.Resources, frameworks []kueue.KueueIntegration, draSupported bool) map[string]bool {
+func buildFeatureGates(resources kueue.Resources, frameworks []kueue.KueueIntegration, draSupported bool, integrationExtFrameworks []kueue.ExternalFramework, multiKueue *kueue.MultiKueue) map[string]bool {
 	featureGates := map[string]bool{}
 
 	// DynamicResourceAllocation is Alpha in Kueue, so we explicitly enable it
@@ -203,6 +203,14 @@ func buildFeatureGates(resources kueue.Resources, frameworks []kueue.KueueIntegr
 			featureGates["SparkApplicationIntegration"] = true
 			break
 		}
+	}
+
+	// ShortWorkloadNames is Alpha in Kueue. Enable it when external frameworks
+	// are configured to prevent workload names from exceeding the 63-character
+	// Kubernetes label value limit in the MultiKueue external frameworks adapter.
+	// See https://issues.redhat.com/browse/OCPBUGS-82009.
+	if len(integrationExtFrameworks) > 0 || (multiKueue != nil && len(multiKueue.ExternalFrameworks) > 0) {
+		featureGates["ShortWorkloadNames"] = true
 	}
 
 	if len(featureGates) == 0 {
@@ -263,7 +271,7 @@ func defaultKueueConfigurationTemplate(namespace string, kueueCfg kueue.KueueCon
 		WaitForPodsReady:           buildWaitForPodsReady(kueueCfg.GangScheduling),
 		FairSharing:                buildFairSharing(kueueCfg.Preemption),
 		Resources:                  buildResources(kueueCfg.Resources),
-		FeatureGates:               buildFeatureGates(kueueCfg.Resources, kueueCfg.Integrations.Frameworks, draSupported),
+		FeatureGates:               buildFeatureGates(kueueCfg.Resources, kueueCfg.Integrations.Frameworks, draSupported, kueueCfg.Integrations.ExternalFrameworks, kueueCfg.MultiKueue),
 		MultiKueue:                 mapOperatorMultiKueueToKueue(kueueCfg.MultiKueue, gvrToKind),
 	}
 }

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -548,6 +548,8 @@ controller:
     Pod: 5
     ResourceFlavor.kueue.x-k8s.io: 1
     Workload.kueue.x-k8s.io: 5
+featureGates:
+  ShortWorkloadNames: true
 health:
   healthProbeBindAddress: :8081
 integrations:
@@ -753,6 +755,8 @@ controller:
     Pod: 5
     ResourceFlavor.kueue.x-k8s.io: 1
     Workload.kueue.x-k8s.io: 5
+featureGates:
+  ShortWorkloadNames: true
 health:
   healthProbeBindAddress: :8081
 integrations:
@@ -781,6 +785,68 @@ multiKueue:
   - name: CustomJob.v1.example.com
   - name: myworkloads.v1alpha1.test.io
   gcInterval: null
+namespace: test
+webhook:
+  port: 9443
+`,
+				},
+			},
+			wantErr: nil,
+		},
+		"integration external frameworks enables short workload names": {
+			configuration: kueue.KueueConfiguration{
+				Integrations: kueue.Integrations{
+					Frameworks: []kueue.KueueIntegration{kueue.KueueIntegrationBatchJob},
+					ExternalFrameworks: []kueue.ExternalFramework{
+						{
+							Group:    "tekton.dev",
+							Version:  "v1",
+							Resource: "pipelineruns",
+						},
+					},
+				},
+			},
+			wantCfgMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+clientConnection:
+  burst: 100
+  qps: 50
+controller:
+  groupKindConcurrency:
+    ClusterQueue.kueue.x-k8s.io: 1
+    Job.batch: 5
+    LocalQueue.kueue.x-k8s.io: 1
+    Pod: 5
+    ResourceFlavor.kueue.x-k8s.io: 1
+    Workload.kueue.x-k8s.io: 5
+featureGates:
+  ShortWorkloadNames: true
+health:
+  healthProbeBindAddress: :8081
+integrations:
+  externalFrameworks:
+  - pipelineruns.v1.tekton.dev
+  frameworks:
+  - batch/job
+internalCertManagement:
+  enable: false
+kind: Configuration
+leaderElection:
+  leaderElect: true
+  leaseDuration: 2m17s
+  renewDeadline: 1m47s
+  resourceLock: ""
+  resourceName: ""
+  resourceNamespace: ""
+  retryPeriod: 26s
+manageJobsWithoutQueueName: false
+managedJobsNamespaceSelector:
+  matchLabels:
+    kueue.openshift.io/managed: "true"
+metrics:
+  bindAddress: :8443
+  enableClusterQueueResources: true
 namespace: test
 webhook:
   port: 9443


### PR DESCRIPTION
## Summary

When external frameworks are configured (either via `integrations.externalFrameworks` or `multiKueue.externalFrameworks`), workload names generated by the MultiKueue external frameworks adapter can exceed the 63-character Kubernetes label value limit, causing failures.

This PR automatically enables the `ShortWorkloadNames` alpha feature gate in the generated Kueue configuration whenever external frameworks are present, preventing these naming collisions.

## Problem

The MultiKueue external frameworks adapter constructs workload names that can exceed Kubernetes' 63-character label value limit. This causes workload creation to fail with validation errors when external frameworks like Tekton PipelineRuns or custom CRDs are integrated.

See https://issues.redhat.com/browse/OCPBUGS-82009

## Changes

- **`pkg/configmap/configmap.go`**: Updated `buildFeatureGates()` to accept `integrationExtFrameworks` and `multiKueue` parameters. When either `integrations.externalFrameworks` or `multiKueue.externalFrameworks` has entries, the `ShortWorkloadNames` feature gate is set to `true`.
- **`pkg/configmap/configmap_test.go`**: Added test case `"integration external frameworks enables short workload names"` and updated existing MultiKueue test expectations to verify `ShortWorkloadNames` is enabled in the generated configuration.

## Test plan

- [x] Unit tests pass (`go test ./pkg/configmap/...`)
- [x] Existing MultiKueue tests updated to expect `ShortWorkloadNames: true` in the feature gates
- [x] New test validates that `integrations.externalFrameworks` alone triggers the feature gate
- [x] CI passes

/cc @openshift/kueue-maintainers