### PR TITLE
Sync upstream kueue submodule to 056152c9 for kueue upstream release-0.16

### DIFF
--- a/bindata/assets/kueue-operator/crds/crd-provisioningrequestconfigs.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-provisioningrequestconfigs.kueue.x-k8s.io-v1beta2.yaml
@@ -77,6 +77,10 @@ spec:
                 description: |-
                   podSetMergePolicy specifies the policy for merging PodSets before being passed
                   to the cluster autoscaler.
+
+                  The possible policies are:
+                  - `IdenticalPodTemplates`: Merges only identical PodTemplates.
+                  - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.
                 enum:
                 - IdenticalPodTemplates
                 - IdenticalWorkloadSchedulingRequirements
@@ -232,6 +236,10 @@ spec:
                 description: |-
                   podSetMergePolicy specifies the policy for merging PodSets before being passed
                   to the cluster autoscaler.
+
+                  The possible policies are:
+                  - `IdenticalPodTemplates`: Merges only identical PodTemplates.
+                  - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.
                 enum:
                 - IdenticalPodTemplates
                 - IdenticalWorkloadSchedulingRequirements

--- a/bindata/assets/kueue-operator/crds/crd-workloads.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-workloads.kueue.x-k8s.io-v1beta2.yaml
@@ -9442,12 +9442,14 @@ spec:
             : true'
         - message: priorityClassSource is immutable while workload quota reserved
           rule: '(has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c,
-            c.type == ''QuotaReserved'' && c.status == ''True'')) ? (oldSelf.spec.priorityClassSource
+            c.type == ''QuotaReserved'' && c.status == ''True'') && has(oldSelf.spec.priorityClassSource)
+            && has(self.spec.priorityClassSource)) ? (oldSelf.spec.priorityClassSource
             == self.spec.priorityClassSource) : true'
         - message: priorityClassName is immutable while workload quota reserved and
             priorityClassSource is not equal to kueue.x-k8s.io/workloadpriorityclass
           rule: '(has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c,
-            c.type == ''QuotaReserved'' && c.status == ''True'') && (self.spec.priorityClassSource
+            c.type == ''QuotaReserved'' && c.status == ''True'') && has(oldSelf.spec.priorityClassSource)
+            && has(self.spec.priorityClassSource) && (self.spec.priorityClassSource
             != ''kueue.x-k8s.io/workloadpriorityclass'') && has(oldSelf.spec.priorityClassName)
             && has(self.spec.priorityClassName)) ? (oldSelf.spec.priorityClassName
             == self.spec.priorityClassName) : true'


### PR DESCRIPTION
Update upstream/kueue/src submodule from aef09c70 to 056152c9 and regenerate affected CRDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded field descriptions for pod set merge policy configuration options in provisioning request settings, providing clearer guidance on available choices and their intended use.

* **Bug Fixes**
  * Refined validation rules governing workload priority class immutability during quota reservation, ensuring constraints apply only when all required fields are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->