### PR TITLE
Add extended resources support

### DIFF
--- a/bundle/manifests/kueue-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kueue-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
       ]
     capabilities: Basic Install
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2026-03-22T03:06:36Z"
+    createdAt: "2026-04-22T01:38:09Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -165,6 +165,7 @@ spec:
           resources:
           - infrastructures
           - apiservers
+          - featuregates
           verbs:
           - get
           - watch

--- a/deploy/02_clusterrole.yaml
+++ b/deploy/02_clusterrole.yaml
@@ -93,6 +93,7 @@ rules:
     resources:
       - infrastructures
       - apiservers
+      - featuregates
     verbs:
       - get
       - watch

--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -195,7 +195,7 @@ func buildFeatureGates(resources kueue.Resources, frameworks []kueue.KueueIntegr
 	// are available on the cluster. On clusters without DRA support (OCP < 4.21),
 	// the feature gate is not enabled but the deviceClassMappings config is preserved
 	// so it takes effect automatically after a cluster upgrade.
-	if len(resources.DeviceClassMappings) > 0 && draSupported {
+	if (len(resources.DeviceClassMappings) > 0 && draSupported) || draExtendedResourceEnabled {
 		featureGates["DynamicResourceAllocation"] = true
 	}
 

--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -32,8 +32,8 @@ import (
 	kueue "github.com/openshift/kueue-operator/pkg/apis/kueueoperator/v1"
 )
 
-func BuildConfigMap(namespace string, kueueCfg kueue.KueueConfiguration, gvrToKind map[string]string, draSupported bool, tlsOpts *configapi.TLSOptions) (*corev1.ConfigMap, error) {
-	config, err := defaultKueueConfigurationTemplate(namespace, kueueCfg, gvrToKind, draSupported, tlsOpts)
+func BuildConfigMap(namespace string, kueueCfg kueue.KueueConfiguration, gvrToKind map[string]string, draSupported bool, draExtendedResourceEnabled bool, tlsOpts *configapi.TLSOptions) (*corev1.ConfigMap, error) {
+	config, err := defaultKueueConfigurationTemplate(namespace, kueueCfg, gvrToKind, draSupported, draExtendedResourceEnabled, tlsOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func buildResources(resources kueue.Resources) *configapi.Resources {
 	}
 }
 
-func buildFeatureGates(resources kueue.Resources, frameworks []kueue.KueueIntegration, draSupported bool, integrationExtFrameworks []kueue.ExternalFramework, multiKueue *kueue.MultiKueue) map[string]bool {
+func buildFeatureGates(resources kueue.Resources, frameworks []kueue.KueueIntegration, draSupported bool, draExtendedResourceEnabled bool, integrationExtFrameworks []kueue.ExternalFramework, multiKueue *kueue.MultiKueue) map[string]bool {
 	featureGates := map[string]bool{}
 
 	// DynamicResourceAllocation is Alpha in Kueue, so we explicitly enable it
@@ -197,6 +197,14 @@ func buildFeatureGates(resources kueue.Resources, frameworks []kueue.KueueIntegr
 	// so it takes effect automatically after a cluster upgrade.
 	if len(resources.DeviceClassMappings) > 0 && draSupported {
 		featureGates["DynamicResourceAllocation"] = true
+	}
+
+	// DRAExtendedResources is Alpha in Kueue. Enable it when the K8s
+	// DRAExtendedResource feature gate is enabled on the cluster. This allows
+	// workloads to request DRA devices using standard extended resource syntax
+	// (e.g., nvidia.com/gpu: 1) when a DeviceClass has extendedResourceName set.
+	if draExtendedResourceEnabled {
+		featureGates["DRAExtendedResources"] = true
 	}
 
 	// SparkApplicationIntegration is Alpha in Kueue, so we explicitly enable it
@@ -249,7 +257,7 @@ func buildAdmissionFairSharing(admissionFairSharing kueue.AdmissionFairSharing) 
 	return result, nil
 }
 
-func defaultKueueConfigurationTemplate(namespace string, kueueCfg kueue.KueueConfiguration, gvrToKind map[string]string, draSupported bool, tlsOpts *configapi.TLSOptions) (*configapi.Configuration, error) {
+func defaultKueueConfigurationTemplate(namespace string, kueueCfg kueue.KueueConfiguration, gvrToKind map[string]string, draSupported bool, draExtendedResourceEnabled bool, tlsOpts *configapi.TLSOptions) (*configapi.Configuration, error) {
 	admissionFairSharing, err := buildAdmissionFairSharing(kueueCfg.AdmissionFairSharing)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build admission fair sharing: %w", err)
@@ -305,7 +313,7 @@ func defaultKueueConfigurationTemplate(namespace string, kueueCfg kueue.KueueCon
 		WaitForPodsReady:           buildWaitForPodsReady(kueueCfg.GangScheduling),
 		FairSharing:                buildFairSharing(kueueCfg.Preemption),
 		Resources:                  buildResources(kueueCfg.Resources),
-		FeatureGates:               buildFeatureGates(kueueCfg.Resources, kueueCfg.Integrations.Frameworks, draSupported, kueueCfg.Integrations.ExternalFrameworks, kueueCfg.MultiKueue),
+		FeatureGates:               buildFeatureGates(kueueCfg.Resources, kueueCfg.Integrations.Frameworks, draSupported, draExtendedResourceEnabled, kueueCfg.Integrations.ExternalFrameworks, kueueCfg.MultiKueue),
 		MultiKueue:                 mapOperatorMultiKueueToKueue(kueueCfg.MultiKueue, gvrToKind),
 		AdmissionFairSharing:       admissionFairSharing,
 	}, nil

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -451,7 +451,6 @@ webhook:
 			wantErr: nil,
 		},
 		"dra extended resources enabled": {
-			draSupported:               true,
 			draExtendedResourceEnabled: true,
 			configuration: kueue.KueueConfiguration{
 				Integrations: kueue.Integrations{

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -29,12 +29,13 @@ import (
 
 func TestBuildConfigMap(t *testing.T) {
 	testCases := map[string]struct {
-		configuration kueue.KueueConfiguration
-		gvrToKind     map[string]string
-		draSupported  bool
-		tlsOpts       *configapi.TLSOptions
-		wantCfgMap    *corev1.ConfigMap
-		wantErr       error
+		configuration              kueue.KueueConfiguration
+		gvrToKind                  map[string]string
+		draSupported               bool
+		draExtendedResourceEnabled bool
+		tlsOpts                    *configapi.TLSOptions
+		wantCfgMap                 *corev1.ConfigMap
+		wantErr                    error
 	}{
 		"batch job example": {
 			configuration: kueue.KueueConfiguration{
@@ -442,6 +443,61 @@ resources:
     - gpu.example.com
     - gpu-large.example.com
     name: example.com/gpus
+webhook:
+  port: 9443
+`,
+				},
+			},
+			wantErr: nil,
+		},
+		"dra extended resources enabled": {
+			draSupported:               true,
+			draExtendedResourceEnabled: true,
+			configuration: kueue.KueueConfiguration{
+				Integrations: kueue.Integrations{
+					Frameworks: []kueue.KueueIntegration{kueue.KueueIntegrationBatchJob},
+				},
+			},
+			wantCfgMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+clientConnection:
+  burst: 100
+  qps: 50
+controller:
+  groupKindConcurrency:
+    ClusterQueue.kueue.x-k8s.io: 1
+    Job.batch: 5
+    LocalQueue.kueue.x-k8s.io: 1
+    Pod: 5
+    ResourceFlavor.kueue.x-k8s.io: 1
+    Workload.kueue.x-k8s.io: 5
+featureGates:
+  DRAExtendedResources: true
+health:
+  healthProbeBindAddress: :8081
+integrations:
+  frameworks:
+  - batch/job
+internalCertManagement:
+  enable: false
+kind: Configuration
+leaderElection:
+  leaderElect: true
+  leaseDuration: 2m17s
+  renewDeadline: 1m47s
+  resourceLock: ""
+  resourceName: ""
+  resourceNamespace: ""
+  retryPeriod: 26s
+manageJobsWithoutQueueName: false
+managedJobsNamespaceSelector:
+  matchLabels:
+    kueue.openshift.io/managed: "true"
+metrics:
+  bindAddress: :8443
+  enableClusterQueueResources: true
+namespace: test
 webhook:
   port: 9443
 `,
@@ -982,7 +1038,7 @@ webhook:
 
 	for desc, tc := range testCases {
 		t.Run(desc, func(t *testing.T) {
-			got, err := BuildConfigMap("test", tc.configuration, tc.gvrToKind, tc.draSupported, tc.tlsOpts)
+			got, err := BuildConfigMap("test", tc.configuration, tc.gvrToKind, tc.draSupported, tc.draExtendedResourceEnabled, tc.tlsOpts)
 			if err != nil && tc.wantErr == nil {
 				t.Fatalf("Unexpected error: want=%v, got=%v", tc.wantErr, err)
 			}

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -473,6 +473,7 @@ controller:
     Workload.kueue.x-k8s.io: 5
 featureGates:
   DRAExtendedResources: true
+  DynamicResourceAllocation: true
 health:
   healthProbeBindAddress: :8081
 integrations:

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
@@ -103,6 +104,7 @@ type TargetConfigReconciler struct {
 	configInformer             dynamicinformer.DynamicSharedInformerFactory
 	isOpenShift                bool
 	draSupported               bool
+	draExtendedResourceEnabled bool
 }
 
 // computeSpecHash computes a SHA256 hash of the given object's spec.
@@ -315,26 +317,55 @@ func (c *TargetConfigReconciler) sync(ctx context.Context, syncCtx factory.SyncC
 			}
 		}
 	}
-	// Check DRA API availability if deviceClassMappings are configured.
-	// Kueue's DRA integration requires resource.k8s.io/v1 (Kubernetes 1.34+ / OCP 4.21+).
+	// Check DRA API availability (resource.k8s.io/v1).
+	// DRA is GA in Kubernetes 1.34+ (OCP 4.21+).
+	draAPIsAvailable := false
+	found, err = isResourceRegistered(c.discoveryClient, schema.GroupVersionKind{
+		Group:   "resource.k8s.io",
+		Version: "v1",
+		Kind:    "DeviceClass",
+	})
+	if err != nil {
+		klog.Errorf("unable to check if DRA APIs are available: %v", err)
+	} else if found {
+		draAPIsAvailable = true
+	}
+
+	// DynamicResourceAllocation requires deviceClassMappings + DRA APIs.
 	// The deviceClassMappings config is preserved in the configmap so it takes effect
 	// automatically after a cluster upgrade, but the DRA feature gate is only enabled
 	// when the APIs are available.
 	c.draSupported = false
 	if len(kueue.Spec.Config.Resources.DeviceClassMappings) > 0 {
-		found, err := isResourceRegistered(c.discoveryClient, schema.GroupVersionKind{
-			Group:   "resource.k8s.io",
-			Version: "v1",
-			Kind:    "DeviceClass",
-		})
-		if err != nil {
-			klog.Errorf("unable to check if DRA APIs are available: %v", err)
-		} else if found {
+		if draAPIsAvailable {
 			c.draSupported = true
 		} else {
 			klog.Warningf("DRA APIs (resource.k8s.io/v1) not available on this cluster. DRA requires Kubernetes 1.34+ (OCP 4.21+)")
 			c.eventRecorder.Eventf("DRAUnsupported", "DRA APIs not available, deviceClassMappings will not take effect until the cluster is upgraded")
 			missingDependencies = append(missingDependencies, "DRA (Dynamic Resource Allocation) requires Kubernetes 1.34+ (OCP 4.21+)")
+		}
+	}
+
+	// Check if the K8s DRAExtendedResource feature gate is enabled on the cluster.
+	// This is an alpha K8s feature gate not yet in openshift/api, so it can only be
+	// enabled via CustomNoUpgrade. We check spec.customNoUpgrade.enabled on the
+	// FeatureGate CR to determine if kueue's DRAExtendedResources gate should be enabled.
+	// Unlike DynamicResourceAllocation, this does not require deviceClassMappings.
+	if c.isOpenShift && draAPIsAvailable {
+		fg, err := c.openshiftConfigClient.ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
+		if err != nil {
+			klog.Warningf("unable to read FeatureGate CR, preserving previous state: %v", err)
+		} else {
+			c.draExtendedResourceEnabled = false
+			if fg.Spec.FeatureSet == configv1.CustomNoUpgrade && fg.Spec.CustomNoUpgrade != nil {
+				for _, gate := range fg.Spec.CustomNoUpgrade.Enabled {
+					// K8s uses singular "DRAExtendedResource", kueue uses plural "DRAExtendedResources"
+					if string(gate) == "DRAExtendedResource" {
+						c.draExtendedResourceEnabled = true
+						break
+					}
+				}
+			}
 		}
 	}
 
@@ -1281,7 +1312,7 @@ func (c *TargetConfigReconciler) resolveGVRsToKinds(frameworks []kueuev1.Externa
 }
 
 func (c *TargetConfigReconciler) buildAndApplyConfigMap(ctx context.Context, oldCfgMap *v1.ConfigMap, kueueCfg kueuev1.KueueConfiguration, gvrToKind map[string]string, tlsOpts *kueueconfigapi.TLSOptions) (*v1.ConfigMap, bool, error) {
-	cfgMap, buildErr := configmap.BuildConfigMap(c.operatorNamespace, kueueCfg, gvrToKind, c.draSupported, tlsOpts)
+	cfgMap, buildErr := configmap.BuildConfigMap(c.operatorNamespace, kueueCfg, gvrToKind, c.draSupported, c.draExtendedResourceEnabled, tlsOpts)
 	if buildErr != nil {
 		klog.Errorf("Cannot build configmap %s for kueue", c.operatorNamespace)
 		return nil, false, buildErr

--- a/test/e2e/e2e_dra_extended_resources_test.go
+++ b/test/e2e/e2e_dra_extended_resources_test.go
@@ -1,0 +1,577 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	ssv1 "github.com/openshift/kueue-operator/pkg/apis/kueueoperator/v1"
+	"github.com/openshift/kueue-operator/test/e2e/testutils"
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	kueuev1beta2 "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+)
+
+const (
+	erTestNamespace         = "kueue-dra-er-test"
+	erTestQueue             = "dra-er-test-queue"
+	erClusterQueueName      = "dra-er-test-clusterqueue"
+	erMixedTestQueue        = "dra-er-mixed-queue"
+	erMixedClusterQueueName = "dra-er-mixed-clusterqueue"
+	extendedResourceName    = "nvidia.com/gpu"
+)
+
+var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extended-resources"), Ordered, func() {
+	var (
+		initialKueueInstance  *ssv1.Kueue
+		cleanupClusterQueue   func()
+		cleanupLocalQueue     func()
+		cleanupResourceFlavor func()
+		maxGPUsPerNode        int
+	)
+
+	JustAfterEach(func(ctx context.Context) {
+		testutils.DumpKueueControllerManagerLogs(ctx, kubeClient, 500)
+	})
+
+	BeforeAll(func(ctx context.Context) {
+		// Check if DRA APIs are available
+		draSupported := false
+		apiResourceLists, err := kubeClient.Discovery().ServerResourcesForGroupVersion("resource.k8s.io/v1")
+		if err == nil {
+			for _, apiResource := range apiResourceLists.APIResources {
+				if apiResource.Kind == testutils.DeviceClassKind {
+					draSupported = true
+					break
+				}
+			}
+		}
+		if !draSupported {
+			Skip("DRA APIs (resource.k8s.io/v1) not available on this cluster")
+		}
+
+		// Check if ResourceSlices exist for gpu.nvidia.com (driver is running)
+		// and count GPUs per node (only devices with type=="gpu", excluding MIG slices)
+		slices, err := kubeClient.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		hasDriverSlices := false
+		gpusPerNode := map[string]int{}
+		for _, s := range slices.Items {
+			if s.Spec.Driver == draDeviceClassName {
+				hasDriverSlices = true
+				if s.Spec.NodeName != nil {
+					for _, d := range s.Spec.Devices {
+						// The NVIDIA DRA driver uses the bare "type" attribute key (not fully qualified)
+						// with value "gpu" for full GPU devices. MIG slices have different type values.
+						// See: device.attributes['gpu.nvidia.com'].type in DeviceClass CEL selectors.
+						if typeAttr, ok := d.Attributes["type"]; ok {
+							if typeAttr.StringValue != nil && *typeAttr.StringValue == "gpu" {
+								gpusPerNode[*s.Spec.NodeName]++
+							}
+						}
+					}
+				}
+			}
+		}
+		if !hasDriverSlices {
+			Skip("No ResourceSlices found for driver gpu.nvidia.com - NVIDIA DRA driver not running")
+		}
+
+		for _, count := range gpusPerNode {
+			if count > maxGPUsPerNode {
+				maxGPUsPerNode = count
+			}
+		}
+		if maxGPUsPerNode == 0 {
+			Skip("No GPU devices found in ResourceSlices, skipping test")
+		}
+
+		// Check if DeviceClass has extendedResourceName set (K8s DRAExtendedResource gate enabled)
+		dc, err := kubeClient.ResourceV1().DeviceClasses().Get(ctx, draDeviceClassName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		if dc.Spec.ExtendedResourceName == nil || *dc.Spec.ExtendedResourceName == "" {
+			Skip("DeviceClass gpu.nvidia.com does not have extendedResourceName set - DRAExtendedResource feature gate not enabled")
+		}
+
+		kueueInstance, err := clients.KueueClient.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		initialKueueInstance = kueueInstance.DeepCopy()
+
+		applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+
+		Eventually(func() error {
+			configMap, err := kubeClient.CoreV1().ConfigMaps(testutils.OperatorNamespace).Get(ctx, "kueue-manager-config", metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			configData := configMap.Data["controller_manager_config.yaml"]
+			if !strings.Contains(configData, "DRAExtendedResources: true") {
+				return fmt.Errorf("DRAExtendedResources not enabled yet")
+			}
+			return nil
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
+
+		_, err = kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: erTestNamespace,
+				Labels: map[string]string{
+					testutils.OpenShiftManagedLabel: "true",
+				},
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		kueueClient := clients.UpstreamKueueClient
+		cleanupResourceFlavor, err = testutils.NewResourceFlavor().Create(ctx, kueueClient)
+		Expect(err).NotTo(HaveOccurred())
+
+		cq := testutils.NewClusterQueue()
+		cq.Name = erClusterQueueName
+		cq.Spec.ResourceGroups = []kueuev1beta2.ResourceGroup{{
+			CoveredResources: []corev1.ResourceName{"cpu", "memory", corev1.ResourceName(extendedResourceName)},
+			Flavors: []kueuev1beta2.FlavorQuotas{{
+				Name: "default",
+				Resources: []kueuev1beta2.ResourceQuota{
+					{Name: "cpu", NominalQuota: resource.MustParse("100")},
+					{Name: "memory", NominalQuota: resource.MustParse("100Gi")},
+					{Name: corev1.ResourceName(extendedResourceName), NominalQuota: *resource.NewQuantity(int64(maxGPUsPerNode), resource.DecimalSI)},
+				},
+			}},
+		}}
+		cleanupClusterQueue, err = cq.Create(ctx, kueueClient)
+		Expect(err).NotTo(HaveOccurred())
+
+		lq := testutils.NewLocalQueue(erTestNamespace, erTestQueue)
+		lq.Spec.ClusterQueue = kueuev1beta2.ClusterQueueReference(erClusterQueueName)
+		cleanupLocalQueue, err = lq.Create(ctx, kueueClient)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func(ctx context.Context) {
+		if cleanupLocalQueue != nil {
+			cleanupLocalQueue()
+		}
+		if cleanupClusterQueue != nil {
+			cleanupClusterQueue()
+		}
+		if cleanupResourceFlavor != nil {
+			cleanupResourceFlavor()
+		}
+
+		kubeClient.CoreV1().Namespaces().Delete(ctx, erTestNamespace, metav1.DeleteOptions{})
+
+		if initialKueueInstance != nil {
+			applyKueueConfig(ctx, initialKueueInstance.Spec.Config, kubeClient)
+		}
+	})
+
+	It("should admit job with extended resource request and account DRA quota correctly", func(ctx context.Context) {
+		By("Creating Job with extended resource request nvidia.com/gpu")
+		builder := testutils.NewTestResourceBuilder(erTestNamespace, erTestQueue)
+		job := builder.NewJob()
+		setDRAJobCPU(job)
+		job.Name = "er-basic-job"
+		job.Labels[testutils.QueueLabel] = erTestQueue
+		job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
+		job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+			corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
+		}
+		createdJob, err := kubeClient.BatchV1().Jobs(erTestNamespace).Create(ctx, job, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
+
+		By("Verifying workload is admitted with correct quota under extendedResourceName")
+		kueueClient := clients.UpstreamKueueClient
+		Eventually(func(g Gomega) {
+			wlList, err := kueueClient.KueueV1beta2().Workloads(erTestNamespace).List(ctx, metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("kueue.x-k8s.io/job-uid=%s", string(createdJob.UID)),
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(wlList.Items).NotTo(BeEmpty(), "workload not found for job %s", createdJob.Name)
+
+			wl := wlList.Items[0]
+			g.Expect(wl.Status.Admission).NotTo(BeNil(), "workload should be admitted")
+			g.Expect(wl.Status.Admission.PodSetAssignments).To(HaveLen(1))
+
+			assignment := wl.Status.Admission.PodSetAssignments[0]
+			g.Expect(assignment.ResourceUsage).To(HaveKey(corev1.ResourceName(extendedResourceName)))
+			g.Expect(assignment.ResourceUsage[corev1.ResourceName(extendedResourceName)]).To(Equal(resource.MustParse("1")))
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
+
+		By("Verifying job is unsuspended")
+		Eventually(func() bool {
+			return !testutils.IsJobSuspended(ctx, kubeClient, erTestNamespace, createdJob.Name)
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
+
+		By("Verifying job pod is running")
+		Eventually(func() bool {
+			return testutils.IsJobPodRunning(ctx, kubeClient, erTestNamespace, createdJob.Name)
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
+
+		By("Verifying extendedResourceClaimStatus is populated in pod status")
+		Eventually(func(g Gomega) {
+			pods, err := kubeClient.CoreV1().Pods(erTestNamespace).List(ctx, metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("batch.kubernetes.io/job-name=%s", createdJob.Name),
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(pods.Items).NotTo(BeEmpty())
+
+			pod := pods.Items[0]
+			g.Expect(pod.Status.ExtendedResourceClaimStatus).NotTo(BeNil(), "extendedResourceClaimStatus should be populated")
+			g.Expect(pod.Status.ExtendedResourceClaimStatus.ResourceClaimName).NotTo(BeEmpty(), "auto-generated ResourceClaim name should not be empty")
+			g.Expect(pod.Status.ExtendedResourceClaimStatus.RequestMappings).NotTo(BeEmpty(), "requestMappings should not be empty")
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
+
+		By("Verifying auto-generated ResourceClaim has the extended resource annotation")
+		Eventually(func(g Gomega) {
+			pods, err := kubeClient.CoreV1().Pods(erTestNamespace).List(ctx, metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("batch.kubernetes.io/job-name=%s", createdJob.Name),
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(pods.Items).NotTo(BeEmpty())
+
+			claimName := pods.Items[0].Status.ExtendedResourceClaimStatus.ResourceClaimName
+			claim, err := kubeClient.ResourceV1().ResourceClaims(erTestNamespace).Get(ctx, claimName, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(claim.Annotations).To(HaveKeyWithValue("resource.kubernetes.io/extended-resource-claim", "true"))
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
+	})
+
+	It("should suspend job when extended resource quota is exceeded", func(ctx context.Context) {
+		By(fmt.Sprintf("Creating Job requesting %d GPUs via extended resources (quota is %d)", maxGPUsPerNode+1, maxGPUsPerNode))
+		builder := testutils.NewTestResourceBuilder(erTestNamespace, erTestQueue)
+		job := builder.NewJob()
+		setDRAJobCPU(job)
+		job.Name = "er-exceed-job"
+		job.Labels[testutils.QueueLabel] = erTestQueue
+		exceededCount := *resource.NewQuantity(int64(maxGPUsPerNode+1), resource.DecimalSI)
+		job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = exceededCount
+		job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+			corev1.ResourceName(extendedResourceName): exceededCount,
+		}
+		createdJob, err := kubeClient.BatchV1().Jobs(erTestNamespace).Create(ctx, job, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
+
+		By("Verifying job remains suspended")
+		Consistently(func() bool {
+			return testutils.IsJobSuspended(ctx, kubeClient, erTestNamespace, createdJob.Name)
+		}, testutils.ConsistentlyTimeout, testutils.ConsistentlyPoll).Should(BeTrue())
+	})
+
+	It("should admit waiting job after extended resource quota is freed", func(ctx context.Context) {
+		By("Waiting for quota to be fully released from previous tests")
+		kueueClient := clients.UpstreamKueueClient
+		Eventually(func(g Gomega) {
+			cq, err := kueueClient.KueueV1beta2().ClusterQueues().Get(ctx, erClusterQueueName, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			for _, flavor := range cq.Status.FlavorsReservation {
+				for _, res := range flavor.Resources {
+					if res.Name == corev1.ResourceName(extendedResourceName) {
+						g.Expect(res.Total.Cmp(resource.MustParse("0"))).To(Equal(0),
+							"%s quota should be 0 before test starts, got %s", extendedResourceName, res.Total.String())
+					}
+				}
+			}
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
+
+		By(fmt.Sprintf("Creating first job requesting all %d GPUs via extended resources (fills quota)", maxGPUsPerNode))
+		builder := testutils.NewTestResourceBuilder(erTestNamespace, erTestQueue)
+		job1 := builder.NewJob()
+		setDRAJobCPU(job1)
+		job1.Name = "er-fill-job-1"
+		job1.Labels[testutils.QueueLabel] = erTestQueue
+		fillCount := *resource.NewQuantity(int64(maxGPUsPerNode), resource.DecimalSI)
+		job1.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = fillCount
+		job1.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+			corev1.ResourceName(extendedResourceName): fillCount,
+		}
+		createdJob1, err := kubeClient.BatchV1().Jobs(erTestNamespace).Create(ctx, job1, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		defer testutils.CleanUpJob(ctx, kubeClient, createdJob1.Namespace, createdJob1.Name)
+
+		By("Waiting for first job to be admitted")
+		Eventually(func() bool {
+			return !testutils.IsJobSuspended(ctx, kubeClient, erTestNamespace, createdJob1.Name)
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
+
+		By("Verifying first job pod is running")
+		Eventually(func() bool {
+			return testutils.IsJobPodRunning(ctx, kubeClient, erTestNamespace, createdJob1.Name)
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
+
+		By("Creating second job requesting 1 GPU via extended resources (quota full, should be suspended)")
+		job2 := builder.NewJob()
+		setDRAJobCPU(job2)
+		job2.Name = "er-fill-job-2"
+		job2.Labels[testutils.QueueLabel] = erTestQueue
+		job2.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
+		job2.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+			corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
+		}
+		createdJob2, err := kubeClient.BatchV1().Jobs(erTestNamespace).Create(ctx, job2, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		defer testutils.CleanUpJob(ctx, kubeClient, createdJob2.Namespace, createdJob2.Name)
+
+		By("Verifying second job is suspended (quota full)")
+		Consistently(func() bool {
+			return testutils.IsJobSuspended(ctx, kubeClient, erTestNamespace, createdJob2.Name)
+		}, testutils.ConsistentlyTimeout, testutils.ConsistentlyPoll).Should(BeTrue())
+
+		By("Deleting first job to free quota")
+		testutils.CleanUpJob(ctx, kubeClient, createdJob1.Namespace, createdJob1.Name)
+
+		By("Verifying second job is admitted after quota freed")
+		Eventually(func() bool {
+			return !testutils.IsJobSuspended(ctx, kubeClient, erTestNamespace, createdJob2.Name)
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
+
+		By("Verifying second job pod is running")
+		Eventually(func() bool {
+			return testutils.IsJobPodRunning(ctx, kubeClient, erTestNamespace, createdJob2.Name)
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
+	})
+
+	It("should verify ClusterQueue shows correct extended resource usage", func(ctx context.Context) {
+		By("Waiting for quota to be fully released from previous tests")
+		kueueClient := clients.UpstreamKueueClient
+		Eventually(func(g Gomega) {
+			cq, err := kueueClient.KueueV1beta2().ClusterQueues().Get(ctx, erClusterQueueName, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			for _, flavor := range cq.Status.FlavorsReservation {
+				for _, res := range flavor.Resources {
+					if res.Name == corev1.ResourceName(extendedResourceName) {
+						g.Expect(res.Total.Cmp(resource.MustParse("0"))).To(Equal(0),
+							"%s quota should be 0 before test starts, got %s", extendedResourceName, res.Total.String())
+					}
+				}
+			}
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
+
+		By("Creating Job with 1 GPU via extended resource request")
+		builder := testutils.NewTestResourceBuilder(erTestNamespace, erTestQueue)
+		job := builder.NewJob()
+		setDRAJobCPU(job)
+		job.Name = "er-usage-job"
+		job.Labels[testutils.QueueLabel] = erTestQueue
+		job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
+		job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+			corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
+		}
+		createdJob, err := kubeClient.BatchV1().Jobs(erTestNamespace).Create(ctx, job, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
+
+		By("Verifying ClusterQueue shows extended resource reservation")
+		Eventually(func(g Gomega) {
+			cq, err := kueueClient.KueueV1beta2().ClusterQueues().Get(ctx, erClusterQueueName, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(cq.Status.FlavorsReservation).NotTo(BeEmpty())
+
+			found := false
+			for _, flavor := range cq.Status.FlavorsReservation {
+				for _, res := range flavor.Resources {
+					if res.Name == corev1.ResourceName(extendedResourceName) {
+						g.Expect(res.Total.Cmp(resource.MustParse("1"))).To(Equal(0),
+							"ClusterQueue should show 1 %s reserved", extendedResourceName)
+						found = true
+					}
+				}
+			}
+			g.Expect(found).To(BeTrue(), "resource %s not found in ClusterQueue reservation", extendedResourceName)
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
+
+		By("Verifying job pod is running")
+		Eventually(func() bool {
+			return testutils.IsJobPodRunning(ctx, kubeClient, erTestNamespace, createdJob.Name)
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
+	})
+
+	When("Extended Resources are used with deviceClassMappings", Label("dra-extended-resources"), func() {
+		BeforeAll(func(ctx context.Context) {
+			if maxGPUsPerNode < 2 {
+				Skip("Need at least 2 GPUs on a single node for mixed ER + RCT test")
+			}
+		})
+
+		It("should account both ER and RCT under same quota with deviceClassMappings taking precedence", func(ctx context.Context) {
+
+			By("Adding deviceClassMappings to enable DynamicResourceAllocation for RCT path")
+			kueueInstance, err := clients.KueueClient.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			kueueInstance.Spec.Config.Resources.DeviceClassMappings = []ssv1.DeviceClassMapping{
+				{
+					Name:             draLogicalResource,
+					DeviceClassNames: []ssv1.DeviceClassName{draDeviceClassName},
+				},
+			}
+			applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+
+			Eventually(func() error {
+				configMap, err := kubeClient.CoreV1().ConfigMaps(testutils.OperatorNamespace).Get(ctx, "kueue-manager-config", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				configData := configMap.Data["controller_manager_config.yaml"]
+				if !strings.Contains(configData, "DynamicResourceAllocation: true") {
+					return fmt.Errorf("DynamicResourceAllocation not enabled yet")
+				}
+				return nil
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
+
+			By("Creating ClusterQueue and LocalQueue for mixed test")
+			kueueClient := clients.UpstreamKueueClient
+
+			mixedCQ := testutils.NewClusterQueue()
+			mixedCQ.Name = erMixedClusterQueueName
+			mixedCQ.Spec.ResourceGroups = []kueuev1beta2.ResourceGroup{{
+				CoveredResources: []corev1.ResourceName{"cpu", "memory", corev1.ResourceName(draLogicalResource), corev1.ResourceName(extendedResourceName)},
+				Flavors: []kueuev1beta2.FlavorQuotas{{
+					Name: "default",
+					Resources: []kueuev1beta2.ResourceQuota{
+						{Name: "cpu", NominalQuota: resource.MustParse("100")},
+						{Name: "memory", NominalQuota: resource.MustParse("100Gi")},
+						{Name: corev1.ResourceName(draLogicalResource), NominalQuota: *resource.NewQuantity(int64(maxGPUsPerNode), resource.DecimalSI)},
+						{Name: corev1.ResourceName(extendedResourceName), NominalQuota: *resource.NewQuantity(int64(maxGPUsPerNode), resource.DecimalSI)},
+					},
+				}},
+			}}
+			cleanupMixedCQ, err := mixedCQ.Create(ctx, kueueClient)
+			Expect(err).NotTo(HaveOccurred())
+			defer cleanupMixedCQ()
+
+			mixedLQ := testutils.NewLocalQueue(erTestNamespace, erMixedTestQueue)
+			mixedLQ.Spec.ClusterQueue = kueuev1beta2.ClusterQueueReference(erMixedClusterQueueName)
+			cleanupMixedLQ, err := mixedLQ.Create(ctx, kueueClient)
+			Expect(err).NotTo(HaveOccurred())
+			defer cleanupMixedLQ()
+
+			By("Creating ResourceClaimTemplate for 1 GPU")
+			rct := &resourcev1.ResourceClaimTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gpu-template-mixed",
+					Namespace: erTestNamespace,
+				},
+				Spec: resourcev1.ResourceClaimTemplateSpec{
+					Spec: resourcev1.ResourceClaimSpec{
+						Devices: resourcev1.DeviceClaim{
+							Requests: []resourcev1.DeviceRequest{
+								{
+									Name: "gpu-req",
+									Exactly: &resourcev1.ExactDeviceRequest{
+										DeviceClassName: draDeviceClassName,
+										Count:           1,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(erTestNamespace).Create(ctx, rct, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer kubeClient.ResourceV1().ResourceClaimTemplates(erTestNamespace).Delete(ctx, rct.Name, metav1.DeleteOptions{})
+
+			By("Creating Job with both extended resource request and ResourceClaimTemplate")
+			builder := testutils.NewTestResourceBuilder(erTestNamespace, erMixedTestQueue)
+			job := builder.NewJob()
+			setDRAJobCPU(job)
+			job.Name = "er-mixed-job"
+			job.Labels[testutils.QueueLabel] = erMixedTestQueue
+			job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
+			job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+				corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
+			}
+			job.Spec.Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
+				{Name: "gpu", ResourceClaimTemplateName: ptr.To("gpu-template-mixed")},
+			}
+			job.Spec.Template.Spec.Containers[0].Resources.Claims = []corev1.ResourceClaim{
+				{Name: "gpu"},
+			}
+			createdJob, err := kubeClient.BatchV1().Jobs(erTestNamespace).Create(ctx, job, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
+
+			By("Verifying workload is admitted and deviceClassMappings name takes precedence")
+			Eventually(func(g Gomega) {
+				wlList, err := kueueClient.KueueV1beta2().Workloads(erTestNamespace).List(ctx, metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("kueue.x-k8s.io/job-uid=%s", string(createdJob.UID)),
+				})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(wlList.Items).NotTo(BeEmpty(), "workload not found for job %s", createdJob.Name)
+
+				wl := wlList.Items[0]
+				g.Expect(wl.Status.Admission).NotTo(BeNil(), "workload should be admitted")
+				g.Expect(wl.Status.Admission.PodSetAssignments).To(HaveLen(1))
+
+				assignment := wl.Status.Admission.PodSetAssignments[0]
+				g.Expect(assignment.ResourceUsage).To(HaveKey(corev1.ResourceName(draLogicalResource)))
+				g.Expect(assignment.ResourceUsage[corev1.ResourceName(draLogicalResource)]).To(Equal(resource.MustParse("2")),
+					"both ER and RCT should be counted under %s", draLogicalResource)
+
+				// Verify ClusterQueue shows mapping name used, extended resource name stays at 0
+				cqObj, err := kueueClient.KueueV1beta2().ClusterQueues().Get(ctx, erMixedClusterQueueName, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, flavor := range cqObj.Status.FlavorsReservation {
+					for _, res := range flavor.Resources {
+						if res.Name == corev1.ResourceName(draLogicalResource) {
+							g.Expect(res.Total.Cmp(resource.MustParse("2"))).To(Equal(0),
+								"%s should show 2 reserved (ER + RCT converged), got %s", draLogicalResource, res.Total.String())
+						}
+						if res.Name == corev1.ResourceName(extendedResourceName) {
+							g.Expect(res.Total.Cmp(resource.MustParse("0"))).To(Equal(0),
+								"%s should show 0 (mapped to %s), got %s", extendedResourceName, draLogicalResource, res.Total.String())
+						}
+					}
+				}
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
+
+			By("Verifying job is unsuspended")
+			Eventually(func() bool {
+				return !testutils.IsJobSuspended(ctx, kubeClient, erTestNamespace, createdJob.Name)
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
+
+			By("Verifying job pod is running")
+			Eventually(func() bool {
+				return testutils.IsJobPodRunning(ctx, kubeClient, erTestNamespace, createdJob.Name)
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
+
+			By("Verifying pod has both extendedResourceClaimStatus and resourceClaimStatuses")
+			Eventually(func(g Gomega) {
+				pods, err := kubeClient.CoreV1().Pods(erTestNamespace).List(ctx, metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("batch.kubernetes.io/job-name=%s", createdJob.Name),
+				})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pods.Items).NotTo(BeEmpty())
+
+				pod := pods.Items[0]
+				g.Expect(pod.Status.ExtendedResourceClaimStatus).NotTo(BeNil(),
+					"extendedResourceClaimStatus should be populated for ER path")
+				g.Expect(pod.Status.ResourceClaimStatuses).NotTo(BeEmpty(),
+					"resourceClaimStatuses should be populated for RCT path")
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
+		})
+	})
+})

--- a/test/e2e/e2e_dra_extended_resources_test.go
+++ b/test/e2e/e2e_dra_extended_resources_test.go
@@ -34,21 +34,15 @@ import (
 )
 
 const (
-	erTestNamespace         = "kueue-dra-er-test"
-	erTestQueue             = "dra-er-test-queue"
-	erClusterQueueName      = "dra-er-test-clusterqueue"
-	erMixedTestQueue        = "dra-er-mixed-queue"
-	erMixedClusterQueueName = "dra-er-mixed-clusterqueue"
-	extendedResourceName    = "nvidia.com/gpu"
+	erTestNamespacePrefix = "kueue-dra-er-test-"
+	erLocalQueueName      = "er-queue"
+	extendedResourceName  = "nvidia.com/gpu"
 )
 
 var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extended-resources"), Ordered, func() {
 	var (
-		initialKueueInstance  *ssv1.Kueue
-		cleanupClusterQueue   func()
-		cleanupLocalQueue     func()
-		cleanupResourceFlavor func()
-		maxGPUsPerNode        int
+		initialKueueInstance *ssv1.Kueue
+		maxGPUsPerNode       int
 	)
 
 	JustAfterEach(func(ctx context.Context) {
@@ -71,15 +65,26 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 			Skip("DRA APIs (resource.k8s.io/v1) not available on this cluster")
 		}
 
-		// Check if ResourceSlices exist for gpu.nvidia.com (driver is running)
+		// Wait for ResourceSlices to exist for gpu.nvidia.com (driver may still be deploying)
 		// and count GPUs per node (only devices with type=="gpu", excluding MIG slices)
+		Eventually(func() bool {
+			slices, err := kubeClient.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
+			if err != nil {
+				return false
+			}
+			for _, s := range slices.Items {
+				if s.Spec.Driver == draDeviceClassName {
+					return true
+				}
+			}
+			return false
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue(), "No ResourceSlices found for driver gpu.nvidia.com - NVIDIA DRA driver not running")
+
 		slices, err := kubeClient.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		hasDriverSlices := false
 		gpusPerNode := map[string]int{}
 		for _, s := range slices.Items {
 			if s.Spec.Driver == draDeviceClassName {
-				hasDriverSlices = true
 				if s.Spec.NodeName != nil {
 					for _, d := range s.Spec.Devices {
 						// The NVIDIA DRA driver uses the bare "type" attribute key (not fully qualified)
@@ -94,10 +99,6 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 				}
 			}
 		}
-		if !hasDriverSlices {
-			Skip("No ResourceSlices found for driver gpu.nvidia.com - NVIDIA DRA driver not running")
-		}
-
 		for _, count := range gpusPerNode {
 			if count > maxGPUsPerNode {
 				maxGPUsPerNode = count
@@ -120,38 +121,42 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 		applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
 
+		// Wait for DRA feature gates to be enabled in Kueue config
 		Eventually(func() error {
 			configMap, err := kubeClient.CoreV1().ConfigMaps(testutils.OperatorNamespace).Get(ctx, "kueue-manager-config", metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 			configData := configMap.Data["controller_manager_config.yaml"]
+			if !strings.Contains(configData, "DynamicResourceAllocation: true") {
+				return fmt.Errorf("DynamicResourceAllocation not enabled yet")
+			}
 			if !strings.Contains(configData, "DRAExtendedResources: true") {
 				return fmt.Errorf("DRAExtendedResources not enabled yet")
 			}
 			return nil
 		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
+	})
 
-		_, err = kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: erTestNamespace,
-				Labels: map[string]string{
-					testutils.OpenShiftManagedLabel: "true",
-				},
-			},
-		}, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+	AfterAll(func(ctx context.Context) {
+		if initialKueueInstance != nil {
+			applyKueueConfig(ctx, initialKueueInstance.Spec.Config, kubeClient)
+		}
+	})
 
+	It("should admit job with extended resource request and account DRA quota correctly", func(ctx context.Context) {
+		By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
 		kueueClient := clients.UpstreamKueueClient
-		cleanupResourceFlavor, err = testutils.NewResourceFlavor().Create(ctx, kueueClient)
-		Expect(err).NotTo(HaveOccurred())
 
-		cq := testutils.NewClusterQueue()
-		cq.Name = erClusterQueueName
-		cq.Spec.ResourceGroups = []kueuev1beta2.ResourceGroup{{
+		resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupResourceFlavor)
+
+		cqWrapper := testutils.NewClusterQueue().WithGenerateName().WithFlavorName(resourceFlavor.Name)
+		cqWrapper.Spec.ResourceGroups = []kueuev1beta2.ResourceGroup{{
 			CoveredResources: []corev1.ResourceName{"cpu", "memory", corev1.ResourceName(extendedResourceName)},
 			Flavors: []kueuev1beta2.FlavorQuotas{{
-				Name: "default",
+				Name: kueuev1beta2.ResourceFlavorReference(resourceFlavor.Name),
 				Resources: []kueuev1beta2.ResourceQuota{
 					{Name: "cpu", NominalQuota: resource.MustParse("100")},
 					{Name: "memory", NominalQuota: resource.MustParse("100Gi")},
@@ -159,52 +164,42 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 				},
 			}},
 		}}
-		cleanupClusterQueue, err = cq.Create(ctx, kueueClient)
+		cq, cleanupCQ, err := cqWrapper.CreateWithObject(ctx, kueueClient)
 		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupCQ)
 
-		lq := testutils.NewLocalQueue(erTestNamespace, erTestQueue)
-		lq.Spec.ClusterQueue = kueuev1beta2.ClusterQueueReference(erClusterQueueName)
-		cleanupLocalQueue, err = lq.Create(ctx, kueueClient)
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: erTestNamespacePrefix,
+				Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
+			},
+		}
+		cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
 		Expect(err).NotTo(HaveOccurred())
-	})
+		DeferCleanup(cleanupNs)
 
-	AfterAll(func(ctx context.Context) {
-		if cleanupLocalQueue != nil {
-			cleanupLocalQueue()
-		}
-		if cleanupClusterQueue != nil {
-			cleanupClusterQueue()
-		}
-		if cleanupResourceFlavor != nil {
-			cleanupResourceFlavor()
-		}
+		lq := testutils.NewLocalQueue(ns.Name, erLocalQueueName).WithClusterQueue(cq.Name)
+		_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupLQ)
 
-		kubeClient.CoreV1().Namespaces().Delete(ctx, erTestNamespace, metav1.DeleteOptions{})
-
-		if initialKueueInstance != nil {
-			applyKueueConfig(ctx, initialKueueInstance.Spec.Config, kubeClient)
-		}
-	})
-
-	It("should admit job with extended resource request and account DRA quota correctly", func(ctx context.Context) {
 		By("Creating Job with extended resource request nvidia.com/gpu")
-		builder := testutils.NewTestResourceBuilder(erTestNamespace, erTestQueue)
+		builder := testutils.NewTestResourceBuilder(ns.Name, erLocalQueueName)
 		job := builder.NewJob()
 		setDRAJobCPU(job)
 		job.Name = "er-basic-job"
-		job.Labels[testutils.QueueLabel] = erTestQueue
+		job.Labels[testutils.QueueLabel] = erLocalQueueName
 		job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
 		job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
 			corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
 		}
-		createdJob, err := kubeClient.BatchV1().Jobs(erTestNamespace).Create(ctx, job, metav1.CreateOptions{})
+		createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
 
 		By("Verifying workload is admitted with correct quota under extendedResourceName")
-		kueueClient := clients.UpstreamKueueClient
 		Eventually(func(g Gomega) {
-			wlList, err := kueueClient.KueueV1beta2().Workloads(erTestNamespace).List(ctx, metav1.ListOptions{
+			wlList, err := kueueClient.KueueV1beta2().Workloads(ns.Name).List(ctx, metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("kueue.x-k8s.io/job-uid=%s", string(createdJob.UID)),
 			})
 			g.Expect(err).NotTo(HaveOccurred())
@@ -221,17 +216,17 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 		By("Verifying job is unsuspended")
 		Eventually(func() bool {
-			return !testutils.IsJobSuspended(ctx, kubeClient, erTestNamespace, createdJob.Name)
+			return !testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJob.Name)
 		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 		By("Verifying job pod is running")
 		Eventually(func() bool {
-			return testutils.IsJobPodRunning(ctx, kubeClient, erTestNamespace, createdJob.Name)
+			return testutils.IsJobPodRunning(ctx, kubeClient, ns.Name, createdJob.Name)
 		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 		By("Verifying extendedResourceClaimStatus is populated in pod status")
 		Eventually(func(g Gomega) {
-			pods, err := kubeClient.CoreV1().Pods(erTestNamespace).List(ctx, metav1.ListOptions{
+			pods, err := kubeClient.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("batch.kubernetes.io/job-name=%s", createdJob.Name),
 			})
 			g.Expect(err).NotTo(HaveOccurred())
@@ -245,98 +240,159 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 		By("Verifying auto-generated ResourceClaim has the extended resource annotation")
 		Eventually(func(g Gomega) {
-			pods, err := kubeClient.CoreV1().Pods(erTestNamespace).List(ctx, metav1.ListOptions{
+			pods, err := kubeClient.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("batch.kubernetes.io/job-name=%s", createdJob.Name),
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(pods.Items).NotTo(BeEmpty())
 
 			claimName := pods.Items[0].Status.ExtendedResourceClaimStatus.ResourceClaimName
-			claim, err := kubeClient.ResourceV1().ResourceClaims(erTestNamespace).Get(ctx, claimName, metav1.GetOptions{})
+			claim, err := kubeClient.ResourceV1().ResourceClaims(ns.Name).Get(ctx, claimName, metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(claim.Annotations).To(HaveKeyWithValue("resource.kubernetes.io/extended-resource-claim", "true"))
 		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 	})
 
 	It("should suspend job when extended resource quota is exceeded", func(ctx context.Context) {
+		By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
+		kueueClient := clients.UpstreamKueueClient
+
+		resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupResourceFlavor)
+
+		cqWrapper := testutils.NewClusterQueue().WithGenerateName().WithFlavorName(resourceFlavor.Name)
+		cqWrapper.Spec.ResourceGroups = []kueuev1beta2.ResourceGroup{{
+			CoveredResources: []corev1.ResourceName{"cpu", "memory", corev1.ResourceName(extendedResourceName)},
+			Flavors: []kueuev1beta2.FlavorQuotas{{
+				Name: kueuev1beta2.ResourceFlavorReference(resourceFlavor.Name),
+				Resources: []kueuev1beta2.ResourceQuota{
+					{Name: "cpu", NominalQuota: resource.MustParse("100")},
+					{Name: "memory", NominalQuota: resource.MustParse("100Gi")},
+					{Name: corev1.ResourceName(extendedResourceName), NominalQuota: *resource.NewQuantity(int64(maxGPUsPerNode), resource.DecimalSI)},
+				},
+			}},
+		}}
+		cq, cleanupCQ, err := cqWrapper.CreateWithObject(ctx, kueueClient)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupCQ)
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: erTestNamespacePrefix,
+				Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
+			},
+		}
+		cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupNs)
+
+		lq := testutils.NewLocalQueue(ns.Name, erLocalQueueName).WithClusterQueue(cq.Name)
+		_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupLQ)
+
 		By(fmt.Sprintf("Creating Job requesting %d GPUs via extended resources (quota is %d)", maxGPUsPerNode+1, maxGPUsPerNode))
-		builder := testutils.NewTestResourceBuilder(erTestNamespace, erTestQueue)
+		builder := testutils.NewTestResourceBuilder(ns.Name, erLocalQueueName)
 		job := builder.NewJob()
 		setDRAJobCPU(job)
 		job.Name = "er-exceed-job"
-		job.Labels[testutils.QueueLabel] = erTestQueue
+		job.Labels[testutils.QueueLabel] = erLocalQueueName
 		exceededCount := *resource.NewQuantity(int64(maxGPUsPerNode+1), resource.DecimalSI)
 		job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = exceededCount
 		job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
 			corev1.ResourceName(extendedResourceName): exceededCount,
 		}
-		createdJob, err := kubeClient.BatchV1().Jobs(erTestNamespace).Create(ctx, job, metav1.CreateOptions{})
+		createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
 
 		By("Verifying job remains suspended")
 		Consistently(func() bool {
-			return testutils.IsJobSuspended(ctx, kubeClient, erTestNamespace, createdJob.Name)
+			return testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJob.Name)
 		}, testutils.ConsistentlyTimeout, testutils.ConsistentlyPoll).Should(BeTrue())
 	})
 
 	It("should admit waiting job after extended resource quota is freed", func(ctx context.Context) {
-		By("Waiting for quota to be fully released from previous tests")
+		By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
 		kueueClient := clients.UpstreamKueueClient
-		Eventually(func(g Gomega) {
-			cq, err := kueueClient.KueueV1beta2().ClusterQueues().Get(ctx, erClusterQueueName, metav1.GetOptions{})
-			g.Expect(err).NotTo(HaveOccurred())
-			for _, flavor := range cq.Status.FlavorsReservation {
-				for _, res := range flavor.Resources {
-					if res.Name == corev1.ResourceName(extendedResourceName) {
-						g.Expect(res.Total.Cmp(resource.MustParse("0"))).To(Equal(0),
-							"%s quota should be 0 before test starts, got %s", extendedResourceName, res.Total.String())
-					}
-				}
-			}
-		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
+
+		resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupResourceFlavor)
+
+		cqWrapper := testutils.NewClusterQueue().WithGenerateName().WithFlavorName(resourceFlavor.Name)
+		cqWrapper.Spec.ResourceGroups = []kueuev1beta2.ResourceGroup{{
+			CoveredResources: []corev1.ResourceName{"cpu", "memory", corev1.ResourceName(extendedResourceName)},
+			Flavors: []kueuev1beta2.FlavorQuotas{{
+				Name: kueuev1beta2.ResourceFlavorReference(resourceFlavor.Name),
+				Resources: []kueuev1beta2.ResourceQuota{
+					{Name: "cpu", NominalQuota: resource.MustParse("100")},
+					{Name: "memory", NominalQuota: resource.MustParse("100Gi")},
+					{Name: corev1.ResourceName(extendedResourceName), NominalQuota: *resource.NewQuantity(int64(maxGPUsPerNode), resource.DecimalSI)},
+				},
+			}},
+		}}
+		cq, cleanupCQ, err := cqWrapper.CreateWithObject(ctx, kueueClient)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupCQ)
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: erTestNamespacePrefix,
+				Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
+			},
+		}
+		cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupNs)
+
+		lq := testutils.NewLocalQueue(ns.Name, erLocalQueueName).WithClusterQueue(cq.Name)
+		_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupLQ)
 
 		By(fmt.Sprintf("Creating first job requesting all %d GPUs via extended resources (fills quota)", maxGPUsPerNode))
-		builder := testutils.NewTestResourceBuilder(erTestNamespace, erTestQueue)
+		builder := testutils.NewTestResourceBuilder(ns.Name, erLocalQueueName)
 		job1 := builder.NewJob()
 		setDRAJobCPU(job1)
 		job1.Name = "er-fill-job-1"
-		job1.Labels[testutils.QueueLabel] = erTestQueue
+		job1.Labels[testutils.QueueLabel] = erLocalQueueName
 		fillCount := *resource.NewQuantity(int64(maxGPUsPerNode), resource.DecimalSI)
 		job1.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = fillCount
 		job1.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
 			corev1.ResourceName(extendedResourceName): fillCount,
 		}
-		createdJob1, err := kubeClient.BatchV1().Jobs(erTestNamespace).Create(ctx, job1, metav1.CreateOptions{})
+		createdJob1, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job1, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		defer testutils.CleanUpJob(ctx, kubeClient, createdJob1.Namespace, createdJob1.Name)
 
 		By("Waiting for first job to be admitted")
 		Eventually(func() bool {
-			return !testutils.IsJobSuspended(ctx, kubeClient, erTestNamespace, createdJob1.Name)
+			return !testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJob1.Name)
 		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 		By("Verifying first job pod is running")
 		Eventually(func() bool {
-			return testutils.IsJobPodRunning(ctx, kubeClient, erTestNamespace, createdJob1.Name)
+			return testutils.IsJobPodRunning(ctx, kubeClient, ns.Name, createdJob1.Name)
 		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 		By("Creating second job requesting 1 GPU via extended resources (quota full, should be suspended)")
 		job2 := builder.NewJob()
 		setDRAJobCPU(job2)
 		job2.Name = "er-fill-job-2"
-		job2.Labels[testutils.QueueLabel] = erTestQueue
+		job2.Labels[testutils.QueueLabel] = erLocalQueueName
 		job2.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
 		job2.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
 			corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
 		}
-		createdJob2, err := kubeClient.BatchV1().Jobs(erTestNamespace).Create(ctx, job2, metav1.CreateOptions{})
+		createdJob2, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job2, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		defer testutils.CleanUpJob(ctx, kubeClient, createdJob2.Namespace, createdJob2.Name)
 
 		By("Verifying second job is suspended (quota full)")
 		Consistently(func() bool {
-			return testutils.IsJobSuspended(ctx, kubeClient, erTestNamespace, createdJob2.Name)
+			return testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJob2.Name)
 		}, testutils.ConsistentlyTimeout, testutils.ConsistentlyPoll).Should(BeTrue())
 
 		By("Deleting first job to free quota")
@@ -344,53 +400,76 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 		By("Verifying second job is admitted after quota freed")
 		Eventually(func() bool {
-			return !testutils.IsJobSuspended(ctx, kubeClient, erTestNamespace, createdJob2.Name)
+			return !testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJob2.Name)
 		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 		By("Verifying second job pod is running")
 		Eventually(func() bool {
-			return testutils.IsJobPodRunning(ctx, kubeClient, erTestNamespace, createdJob2.Name)
+			return testutils.IsJobPodRunning(ctx, kubeClient, ns.Name, createdJob2.Name)
 		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 	})
 
 	It("should verify ClusterQueue shows correct extended resource usage", func(ctx context.Context) {
-		By("Waiting for quota to be fully released from previous tests")
+		By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
 		kueueClient := clients.UpstreamKueueClient
-		Eventually(func(g Gomega) {
-			cq, err := kueueClient.KueueV1beta2().ClusterQueues().Get(ctx, erClusterQueueName, metav1.GetOptions{})
-			g.Expect(err).NotTo(HaveOccurred())
-			for _, flavor := range cq.Status.FlavorsReservation {
-				for _, res := range flavor.Resources {
-					if res.Name == corev1.ResourceName(extendedResourceName) {
-						g.Expect(res.Total.Cmp(resource.MustParse("0"))).To(Equal(0),
-							"%s quota should be 0 before test starts, got %s", extendedResourceName, res.Total.String())
-					}
-				}
-			}
-		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
+
+		resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupResourceFlavor)
+
+		cqWrapper := testutils.NewClusterQueue().WithGenerateName().WithFlavorName(resourceFlavor.Name)
+		cqWrapper.Spec.ResourceGroups = []kueuev1beta2.ResourceGroup{{
+			CoveredResources: []corev1.ResourceName{"cpu", "memory", corev1.ResourceName(extendedResourceName)},
+			Flavors: []kueuev1beta2.FlavorQuotas{{
+				Name: kueuev1beta2.ResourceFlavorReference(resourceFlavor.Name),
+				Resources: []kueuev1beta2.ResourceQuota{
+					{Name: "cpu", NominalQuota: resource.MustParse("100")},
+					{Name: "memory", NominalQuota: resource.MustParse("100Gi")},
+					{Name: corev1.ResourceName(extendedResourceName), NominalQuota: *resource.NewQuantity(int64(maxGPUsPerNode), resource.DecimalSI)},
+				},
+			}},
+		}}
+		cq, cleanupCQ, err := cqWrapper.CreateWithObject(ctx, kueueClient)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupCQ)
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: erTestNamespacePrefix,
+				Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
+			},
+		}
+		cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupNs)
+
+		lq := testutils.NewLocalQueue(ns.Name, erLocalQueueName).WithClusterQueue(cq.Name)
+		_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupLQ)
 
 		By("Creating Job with 1 GPU via extended resource request")
-		builder := testutils.NewTestResourceBuilder(erTestNamespace, erTestQueue)
+		builder := testutils.NewTestResourceBuilder(ns.Name, erLocalQueueName)
 		job := builder.NewJob()
 		setDRAJobCPU(job)
 		job.Name = "er-usage-job"
-		job.Labels[testutils.QueueLabel] = erTestQueue
+		job.Labels[testutils.QueueLabel] = erLocalQueueName
 		job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
 		job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
 			corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
 		}
-		createdJob, err := kubeClient.BatchV1().Jobs(erTestNamespace).Create(ctx, job, metav1.CreateOptions{})
+		createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
 
 		By("Verifying ClusterQueue shows extended resource reservation")
 		Eventually(func(g Gomega) {
-			cq, err := kueueClient.KueueV1beta2().ClusterQueues().Get(ctx, erClusterQueueName, metav1.GetOptions{})
+			cqObj, err := kueueClient.KueueV1beta2().ClusterQueues().Get(ctx, cq.Name, metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(cq.Status.FlavorsReservation).NotTo(BeEmpty())
+			g.Expect(cqObj.Status.FlavorsReservation).NotTo(BeEmpty())
 
 			found := false
-			for _, flavor := range cq.Status.FlavorsReservation {
+			for _, flavor := range cqObj.Status.FlavorsReservation {
 				for _, res := range flavor.Resources {
 					if res.Name == corev1.ResourceName(extendedResourceName) {
 						g.Expect(res.Total.Cmp(resource.MustParse("1"))).To(Equal(0),
@@ -402,9 +481,14 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 			g.Expect(found).To(BeTrue(), "resource %s not found in ClusterQueue reservation", extendedResourceName)
 		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
+		By("Verifying job is unsuspended")
+		Eventually(func() bool {
+			return !testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJob.Name)
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
+
 		By("Verifying job pod is running")
 		Eventually(func() bool {
-			return testutils.IsJobPodRunning(ctx, kubeClient, erTestNamespace, createdJob.Name)
+			return testutils.IsJobPodRunning(ctx, kubeClient, ns.Name, createdJob.Name)
 		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 	})
 
@@ -416,7 +500,6 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 		})
 
 		It("should account both ER and RCT under same quota with deviceClassMappings taking precedence", func(ctx context.Context) {
-
 			By("Adding deviceClassMappings to enable DynamicResourceAllocation for RCT path")
 			kueueInstance, err := clients.KueueClient.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -441,15 +524,18 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 				return nil
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
-			By("Creating ClusterQueue and LocalQueue for mixed test")
+			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
 			kueueClient := clients.UpstreamKueueClient
 
-			mixedCQ := testutils.NewClusterQueue()
-			mixedCQ.Name = erMixedClusterQueueName
-			mixedCQ.Spec.ResourceGroups = []kueuev1beta2.ResourceGroup{{
+			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(cleanupResourceFlavor)
+
+			cqWrapper := testutils.NewClusterQueue().WithGenerateName().WithFlavorName(resourceFlavor.Name)
+			cqWrapper.Spec.ResourceGroups = []kueuev1beta2.ResourceGroup{{
 				CoveredResources: []corev1.ResourceName{"cpu", "memory", corev1.ResourceName(draLogicalResource), corev1.ResourceName(extendedResourceName)},
 				Flavors: []kueuev1beta2.FlavorQuotas{{
-					Name: "default",
+					Name: kueuev1beta2.ResourceFlavorReference(resourceFlavor.Name),
 					Resources: []kueuev1beta2.ResourceQuota{
 						{Name: "cpu", NominalQuota: resource.MustParse("100")},
 						{Name: "memory", NominalQuota: resource.MustParse("100Gi")},
@@ -458,21 +544,30 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 					},
 				}},
 			}}
-			cleanupMixedCQ, err := mixedCQ.Create(ctx, kueueClient)
+			cq, cleanupCQ, err := cqWrapper.CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer cleanupMixedCQ()
+			DeferCleanup(cleanupCQ)
 
-			mixedLQ := testutils.NewLocalQueue(erTestNamespace, erMixedTestQueue)
-			mixedLQ.Spec.ClusterQueue = kueuev1beta2.ClusterQueueReference(erMixedClusterQueueName)
-			cleanupMixedLQ, err := mixedLQ.Create(ctx, kueueClient)
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: erTestNamespacePrefix,
+					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
+				},
+			}
+			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
 			Expect(err).NotTo(HaveOccurred())
-			defer cleanupMixedLQ()
+			DeferCleanup(cleanupNs)
+
+			lq := testutils.NewLocalQueue(ns.Name, "er-mixed-queue").WithClusterQueue(cq.Name)
+			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(cleanupLQ)
 
 			By("Creating ResourceClaimTemplate for 1 GPU")
 			rct := &resourcev1.ResourceClaimTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "gpu-template-mixed",
-					Namespace: erTestNamespace,
+					Namespace: ns.Name,
 				},
 				Spec: resourcev1.ResourceClaimTemplateSpec{
 					Spec: resourcev1.ResourceClaimSpec{
@@ -490,16 +585,16 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 					},
 				},
 			}
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(erTestNamespace).Create(ctx, rct, metav1.CreateOptions{})
+			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer kubeClient.ResourceV1().ResourceClaimTemplates(erTestNamespace).Delete(ctx, rct.Name, metav1.DeleteOptions{})
+			defer kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Delete(ctx, rct.Name, metav1.DeleteOptions{})
 
 			By("Creating Job with both extended resource request and ResourceClaimTemplate")
-			builder := testutils.NewTestResourceBuilder(erTestNamespace, erMixedTestQueue)
+			builder := testutils.NewTestResourceBuilder(ns.Name, "er-mixed-queue")
 			job := builder.NewJob()
 			setDRAJobCPU(job)
 			job.Name = "er-mixed-job"
-			job.Labels[testutils.QueueLabel] = erMixedTestQueue
+			job.Labels[testutils.QueueLabel] = "er-mixed-queue"
 			job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
 			job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
 				corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
@@ -510,13 +605,13 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 			job.Spec.Template.Spec.Containers[0].Resources.Claims = []corev1.ResourceClaim{
 				{Name: "gpu"},
 			}
-			createdJob, err := kubeClient.BatchV1().Jobs(erTestNamespace).Create(ctx, job, metav1.CreateOptions{})
+			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
 
 			By("Verifying workload is admitted and deviceClassMappings name takes precedence")
 			Eventually(func(g Gomega) {
-				wlList, err := kueueClient.KueueV1beta2().Workloads(erTestNamespace).List(ctx, metav1.ListOptions{
+				wlList, err := kueueClient.KueueV1beta2().Workloads(ns.Name).List(ctx, metav1.ListOptions{
 					LabelSelector: fmt.Sprintf("kueue.x-k8s.io/job-uid=%s", string(createdJob.UID)),
 				})
 				g.Expect(err).NotTo(HaveOccurred())
@@ -532,7 +627,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 					"both ER and RCT should be counted under %s", draLogicalResource)
 
 				// Verify ClusterQueue shows mapping name used, extended resource name stays at 0
-				cqObj, err := kueueClient.KueueV1beta2().ClusterQueues().Get(ctx, erMixedClusterQueueName, metav1.GetOptions{})
+				cqObj, err := kueueClient.KueueV1beta2().ClusterQueues().Get(ctx, cq.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 				for _, flavor := range cqObj.Status.FlavorsReservation {
 					for _, res := range flavor.Resources {
@@ -550,17 +645,17 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 			By("Verifying job is unsuspended")
 			Eventually(func() bool {
-				return !testutils.IsJobSuspended(ctx, kubeClient, erTestNamespace, createdJob.Name)
+				return !testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJob.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Verifying job pod is running")
 			Eventually(func() bool {
-				return testutils.IsJobPodRunning(ctx, kubeClient, erTestNamespace, createdJob.Name)
+				return testutils.IsJobPodRunning(ctx, kubeClient, ns.Name, createdJob.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Verifying pod has both extendedResourceClaimStatus and resourceClaimStatuses")
 			Eventually(func(g Gomega) {
-				pods, err := kubeClient.CoreV1().Pods(erTestNamespace).List(ctx, metav1.ListOptions{
+				pods, err := kubeClient.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{
 					LabelSelector: fmt.Sprintf("batch.kubernetes.io/job-name=%s", createdJob.Name),
 				})
 				g.Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/e2e_dra_test.go
+++ b/test/e2e/e2e_dra_test.go
@@ -66,7 +66,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 		apiResourceLists, err := kubeClient.Discovery().ServerResourcesForGroupVersion("resource.k8s.io/v1")
 		if err == nil {
 			for _, apiResource := range apiResourceLists.APIResources {
-				if apiResource.Kind == "DeviceClass" {
+				if apiResource.Kind == testutils.DeviceClassKind {
 					draSupported = true
 					break
 				}

--- a/test/e2e/e2e_operator_test.go
+++ b/test/e2e/e2e_operator_test.go
@@ -409,7 +409,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			apiResourceLists, err := kubeClient.Discovery().ServerResourcesForGroupVersion("resource.k8s.io/v1")
 			if err == nil {
 				for _, apiResource := range apiResourceLists.APIResources {
-					if apiResource.Kind == "DeviceClass" {
+					if apiResource.Kind == testutils.DeviceClassKind {
 						draSupported = true
 						break
 					}

--- a/test/e2e/testutils/constants.go
+++ b/test/e2e/testutils/constants.go
@@ -29,4 +29,5 @@ const (
 	DeletionPoll          = 5 * time.Second
 	ConsistentlyTimeout   = 5 * time.Second
 	ConsistentlyPoll      = 1 * time.Second
+	DeviceClassKind       = "DeviceClass"
 )


### PR DESCRIPTION
Signed-off-by: Pannaga Rao Bhoja Ramamanohara

PR Summary

- Enable kueue DRAExtendedResources feature gate when the K8s DRAExtendedResource gate is detected on the cluster. Since DRAExtendedResource is not in openshift/api, it can only be set via CustomNoUpgrade — the operator checks spec.customNoUpgrade.enabled on the FeatureGate CR to determine this.
- Add featuregates to the operator's ClusterRole RBAC and regenerate the bundle CSV to allow reading the FeatureGate CR.                                                                                          
- Decouple DRA API availability check from deviceClassMappings so extended resources work without requiring explicit device class configuration.                                                                  
-  Add e2e_dra_extended_resources_test.go with tests for ER admission, quota enforcement, quota release, ClusterQueue usage, and mixed ER+RCT convergence (the mixed test requires 2+ GPUs on a single node and is skipped otherwise).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the DRA Extended Resources feature gate so extended-resource scheduling and accounting can be enabled via cluster feature configuration.

* **Chores**
  * Updated operator permissions to allow reading feature-gate resources for correct feature detection and config application.

* **Tests**
  * Added comprehensive end-to-end tests validating extended-resource admission, reservation accounting, mixed ER+RCT scenarios, and controller config changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->