### PR TITLE
Use same base image as Dockerfile.ci for kueue and must gather

### DIFF
--- a/Dockerfile.ci.kueue
+++ b/Dockerfile.ci.kueue
@@ -5,7 +5,7 @@ COPY . .
 WORKDIR /workspace/upstream/kueue
 RUN ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.21
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.19
 WORKDIR /
 COPY --from=build /workspace/upstream/kueue/src/bin/manager /
 USER 65532:65532

--- a/Dockerfile.ci.must-gather
+++ b/Dockerfile.ci.must-gather
@@ -1,6 +1,6 @@
 FROM registry.ci.openshift.org/ocp/4.20:cli AS cli-image
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.21
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.19
 
 COPY --from=cli-image /usr/bin/oc /usr/bin/oc
 


### PR DESCRIPTION
Failures in https://github.com/openshift/release/pull/77630 seem to hint there isn't a 4.21 image yet.

