### PR TITLE
Sync upstream kueue submodule to April 20th

### DIFF
--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-clusterqueue-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-clusterqueue-viewer-role.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
   name: kueue-clusterqueue-viewer-role
 rules:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-cohort-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-cohort-viewer-role.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
   name: kueue-cohort-viewer-role
 rules:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-jaxjob-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-jaxjob-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
   name: kueue-jaxjob-viewer-role

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-job-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-job-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
   name: kueue-job-viewer-role

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-jobset-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-jobset-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
   name: kueue-jobset-viewer-role

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-leaderworkerset-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-leaderworkerset-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
   name: kueue-leaderworkerset-viewer-role

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-localqueue-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-localqueue-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
   name: kueue-localqueue-viewer-role

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-mpijob-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-mpijob-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
   name: kueue-mpijob-viewer-role

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-paddlejob-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-paddlejob-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
   name: kueue-paddlejob-viewer-role

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-pending-workloads-cq-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-pending-workloads-cq-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
   name: kueue-pending-workloads-cq-viewer-role
 rules:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-pending-workloads-lq-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-pending-workloads-lq-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
   name: kueue-pending-workloads-lq-viewer-role

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-pytorchjob-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-pytorchjob-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
   name: kueue-pytorchjob-viewer-role

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-raycluster-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-raycluster-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
   name: kueue-raycluster-viewer-role
 rules:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-rayjob-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-rayjob-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
   name: kueue-rayjob-viewer-role

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-rayservice-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-rayservice-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
   name: kueue-rayservice-viewer-role
 rules:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-resourceflavor-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-resourceflavor-viewer-role.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
   name: kueue-resourceflavor-viewer-role
 rules:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-sparkapplication-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-sparkapplication-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
   name: kueue-sparkapplication-viewer-role

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-tfjob-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-tfjob-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
   name: kueue-tfjob-viewer-role

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-topology-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-topology-viewer-role.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
   name: kueue-topology-viewer-role
 rules:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-trainjob-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-trainjob-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
   name: kueue-trainjob-viewer-role

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-workload-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-workload-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
   name: kueue-workload-viewer-role

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-xgboostjob-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-xgboostjob-viewer-role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
   name: kueue-xgboostjob-viewer-role

--- a/bindata/assets/kueue-operator/crds/crd-provisioningrequestconfigs.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-provisioningrequestconfigs.kueue.x-k8s.io-v1beta2.yaml
@@ -77,6 +77,10 @@ spec:
                 description: |-
                   podSetMergePolicy specifies the policy for merging PodSets before being passed
                   to the cluster autoscaler.
+
+                  The possible policies are:
+                  - `IdenticalPodTemplates`: Merges only identical PodTemplates.
+                  - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.
                 enum:
                 - IdenticalPodTemplates
                 - IdenticalWorkloadSchedulingRequirements
@@ -232,6 +236,10 @@ spec:
                 description: |-
                   podSetMergePolicy specifies the policy for merging PodSets before being passed
                   to the cluster autoscaler.
+
+                  The possible policies are:
+                  - `IdenticalPodTemplates`: Merges only identical PodTemplates.
+                  - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.
                 enum:
                 - IdenticalPodTemplates
                 - IdenticalWorkloadSchedulingRequirements

--- a/bindata/assets/kueue-operator/crds/crd-workloads.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-workloads.kueue.x-k8s.io-v1beta2.yaml
@@ -9442,12 +9442,14 @@ spec:
             : true'
         - message: priorityClassSource is immutable while workload quota reserved
           rule: '(has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c,
-            c.type == ''QuotaReserved'' && c.status == ''True'')) ? (oldSelf.spec.priorityClassSource
+            c.type == ''QuotaReserved'' && c.status == ''True'') && has(oldSelf.spec.priorityClassSource)
+            && has(self.spec.priorityClassSource)) ? (oldSelf.spec.priorityClassSource
             == self.spec.priorityClassSource) : true'
         - message: priorityClassName is immutable while workload quota reserved and
             priorityClassSource is not equal to kueue.x-k8s.io/workloadpriorityclass
           rule: '(has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c,
-            c.type == ''QuotaReserved'' && c.status == ''True'') && (self.spec.priorityClassSource
+            c.type == ''QuotaReserved'' && c.status == ''True'') && has(oldSelf.spec.priorityClassSource)
+            && has(self.spec.priorityClassSource) && (self.spec.priorityClassSource
             != ''kueue.x-k8s.io/workloadpriorityclass'') && has(oldSelf.spec.priorityClassName)
             && has(self.spec.priorityClassName)) ? (oldSelf.spec.priorityClassName
             == self.spec.priorityClassName) : true'


### PR DESCRIPTION
## Summary

Syncs the upstream kueue submodule (`upstream/kueue/src`) from `2438fa5f` to `df4b1c04` and regenerates bindata assets to pick up the following upstream changes:

### RBAC: Aggregate viewer ClusterRoles to standard Kubernetes roles

- Added `rbac.authorization.k8s.io/aggregate-to-admin` label to all 22 viewer ClusterRoles (clusterqueue, cohort, resourceflavor, topology, and all workload-type viewers)
- Added `rbac.authorization.k8s.io/aggregate-to-edit` and `rbac.authorization.k8s.io/aggregate-to-view` labels to workload-type viewer ClusterRoles (job, jobset, localqueue, workload, pending-workloads, and all training/ray/spark framework viewers)
- Cluster-scoped resource viewers (clusterqueue, cohort, resourceflavor, topology) only aggregate to `admin`, not `edit`/`view`, per upstream design ([upstream #10519](https://github.com/kubernetes-sigs/kueue/pull/10519), [upstream #10482](https://github.com/kubernetes-sigs/kueue/pull/10482))

This means users with the standard Kubernetes `admin`, `edit`, or `view` ClusterRoles will now automatically inherit the appropriate Kueue viewer permissions without needing explicit Kueue role bindings.

### CRD: Fix CEL validation for priorityClassSource immutability

- Fixed CEL expressions in the Workloads CRD that enforce immutability of `priorityClassSource` and `priorityClassName` while quota is reserved
- The previous expressions would fail if `priorityClassSource` was not set on the old or new object; now they guard with `has()` checks before comparing ([upstream #10594](https://github.com/kubernetes-sigs/kueue/pull/10594))

### CRD: Clarify ProvisioningRequestConfig podSetMergePolicy docs

- Added inline documentation to the `podSetMergePolicy` field in the ProvisioningRequestConfig CRD, describing the two enum values: `IdenticalPodTemplates` and `IdenticalWorkloadSchedulingRequirements` ([upstream #10522](https://github.com/kubernetes-sigs/kueue/pull/10522))

## Test plan

- [ ] Verify kueue-operator builds successfully
- [ ] Verify e2e tests pass with the updated bindata/CRDs
- [ ] Confirm viewer ClusterRoles correctly aggregate to admin/edit/view after deployment


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced RBAC integration by enabling Kubernetes cluster role aggregation for admin, edit, and view permissions across job workload types and queue management resources.

* **Improvements**
  * Refined workload CRD validation rules for priority class configuration.
  * Improved CRD documentation for pod set merge policy options.

* **Chores**
  * Updated upstream source reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->