### PR TITLE
Enable admission fair sharing e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ e2e-upstream-test: ginkgo
 	@echo "Running e2e tests on OpenShift cluster ($(shell oc whoami --show-server))"
 	mkdir -p "$(ARTIFACT_DIR)"
 	IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(GINKGO_ARGS)" \
-	ARTIFACT_DIR=$(ARTIFACT_DIR) E2E_TARGET_FOLDERS="$${E2E_TARGET_FOLDERS:-singlecluster certmanager}" \
+	ARTIFACT_DIR=$(ARTIFACT_DIR) E2E_TARGET_FOLDERS="$${E2E_TARGET_FOLDERS:-singlecluster certmanager customconfigs}" \
 	SKIP_DEPLOY=true \
 	./upstream/kueue/e2e-test-ocp.sh
 

--- a/upstream/kueue/e2e-test-ocp.sh
+++ b/upstream/kueue/e2e-test-ocp.sh
@@ -55,6 +55,9 @@ function ginkgo_label_filter() {
     dra)
       echo ""
       ;;
+    customconfigs)
+      echo "feature:admissionfairsharing"
+      ;;
     *)
       echo ""
       ;;
@@ -84,9 +87,34 @@ label_worker_nodes
 # Disable scc rules for e2e pod tests
 allow_privileged_access
 
+function configure_kueue_for_folder() {
+  local folder="$1"
+  case "$folder" in
+    customconfigs)
+      echo "Patching cluster Kueue CR for customconfigs..."
+      $OC patch kueue.kueue.openshift.io/cluster --type=merge -p \
+        '{"spec":{"config":{"admissionFairSharing":{"configuration":"Custom","custom":{"usageHalfLifeTimeSeconds":1,"usageSamplingIntervalSeconds":1}}}}}'
+      # Let's wait for the reconciliation to complete. The test suite checks if kueue-controller-manager is available.
+      $OC wait kueue.kueue.openshift.io/cluster --for=condition=Available="False" --timeout=120s
+      ;;
+  esac
+}
+
+function restore_kueue_for_folder() {
+  local folder="$1"
+  case "$folder" in
+    customconfigs)
+      echo "Removing admissionFairSharing from cluster Kueue CR..."
+      $OC patch kueue.kueue.openshift.io/cluster --type=json -p \
+        '[{"op":"remove","path":"/spec/config/admissionFairSharing"}]'
+      ;;
+  esac
+}
+
 exit_code=0
 for folder in $E2E_TARGET_FOLDERS; do
   echo "=== Running upstream e2e tests for: ${folder} ==="
+  configure_kueue_for_folder "$folder"
   label_filter=$(ginkgo_label_filter "$folder")
   folder_ginkgo_args="${GINKGO_ARGS:-}"
   if [ -n "$label_filter" ]; then
@@ -103,6 +131,8 @@ for folder in $E2E_TARGET_FOLDERS; do
     --flake-attempts=3 \
     --no-color \
     -v "./upstream/kueue/src/test/e2e/${folder}/..." || exit_code=$?
+
+  restore_kueue_for_folder "$folder"
 done
 exit $exit_code
 

--- a/upstream/kueue/patch/README.md
+++ b/upstream/kueue/patch/README.md
@@ -2,7 +2,7 @@
 
 ## e2e.patch
 
-This patch sets up our e2e tests to skip waiting for operators as the namespace name is different and set up our namespaces.
+This patch sets up our e2e tests to skip waiting for operators as the namespace name is different and set up our namespaces. It also skips the configuration change for admission fair sharing as the configuration is managed in the Kueue instance.
 
 ## test_util_e2e.patch
 

--- a/upstream/kueue/patch/e2e.patch
+++ b/upstream/kueue/patch/e2e.patch
@@ -71,4 +71,45 @@ index 19f27e21c..bafcde7cf 100644
 +	certSecretName               = "metrics-server-cert"
  	certMountPath                = "/etc/kueue/metrics/certs"
  )
+
+diff --git a/test/e2e/customconfigs/admission_fair_sharing_test.go b/test/e2e/customconfigs/admission_fair_sharing_test.go
+index d1acafd0e..5cc83705d 100644
+--- a/test/e2e/customconfigs/admission_fair_sharing_test.go
++++ b/test/e2e/customconfigs/admission_fair_sharing_test.go
+@@ -17,8 +17,6 @@ limitations under the License.
+ package customconfigs
+ 
+ import (
+-	"time"
+-
+ 	"github.com/onsi/ginkgo/v2"
+ 	"github.com/onsi/gomega"
+ 	batchv1 "k8s.io/api/batch/v1"
+@@ -28,7 +26,6 @@ import (
+ 	"k8s.io/utils/ptr"
+ 	"sigs.k8s.io/controller-runtime/pkg/client"
+ 
+-	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+ 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+ 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+ 	jobtesting "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+@@ -42,12 +39,12 @@ var _ = ginkgo.Describe("Admission Fair Sharing", ginkgo.Label("feature:admissio
+ 	)
+ 
+ 	ginkgo.BeforeAll(func() {
+-		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
+-			cfg.AdmissionFairSharing = &configapi.AdmissionFairSharing{
+-				UsageHalfLifeTime:     metav1.Duration{Duration: 1 * time.Second},
+-				UsageSamplingInterval: metav1.Duration{Duration: 1 * time.Second},
+-			}
+-		})
++		// util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
++		// 	cfg.AdmissionFairSharing = &configapi.AdmissionFairSharing{
++		// 		UsageHalfLifeTime:     metav1.Duration{Duration: 1 * time.Second},
++		// 		UsageSamplingInterval: metav1.Duration{Duration: 1 * time.Second},
++		// 	}
++		// })
+ 
+ 		rf = utiltestingapi.MakeResourceFlavor("afs-rf").Obj()
+ 		util.MustCreate(ctx, k8sClient, rf)
  


### PR DESCRIPTION
Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Default e2e runs now include the custom admission fair-sharing scenarios.
  * Custom scenario runs apply admission fair-sharing configuration before tests.
  * Test namespaces are marked as managed; cert-manager metrics reference a new certificate secret name.
  * Single-cluster suite reduces certain feature-gate wait behavior.

* **Chores**
  * Default e2e target expanded to include the customconfigs suite by default.

* **Documentation**
  * Patch README notes that admission fair-sharing changes are managed and skipped by the patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->