### PR TITLE
Add CI-compatible Dockerfile for kueue operand

### DIFF
--- a/Dockerfile.ci.kueue
+++ b/Dockerfile.ci.kueue
@@ -1,0 +1,19 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21 AS build
+
+WORKDIR /workspace
+COPY . .
+WORKDIR /workspace/upstream/kueue
+RUN ./build.sh
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.21
+WORKDIR /
+COPY --from=build /workspace/upstream/kueue/src/bin/manager /
+USER 65532:65532
+
+LABEL io.k8s.display-name="OpenShift Kueue Operand based on RHEL 9" \
+      io.k8s.description="This is the Kueue operand component of OpenShift based on RHEL 9" \
+      io.openshift.tags="openshift,operand,kueue" \
+      com.redhat.delivery.appregistry=true \
+      maintainer="AOS Node team, <aos-node@redhat.com>"
+
+ENTRYPOINT ["/manager"]

--- a/Dockerfile.ci.must-gather
+++ b/Dockerfile.ci.must-gather
@@ -1,0 +1,19 @@
+FROM registry.ci.openshift.org/ocp/4.20:cli AS cli-image
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.21
+
+COPY --from=cli-image /usr/bin/oc /usr/bin/oc
+
+RUN dnf install -y rsync tar && dnf clean all
+
+COPY must-gather/collection-scripts/gather /usr/bin/gather
+COPY must-gather/collection-scripts/gather-kueue /usr/bin/gather-kueue
+
+RUN chmod +x /usr/bin/gather /usr/bin/gather-kueue
+
+CMD ["/bin/bash", "/usr/bin/gather"]
+
+LABEL io.k8s.display-name="OpenShift Kueue must-gather" \
+      io.k8s.description="This is a must-gather for the Kueue" \
+      io.openshift.tags="openshift,kueue-must-gather" \
+      maintainer="AOS Node team, <aos-node@redhat.com>"


### PR DESCRIPTION
## Summary
- Add `Dockerfile.ci.kueue` that uses CI-accessible base images (`registry.ci.openshift.org`) instead of `brew.registry.redhat.io`, enabling the kueue operand to be built in Prow CI jobs
- This is needed by the openshift/release CI config to substitute the operand image in the operator bundle during CI e2e testing (openshift/release#77630)


🤖 Generated with [Claude Code](https://claude.com/claude-code)