### PR TITLE
Add CEL expression tests for AdmissionFairSharing

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -367,6 +367,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gomodules.xyz/jsonpatch/v2 v2.5.0 h1:JELs8RLM12qJGXU4u/TO3V25KW8GreMKl9pdkk14RM0=
+gomodules.xyz/jsonpatch/v2 v2.5.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
 gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
 google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 h1:fCvbg86sFXwdrl5LgVcTEvNC+2txB5mgROGmRL5mrls=

--- a/test/envtest/kueue_admissionfairsharing_cel_test.go
+++ b/test/envtest/kueue_admissionfairsharing_cel_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package envtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	kueueopv1 "github.com/openshift/kueue-operator/pkg/apis/kueueoperator/v1"
+	kueueclient "github.com/openshift/kueue-operator/pkg/generated/clientset/versioned"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+const kueueCRDPath = "../../manifests/kueue.openshift.io_kueues.yaml"
+
+var (
+	testEnv *envtest.Environment
+	clients *kueueclient.Clientset
+	kueue   *kueueopv1.Kueue
+	err     error
+)
+
+func TestAdmissionFairSharingCEL(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AdmissionFairSharingCEL envtest suite")
+}
+
+var _ = BeforeSuite(func() {
+	testEnv = &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths:              []string{kueueCRDPath},
+			ErrorIfPathMissing: true,
+		},
+		ErrorIfCRDPathMissing:    true,
+		DownloadBinaryAssets:     true,
+		ControlPlaneStartTimeout: 2 * time.Minute,
+		ControlPlaneStopTimeout:  1 * time.Minute,
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	clients, err = kueueclient.NewForConfig(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(clients).NotTo(BeNil())
+
+	kueues := clients.KueueV1().Kueues()
+	kueueObj := &kueueopv1.Kueue{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: kueueopv1.KueueOperandSpec{
+			OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed},
+			Config: kueueopv1.KueueConfiguration{
+				Integrations: kueueopv1.Integrations{
+					Frameworks: []kueueopv1.KueueIntegration{kueueopv1.KueueIntegrationBatchJob},
+				},
+			},
+		},
+	}
+	kueue, err = kueues.Create(context.Background(), kueueObj, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	if testEnv == nil {
+		return
+	}
+	Expect(testEnv.Stop()).To(Succeed())
+})
+
+var _ = Describe("AdmissionFairSharingCEL", func() {
+	It("should not allow updating to Custom configuration without custom field", func(ctx context.Context) {
+		By("setting only admissionFairSharing.configuration to Custom (no custom object)")
+		kueue.Spec.Config.AdmissionFairSharing = kueueopv1.AdmissionFairSharing{
+			Configuration: kueueopv1.AdmissionFairSharingConfigurationCustom,
+		}
+		_, err = clients.KueueV1().Kueues().Update(ctx, kueue, metav1.UpdateOptions{})
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "want invalid for Custom without custom field: %v", err)
+	})
+	It("should not allow resourceWeights name with name wrongly formatted", func(ctx context.Context) {
+		By("setting resourceWeights name with name wrongly formatted")
+		kueue.Spec.Config.AdmissionFairSharing = kueueopv1.AdmissionFairSharing{
+			Configuration: kueueopv1.AdmissionFairSharingConfigurationCustom,
+			Custom: kueueopv1.AdmissionFairSharingCustom{
+				ResourceWeights: []kueueopv1.ResourceWeight{
+					{Name: "/gpu", Weight: "1.0"},
+				},
+			},
+		}
+		_, err = clients.KueueV1().Kueues().Update(ctx, kueue, metav1.UpdateOptions{})
+		Expect(err).To(HaveOccurred(), "want error for resourceWeights name: %v", err)
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "want invalid for resourceWeights name: %v", err)
+	})
+	It("should not allow resourceWeights weight not being a number", func(ctx context.Context) {
+		By("setting resourceWeights weight not a number")
+		kueue.Spec.Config.AdmissionFairSharing = kueueopv1.AdmissionFairSharing{
+			Configuration: kueueopv1.AdmissionFairSharingConfigurationCustom,
+			Custom: kueueopv1.AdmissionFairSharingCustom{
+				ResourceWeights: []kueueopv1.ResourceWeight{
+					{Name: "nvidia.com/gpu", Weight: "foo"},
+				},
+			},
+		}
+		_, err = clients.KueueV1().Kueues().Update(ctx, kueue, metav1.UpdateOptions{})
+		Expect(err).To(HaveOccurred(), "want error for resourceWeights weight not a number: %v", err)
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "want invalid for resourceWeights weight not a number: %v", err)
+	})
+	It("should not allow resourceWeights with negative weight", func(ctx context.Context) {
+		By("setting resourceWeights with negative weight")
+		kueue.Spec.Config.AdmissionFairSharing = kueueopv1.AdmissionFairSharing{
+			Configuration: kueueopv1.AdmissionFairSharingConfigurationCustom,
+			Custom: kueueopv1.AdmissionFairSharingCustom{
+				ResourceWeights: []kueueopv1.ResourceWeight{
+					{Name: "nvidia.com/gpu", Weight: "-1.0"},
+				},
+			},
+		}
+		_, err = clients.KueueV1().Kueues().Update(ctx, kueue, metav1.UpdateOptions{})
+		Expect(err).To(HaveOccurred(), "want error for resourceWeights with negative weight: %v", err)
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "want invalid for resourceWeights with negative weight: %v", err)
+	})
+
+	It("should allow resourceWeights name with fully qualified name", func(ctx context.Context) {
+		By("setting resourceWeights name with fully qualified name")
+		kueue.Spec.Config.AdmissionFairSharing = kueueopv1.AdmissionFairSharing{
+			Configuration: kueueopv1.AdmissionFairSharingConfigurationCustom,
+			Custom: kueueopv1.AdmissionFairSharingCustom{
+				ResourceWeights: []kueueopv1.ResourceWeight{
+					{Name: "nvidia.com/gpu", Weight: "1.0"},
+				},
+			},
+		}
+		kueue, err = clients.KueueV1().Kueues().Update(ctx, kueue, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1653,10 +1653,19 @@ sigs.k8s.io/controller-runtime/pkg/client/apiutil
 sigs.k8s.io/controller-runtime/pkg/client/config
 sigs.k8s.io/controller-runtime/pkg/controller/controllerutil
 sigs.k8s.io/controller-runtime/pkg/conversion
+sigs.k8s.io/controller-runtime/pkg/envtest
+sigs.k8s.io/controller-runtime/pkg/internal/flock
 sigs.k8s.io/controller-runtime/pkg/internal/log
+sigs.k8s.io/controller-runtime/pkg/internal/testing/addr
+sigs.k8s.io/controller-runtime/pkg/internal/testing/certs
+sigs.k8s.io/controller-runtime/pkg/internal/testing/controlplane
+sigs.k8s.io/controller-runtime/pkg/internal/testing/process
 sigs.k8s.io/controller-runtime/pkg/log
 sigs.k8s.io/controller-runtime/pkg/log/zap
+sigs.k8s.io/controller-runtime/pkg/metrics
 sigs.k8s.io/controller-runtime/pkg/scheme
+sigs.k8s.io/controller-runtime/pkg/webhook/conversion
+sigs.k8s.io/controller-runtime/pkg/webhook/conversion/metrics
 # sigs.k8s.io/controller-tools v0.19.0 => github.com/openshift/controller-tools v0.12.1-0.20250402141027-24f590ca0886
 ## explicit; go 1.23.0
 sigs.k8s.io/controller-tools/cmd/controller-gen

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/binaries.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/binaries.go
@@ -1,0 +1,387 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envtest
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha512"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/version"
+	"sigs.k8s.io/yaml"
+)
+
+// DefaultBinaryAssetsIndexURL is the default index used in HTTPClient.
+var DefaultBinaryAssetsIndexURL = "https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/HEAD/envtest-releases.yaml"
+
+// SetupEnvtestDefaultBinaryAssetsDirectory returns the default location that setup-envtest uses to store envtest binaries.
+// Setting BinaryAssetsDirectory to this directory allows sharing envtest binaries with setup-envtest.
+//
+// The directory is dependent on operating system:
+//
+// - Windows: %LocalAppData%\kubebuilder-envtest
+// - OSX: ~/Library/Application Support/io.kubebuilder.envtest
+// - Others: ${XDG_DATA_HOME:-~/.local/share}/kubebuilder-envtest
+//
+// Otherwise, it errors out.  Note that these paths must not be relied upon
+// manually.
+func SetupEnvtestDefaultBinaryAssetsDirectory() (string, error) {
+	var baseDir string
+
+	// find the base data directory
+	switch runtime.GOOS {
+	case "windows":
+		baseDir = os.Getenv("LocalAppData")
+		if baseDir == "" {
+			return "", errors.New("%LocalAppData% is not defined")
+		}
+	case "darwin":
+		homeDir := os.Getenv("HOME")
+		if homeDir == "" {
+			return "", errors.New("$HOME is not defined")
+		}
+		baseDir = filepath.Join(homeDir, "Library/Application Support")
+	default:
+		baseDir = os.Getenv("XDG_DATA_HOME")
+		if baseDir == "" {
+			homeDir := os.Getenv("HOME")
+			if homeDir == "" {
+				return "", errors.New("neither $XDG_DATA_HOME nor $HOME are defined")
+			}
+			baseDir = filepath.Join(homeDir, ".local/share")
+		}
+	}
+
+	// append our program-specific dir to it (OSX has a slightly different
+	// convention so try to follow that).
+	switch runtime.GOOS {
+	case "darwin", "ios":
+		return filepath.Join(baseDir, "io.kubebuilder.envtest", "k8s"), nil
+	default:
+		return filepath.Join(baseDir, "kubebuilder-envtest", "k8s"), nil
+	}
+}
+
+// index represents an index of envtest binary archives. Example:
+//
+//	releases:
+//		v1.28.0:
+//			envtest-v1.28.0-darwin-amd64.tar.gz:
+//	    		hash: <sha512-hash>
+//				selfLink: <url-to-archive-with-envtest-binaries>
+type index struct {
+	// Releases maps Kubernetes versions to Releases (envtest archives).
+	Releases map[string]release `json:"releases"`
+}
+
+// release maps an archive name to an archive.
+type release map[string]archive
+
+// archive contains the self link to an archive and its hash.
+type archive struct {
+	Hash     string `json:"hash"`
+	SelfLink string `json:"selfLink"`
+}
+
+// parseKubernetesVersion returns:
+//  1. the SemVer form of s when it refers to a specific Kubernetes release, or
+//  2. the major and minor portions of s when it refers to a release series, or
+//  3. an error
+func parseKubernetesVersion(s string) (exact string, major, minor uint, err error) {
+	if v, err := version.ParseSemantic(s); err == nil {
+		return v.String(), 0, 0, nil
+	}
+
+	// See two parseable components and nothing else.
+	if v, err := version.ParseGeneric(s); err == nil && len(v.Components()) == 2 {
+		if v.String() == strings.TrimPrefix(s, "v") {
+			return "", v.Major(), v.Minor(), nil
+		}
+	}
+
+	return "", 0, 0, fmt.Errorf("could not parse %q as version", s)
+}
+
+func downloadBinaryAssets(ctx context.Context, binaryAssetsDirectory, binaryAssetsVersion, binaryAssetsIndexURL string) (string, string, string, error) {
+	if binaryAssetsIndexURL == "" {
+		binaryAssetsIndexURL = DefaultBinaryAssetsIndexURL
+	}
+
+	downloadRootDir := binaryAssetsDirectory
+	if downloadRootDir == "" {
+		var err error
+		if downloadRootDir, err = os.MkdirTemp("", "envtest-binaries-"); err != nil {
+			return "", "", "", fmt.Errorf("failed to create tmp directory for envtest binaries: %w", err)
+		}
+	}
+
+	var binaryAssetsIndex *index
+	switch exact, major, minor, err := parseKubernetesVersion(binaryAssetsVersion); {
+	case binaryAssetsVersion != "" && err != nil:
+		return "", "", "", err
+
+	case binaryAssetsVersion != "" && exact != "":
+		// Look for these specific binaries locally before downloading them from the release index.
+		// Use the canonical form of the version from here on.
+		binaryAssetsVersion = "v" + exact
+
+	case binaryAssetsVersion == "" || major != 0 || minor != 0:
+		// Select a stable version from the release index before continuing.
+		binaryAssetsIndex, err = getIndex(ctx, binaryAssetsIndexURL)
+		if err != nil {
+			return "", "", "", err
+		}
+
+		binaryAssetsVersion, err = latestStableVersionFromIndex(binaryAssetsIndex, major, minor)
+		if err != nil {
+			return "", "", "", err
+		}
+	}
+
+	// Storing the envtest binaries in a directory structure that is compatible with setup-envtest.
+	// This makes it possible to share the envtest binaries with setup-envtest if the BinaryAssetsDirectory is set to SetupEnvtestDefaultBinaryAssetsDirectory().
+	downloadDir := path.Join(downloadRootDir, fmt.Sprintf("%s-%s-%s", strings.TrimPrefix(binaryAssetsVersion, "v"), runtime.GOOS, runtime.GOARCH))
+	if !fileExists(downloadDir) {
+		if err := os.MkdirAll(downloadDir, 0700); err != nil {
+			return "", "", "", fmt.Errorf("failed to create directory %q for envtest binaries: %w", downloadDir, err)
+		}
+	}
+
+	apiServerPath := path.Join(downloadDir, "kube-apiserver")
+	etcdPath := path.Join(downloadDir, "etcd")
+	kubectlPath := path.Join(downloadDir, "kubectl")
+
+	if fileExists(apiServerPath) && fileExists(etcdPath) && fileExists(kubectlPath) {
+		// Nothing to do if the binaries already exist.
+		return apiServerPath, etcdPath, kubectlPath, nil
+	}
+
+	// Get Index if we didn't have to get it above to get the latest stable version.
+	if binaryAssetsIndex == nil {
+		var err error
+		binaryAssetsIndex, err = getIndex(ctx, binaryAssetsIndexURL)
+		if err != nil {
+			return "", "", "", err
+		}
+	}
+
+	buf := &bytes.Buffer{}
+	if err := downloadBinaryAssetsArchive(ctx, binaryAssetsIndex, binaryAssetsVersion, buf); err != nil {
+		return "", "", "", err
+	}
+
+	gzStream, err := gzip.NewReader(buf)
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to create gzip reader to extract envtest binaries: %w", err)
+	}
+	tarReader := tar.NewReader(gzStream)
+
+	var header *tar.Header
+	for header, err = tarReader.Next(); err == nil; header, err = tarReader.Next() {
+		if header.Typeflag != tar.TypeReg {
+			// Skip non-regular file entry in archive.
+			continue
+		}
+
+		// Just dump all files directly into the download directory, ignoring the prefixed directory paths.
+		// We also ignore bits for the most part (except for X).
+		fileName := filepath.Base(header.Name)
+		perms := 0555 & header.Mode // make sure we're at most r+x
+
+		// Setting O_EXCL to get an error if the file already exists.
+		f, err := os.OpenFile(path.Join(downloadDir, fileName), os.O_RDWR|os.O_CREATE|os.O_EXCL|os.O_TRUNC, os.FileMode(perms))
+		if err != nil {
+			if os.IsExist(err) {
+				// Nothing to do if the file already exists. We assume another process created the file concurrently.
+				continue
+			}
+			return "", "", "", fmt.Errorf("failed to create file %s in directory %s: %w", fileName, downloadDir, err)
+		}
+		if err := func() error {
+			defer f.Close()
+			if _, err := io.Copy(f, tarReader); err != nil {
+				return fmt.Errorf("failed to write file %s in directory %s: %w", fileName, downloadDir, err)
+			}
+			return nil
+		}(); err != nil {
+			return "", "", "", fmt.Errorf("failed to close file %s in directory %s: %w", fileName, downloadDir, err)
+		}
+	}
+
+	return apiServerPath, etcdPath, kubectlPath, nil
+}
+
+func fileExists(path string) bool {
+	if _, err := os.Stat(path); err == nil {
+		return true
+	}
+	return false
+}
+
+func downloadBinaryAssetsArchive(ctx context.Context, index *index, version string, out io.Writer) error {
+	archives, ok := index.Releases[version]
+	if !ok {
+		return fmt.Errorf("failed to find envtest binaries for version %s", version)
+	}
+
+	archiveName := fmt.Sprintf("envtest-%s-%s-%s.tar.gz", version, runtime.GOOS, runtime.GOARCH)
+	archive, ok := archives[archiveName]
+	if !ok {
+		return fmt.Errorf("failed to find envtest binaries for version %s with archiveName %s", version, archiveName)
+	}
+
+	archiveURL, err := url.Parse(archive.SelfLink)
+	if err != nil {
+		return fmt.Errorf("failed to parse envtest binaries archive URL %q: %w", archiveURL, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", archiveURL.String(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request to download %s: %w", archiveURL.String(), err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to download %s: %w", archiveURL.String(), err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("failed to download %s, got status %q", archiveURL.String(), resp.Status)
+	}
+
+	return readBody(resp, out, archiveName, archive.Hash)
+}
+
+// latestStableVersionFromIndex returns the version with highest [precedence] in index that is not a prerelease.
+// When either major or minor are not zero, the returned version will have those major and minor versions.
+// Note that the version cannot be limited to 0.0.x this way.
+//
+// It is an error when there is no appropriate version in index.
+//
+// [precedence]: https://semver.org/spec/v2.0.0.html#spec-item-11
+func latestStableVersionFromIndex(index *index, major, minor uint) (string, error) {
+	if len(index.Releases) == 0 {
+		return "", fmt.Errorf("failed to find latest stable version from index: index is empty")
+	}
+
+	var found *version.Version
+	for releaseVersion := range index.Releases {
+		v, err := version.ParseSemantic(releaseVersion)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse version %q: %w", releaseVersion, err)
+		}
+
+		// Filter out pre-releases.
+		if len(v.PreRelease()) > 0 {
+			continue
+		}
+
+		// Filter on release series, if any.
+		if (major != 0 || minor != 0) && (v.Major() != major || v.Minor() != minor) {
+			continue
+		}
+
+		if found == nil || v.GreaterThan(found) {
+			found = v
+		}
+	}
+
+	if found == nil {
+		search := "any"
+		if major != 0 || minor != 0 {
+			search = fmt.Sprint(major, ".", minor)
+		}
+
+		return "", fmt.Errorf("failed to find latest stable version from index: index does not have %s stable versions", search)
+	}
+
+	return "v" + found.String(), nil
+}
+
+func getIndex(ctx context.Context, indexURL string) (*index, error) {
+	loc, err := url.Parse(indexURL)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse index URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", loc.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to construct request to get index: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to perform request to get index: %w", err)
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("unable to get index -- got status %q", resp.Status)
+	}
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get index -- unable to read body %w", err)
+	}
+
+	var index index
+	if err := yaml.Unmarshal(responseBody, &index); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal index: %w", err)
+	}
+	return &index, nil
+}
+
+func readBody(resp *http.Response, out io.Writer, archiveName string, expectedHash string) error {
+	// Stream in chunks to do the checksum
+	buf := make([]byte, 32*1024) // 32KiB, same as io.Copy
+	hasher := sha512.New()
+
+	for cont := true; cont; {
+		amt, err := resp.Body.Read(buf)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("unable read next chunk of %s: %w", archiveName, err)
+		}
+		if amt > 0 {
+			// checksum never returns errors according to docs
+			hasher.Write(buf[:amt])
+			if _, err := out.Write(buf[:amt]); err != nil {
+				return fmt.Errorf("unable write next chunk of %s: %w", archiveName, err)
+			}
+		}
+		cont = amt > 0 && !errors.Is(err, io.EOF)
+	}
+
+	actualHash := hex.EncodeToString(hasher.Sum(nil))
+	if actualHash != expectedHash {
+		return fmt.Errorf("checksum mismatch for %s: %s (computed) != %s (expected)", archiveName, actualHash, expectedHash)
+	}
+
+	return nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/crd.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/crd.go
@@ -1,0 +1,463 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envtest
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
+)
+
+// CRDInstallOptions are the options for installing CRDs.
+type CRDInstallOptions struct {
+	// Scheme is used to determine if conversion webhooks should be enabled
+	// for a particular CRD / object.
+	//
+	// Conversion webhooks are going to be enabled if an object in the scheme
+	// implements Hub and Spoke conversions.
+	//
+	// If nil, scheme.Scheme is used.
+	Scheme *runtime.Scheme
+
+	// Paths is a list of paths to the directories or files containing CRDs
+	Paths []string
+
+	// CRDs is a list of CRDs to install
+	CRDs []*apiextensionsv1.CustomResourceDefinition
+
+	// ErrorIfPathMissing will cause an error if a Path does not exist
+	ErrorIfPathMissing bool
+
+	// MaxTime is the max time to wait
+	MaxTime time.Duration
+
+	// PollInterval is the interval to check
+	PollInterval time.Duration
+
+	// CleanUpAfterUse will cause the CRDs listed for installation to be
+	// uninstalled when terminating the test environment.
+	// Defaults to false.
+	CleanUpAfterUse bool
+
+	// WebhookOptions contains the conversion webhook information to install
+	// on the CRDs. This field is usually inherited by the EnvTest options.
+	//
+	// If you're passing this field manually, you need to make sure that
+	// the CA information and host port is filled in properly.
+	WebhookOptions WebhookInstallOptions
+}
+
+const (
+	defaultPollInterval = 100 * time.Millisecond
+	defaultMaxWait      = 10 * time.Second
+)
+
+// InstallCRDs installs a collection of CRDs into a cluster by reading the crd yaml files from a directory.
+func InstallCRDs(config *rest.Config, options CRDInstallOptions) ([]*apiextensionsv1.CustomResourceDefinition, error) {
+	defaultCRDOptions(&options)
+
+	// Read the CRD yamls into options.CRDs
+	if err := ReadCRDFiles(&options); err != nil {
+		return nil, fmt.Errorf("unable to read CRD files: %w", err)
+	}
+
+	if err := modifyConversionWebhooks(options.CRDs, options.Scheme, options.WebhookOptions); err != nil {
+		return nil, err
+	}
+
+	// Create the CRDs in the apiserver
+	if err := CreateCRDs(config, options.CRDs); err != nil {
+		return options.CRDs, fmt.Errorf("unable to create CRD instances: %w", err)
+	}
+
+	// Wait for the CRDs to appear as Resources in the apiserver
+	if err := WaitForCRDs(config, options.CRDs, options); err != nil {
+		return options.CRDs, fmt.Errorf("something went wrong waiting for CRDs to appear as API resources: %w", err)
+	}
+
+	return options.CRDs, nil
+}
+
+// ReadCRDFiles reads the directories of CRDs in options.Paths and adds the CRD structs to options.CRDs.
+func ReadCRDFiles(options *CRDInstallOptions) error {
+	if len(options.Paths) > 0 {
+		crdList, err := renderCRDs(options)
+		if err != nil {
+			return err
+		}
+
+		options.CRDs = append(options.CRDs, crdList...)
+	}
+	return nil
+}
+
+// defaultCRDOptions sets the default values for CRDs.
+func defaultCRDOptions(o *CRDInstallOptions) {
+	if o.Scheme == nil {
+		o.Scheme = scheme.Scheme
+	}
+	if o.MaxTime == 0 {
+		o.MaxTime = defaultMaxWait
+	}
+	if o.PollInterval == 0 {
+		o.PollInterval = defaultPollInterval
+	}
+}
+
+// WaitForCRDs waits for the CRDs to appear in discovery.
+func WaitForCRDs(config *rest.Config, crds []*apiextensionsv1.CustomResourceDefinition, options CRDInstallOptions) error {
+	// Add each CRD to a map of GroupVersion to Resource
+	waitingFor := map[schema.GroupVersion]*sets.Set[string]{}
+	for _, crd := range crds {
+		gvs := []schema.GroupVersion{}
+		for _, version := range crd.Spec.Versions {
+			if version.Served {
+				gvs = append(gvs, schema.GroupVersion{Group: crd.Spec.Group, Version: version.Name})
+			}
+		}
+
+		for _, gv := range gvs {
+			log.V(1).Info("adding API in waitlist", "GV", gv)
+			if _, found := waitingFor[gv]; !found {
+				// Initialize the set
+				waitingFor[gv] = &sets.Set[string]{}
+			}
+			// Add the Resource
+			waitingFor[gv].Insert(crd.Spec.Names.Plural)
+		}
+	}
+
+	// Poll until all resources are found in discovery
+	p := &poller{config: config, waitingFor: waitingFor}
+	return wait.PollUntilContextTimeout(context.TODO(), options.PollInterval, options.MaxTime, true, p.poll)
+}
+
+// poller checks if all the resources have been found in discovery, and returns false if not.
+type poller struct {
+	// config is used to get discovery
+	config *rest.Config
+
+	// waitingFor is the map of resources keyed by group version that have not yet been found in discovery
+	waitingFor map[schema.GroupVersion]*sets.Set[string]
+}
+
+// poll checks if all the resources have been found in discovery, and returns false if not.
+func (p *poller) poll(ctx context.Context) (done bool, err error) {
+	// Create a new clientset to avoid any client caching of discovery
+	cs, err := clientset.NewForConfig(p.config)
+	if err != nil {
+		return false, err
+	}
+
+	allFound := true
+	for gv, resources := range p.waitingFor {
+		// All resources found, do nothing
+		if resources.Len() == 0 {
+			delete(p.waitingFor, gv)
+			continue
+		}
+
+		// Get the Resources for this GroupVersion
+		// TODO: Maybe the controller-runtime client should be able to do this...
+		resourceList, err := cs.Discovery().ServerResourcesForGroupVersion(gv.Group + "/" + gv.Version)
+		if err != nil {
+			return false, nil //nolint:nilerr
+		}
+
+		// Remove each found resource from the resources set that we are waiting for
+		for _, resource := range resourceList.APIResources {
+			resources.Delete(resource.Name)
+		}
+
+		// Still waiting on some resources in this group version
+		if resources.Len() != 0 {
+			allFound = false
+		}
+	}
+	return allFound, nil
+}
+
+// UninstallCRDs uninstalls a collection of CRDs by reading the crd yaml files from a directory.
+func UninstallCRDs(config *rest.Config, options CRDInstallOptions) error {
+	// Read the CRD yamls into options.CRDs
+	if err := ReadCRDFiles(&options); err != nil {
+		return err
+	}
+
+	// Delete the CRDs from the apiserver
+	cs, err := client.New(config, client.Options{})
+	if err != nil {
+		return err
+	}
+
+	// Uninstall each CRD
+	for _, crd := range options.CRDs {
+		log.V(1).Info("uninstalling CRD", "crd", crd.GetName())
+		if err := cs.Delete(context.TODO(), crd); err != nil {
+			// If CRD is not found, we can consider success
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// CreateCRDs creates the CRDs.
+func CreateCRDs(config *rest.Config, crds []*apiextensionsv1.CustomResourceDefinition) error {
+	cs, err := client.New(config, client.Options{})
+	if err != nil {
+		return fmt.Errorf("unable to create client: %w", err)
+	}
+
+	// Create each CRD
+	for _, crd := range crds {
+		log.V(1).Info("installing CRD", "crd", crd.GetName())
+		existingCrd := crd.DeepCopy()
+		err := cs.Get(context.TODO(), client.ObjectKey{Name: crd.GetName()}, existingCrd)
+		switch {
+		case apierrors.IsNotFound(err):
+			if err := cs.Create(context.TODO(), crd); err != nil {
+				return fmt.Errorf("unable to create CRD %q: %w", crd.GetName(), err)
+			}
+		case err != nil:
+			return fmt.Errorf("unable to get CRD %q to check if it exists: %w", crd.GetName(), err)
+		default:
+			log.V(1).Info("CRD already exists, updating", "crd", crd.GetName())
+			if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				if err := cs.Get(context.TODO(), client.ObjectKey{Name: crd.GetName()}, existingCrd); err != nil {
+					return err
+				}
+				crd.SetResourceVersion(existingCrd.GetResourceVersion())
+				return cs.Update(context.TODO(), crd)
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// renderCRDs iterate through options.Paths and extract all CRD files.
+func renderCRDs(options *CRDInstallOptions) ([]*apiextensionsv1.CustomResourceDefinition, error) {
+	type GVKN struct {
+		GVK  schema.GroupVersionKind
+		Name string
+	}
+
+	crds := map[GVKN]*apiextensionsv1.CustomResourceDefinition{}
+
+	for _, path := range options.Paths {
+		var (
+			err      error
+			info     os.FileInfo
+			files    []string
+			filePath = path
+		)
+
+		// Return the error if ErrorIfPathMissing exists
+		if info, err = os.Stat(path); os.IsNotExist(err) {
+			if options.ErrorIfPathMissing {
+				return nil, err
+			}
+			continue
+		}
+
+		if !info.IsDir() {
+			filePath, files = filepath.Dir(path), []string{info.Name()}
+		} else {
+			entries, err := os.ReadDir(path)
+			if err != nil {
+				return nil, err
+			}
+			for _, e := range entries {
+				files = append(files, e.Name())
+			}
+		}
+
+		log.V(1).Info("reading CRDs from path", "path", path)
+		crdList, err := readCRDs(filePath, files)
+		if err != nil {
+			return nil, err
+		}
+
+		for i, crd := range crdList {
+			gvkn := GVKN{GVK: crd.GroupVersionKind(), Name: crd.GetName()}
+			if _, found := crds[gvkn]; found {
+				// Currently, we only print a log when there are duplicates. We may want to error out if that makes more sense.
+				log.Info("there are more than one CRD definitions with the same <Group, Version, Kind, Name>", "GVKN", gvkn)
+			}
+			// We always use the CRD definition that we found last.
+			crds[gvkn] = crdList[i]
+		}
+	}
+
+	// Converting map to a list to return
+	res := []*apiextensionsv1.CustomResourceDefinition{}
+	for _, obj := range crds {
+		res = append(res, obj)
+	}
+	return res, nil
+}
+
+// modifyConversionWebhooks takes all the registered CustomResourceDefinitions and applies modifications
+// to conditionally enable webhooks if the type is registered within the scheme.
+func modifyConversionWebhooks(crds []*apiextensionsv1.CustomResourceDefinition, scheme *runtime.Scheme, webhookOptions WebhookInstallOptions) error {
+	if len(webhookOptions.LocalServingCAData) == 0 {
+		return nil
+	}
+
+	// Determine all registered convertible types.
+	convertibles := map[schema.GroupKind]struct{}{}
+	for gvk := range scheme.AllKnownTypes() {
+		obj, err := scheme.New(gvk)
+		if err != nil {
+			return err
+		}
+		if ok, err := conversion.IsConvertible(scheme, obj); ok && err == nil {
+			convertibles[gvk.GroupKind()] = struct{}{}
+		}
+	}
+
+	// generate host port.
+	hostPort, err := webhookOptions.generateHostPort()
+	if err != nil {
+		return err
+	}
+	url := ptr.To(fmt.Sprintf("https://%s/convert", hostPort))
+
+	for i := range crds {
+		// Continue if we're preserving unknown fields.
+		if crds[i].Spec.PreserveUnknownFields {
+			continue
+		}
+		if !webhookOptions.IgnoreSchemeConvertible {
+			// Continue if the GroupKind isn't registered as being convertible,
+			// and remove any existing conversion webhooks if they exist.
+			// This is to prevent the CRD from being rejected by the apiserver, usually
+			// manifests that are generated by controller-gen will have a conversion
+			// webhook set, but we don't want to enable it if the type isn't registered.
+			if _, ok := convertibles[schema.GroupKind{
+				Group: crds[i].Spec.Group,
+				Kind:  crds[i].Spec.Names.Kind,
+			}]; !ok {
+				crds[i].Spec.Conversion = nil
+				continue
+			}
+		}
+		if crds[i].Spec.Conversion == nil {
+			crds[i].Spec.Conversion = &apiextensionsv1.CustomResourceConversion{
+				Webhook: &apiextensionsv1.WebhookConversion{},
+			}
+		}
+		crds[i].Spec.Conversion.Strategy = apiextensionsv1.WebhookConverter
+		crds[i].Spec.Conversion.Webhook.ConversionReviewVersions = []string{"v1", "v1beta1"}
+		crds[i].Spec.Conversion.Webhook.ClientConfig = &apiextensionsv1.WebhookClientConfig{
+			Service:  nil,
+			URL:      url,
+			CABundle: webhookOptions.LocalServingCAData,
+		}
+	}
+
+	return nil
+}
+
+// readCRDs reads the CRDs from files and Unmarshals them into structs.
+func readCRDs(basePath string, files []string) ([]*apiextensionsv1.CustomResourceDefinition, error) {
+	var crds []*apiextensionsv1.CustomResourceDefinition
+
+	// White list the file extensions that may contain CRDs
+	crdExts := sets.NewString(".json", ".yaml", ".yml")
+
+	for _, file := range files {
+		// Only parse allowlisted file types
+		if !crdExts.Has(filepath.Ext(file)) {
+			continue
+		}
+
+		// Unmarshal CRDs from file into structs
+		docs, err := readDocuments(filepath.Join(basePath, file))
+		if err != nil {
+			return nil, err
+		}
+
+		for _, doc := range docs {
+			crd := &apiextensionsv1.CustomResourceDefinition{}
+			if err = yaml.Unmarshal(doc, crd); err != nil {
+				return nil, err
+			}
+
+			if crd.Kind != "CustomResourceDefinition" || crd.Spec.Names.Kind == "" || crd.Spec.Group == "" {
+				continue
+			}
+			crds = append(crds, crd)
+		}
+
+		log.V(1).Info("read CRDs from file", "file", file)
+	}
+	return crds, nil
+}
+
+// readDocuments reads documents from file.
+func readDocuments(fp string) ([][]byte, error) {
+	b, err := os.ReadFile(fp)
+	if err != nil {
+		return nil, err
+	}
+
+	docs := [][]byte{}
+	reader := k8syaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(b)))
+	for {
+		// Read document
+		doc, err := reader.Read()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return nil, err
+		}
+
+		docs = append(docs, doc)
+	}
+
+	return docs, nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/doc.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package envtest provides libraries for integration testing by starting a local control plane
+//
+// Control plane binaries (etcd and kube-apiserver) are loaded by default from
+// /usr/local/kubebuilder/bin.  This can be overridden by setting the
+// KUBEBUILDER_ASSETS environment variable, or by directly creating a
+// ControlPlane for the Environment to use.
+//
+// Environment can also be configured to work with an existing cluster, and
+// simply load CRDs and provide client configuration.
+package envtest

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/helper.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/helper.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envtest
+
+import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+var (
+	crdScheme = scheme.Scheme
+)
+
+// init is required to correctly initialize the crdScheme package variable.
+func init() {
+	_ = apiextensionsv1.AddToScheme(crdScheme)
+}
+
+// mergePaths merges two string slices containing paths.
+// This function makes no guarantees about order of the merged slice.
+func mergePaths(s1, s2 []string) []string {
+	m := make(map[string]struct{})
+	for _, s := range s1 {
+		m[s] = struct{}{}
+	}
+	for _, s := range s2 {
+		m[s] = struct{}{}
+	}
+	merged := make([]string, len(m))
+	i := 0
+	for key := range m {
+		merged[i] = key
+		i++
+	}
+	return merged
+}
+
+// mergeCRDs merges two CRD slices using their names.
+// This function makes no guarantees about order of the merged slice.
+func mergeCRDs(s1, s2 []*apiextensionsv1.CustomResourceDefinition) []*apiextensionsv1.CustomResourceDefinition {
+	m := make(map[string]*apiextensionsv1.CustomResourceDefinition)
+	for _, obj := range s1 {
+		m[obj.GetName()] = obj
+	}
+	for _, obj := range s2 {
+		m[obj.GetName()] = obj
+	}
+	merged := make([]*apiextensionsv1.CustomResourceDefinition, len(m))
+	i := 0
+	for _, obj := range m {
+		merged[i] = obj.DeepCopy()
+		i++
+	}
+	return merged
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/server.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/server.go
@@ -1,0 +1,450 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envtest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/controlplane"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/process"
+)
+
+var log = logf.RuntimeLog.WithName("test-env")
+
+/*
+It's possible to override some defaults, by setting the following environment variables:
+* USE_EXISTING_CLUSTER (boolean): if set to true, envtest will use an existing cluster
+* TEST_ASSET_KUBE_APISERVER (string): path to the api-server binary to use
+* TEST_ASSET_ETCD (string): path to the etcd binary to use
+* TEST_ASSET_KUBECTL (string): path to the kubectl binary to use
+* KUBEBUILDER_ASSETS (string): directory containing the binaries to use (api-server, etcd and kubectl). Defaults to /usr/local/kubebuilder/bin.
+* KUBEBUILDER_CONTROLPLANE_START_TIMEOUT (string supported by time.ParseDuration): timeout for test control plane to start. Defaults to 20s.
+* KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT (string supported by time.ParseDuration): timeout for test control plane to start. Defaults to 20s.
+* KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT (boolean): if set to true, the control plane's stdout and stderr are attached to os.Stdout and os.Stderr
+*/
+const (
+	envUseExistingCluster = "USE_EXISTING_CLUSTER"
+	envStartTimeout       = "KUBEBUILDER_CONTROLPLANE_START_TIMEOUT"
+	envStopTimeout        = "KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT"
+	envAttachOutput       = "KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT"
+	StartTimeout          = 60
+	StopTimeout           = 60
+
+	defaultKubebuilderControlPlaneStartTimeout = 20 * time.Second
+	defaultKubebuilderControlPlaneStopTimeout  = 20 * time.Second
+)
+
+// internal types we expose as part of our public API.
+type (
+	// ControlPlane is the re-exported ControlPlane type from the internal testing package.
+	ControlPlane = controlplane.ControlPlane
+
+	// APIServer is the re-exported APIServer from the internal testing package.
+	APIServer = controlplane.APIServer
+
+	// Etcd is the re-exported Etcd from the internal testing package.
+	Etcd = controlplane.Etcd
+
+	// User represents a Kubernetes user to provision for auth purposes.
+	User = controlplane.User
+
+	// AuthenticatedUser represets a Kubernetes user that's been provisioned.
+	AuthenticatedUser = controlplane.AuthenticatedUser
+
+	// ListenAddr indicates the address and port that the API server should listen on.
+	ListenAddr = process.ListenAddr
+
+	// SecureServing contains details describing how the API server should serve
+	// its secure endpoint.
+	SecureServing = controlplane.SecureServing
+
+	// Authn is an authentication method that can be used with the control plane to
+	// provision users.
+	Authn = controlplane.Authn
+
+	// Arguments allows configuring a process's flags.
+	Arguments = process.Arguments
+
+	// Arg is a single flag with one or more values.
+	Arg = process.Arg
+)
+
+var (
+	// EmptyArguments constructs a new set of flags with nothing set.
+	//
+	// This is mostly useful for testing helper methods -- you'll want to call
+	// Configure on the APIServer (or etcd) to configure their arguments.
+	EmptyArguments = process.EmptyArguments
+)
+
+// Environment creates a Kubernetes test environment that will start / stop the Kubernetes control plane and
+// install extension APIs.
+type Environment struct {
+	// ControlPlane is the ControlPlane including the apiserver and etcd.
+	// Binary paths (APIServer.Path, Etcd.Path, KubectlPath) can be pre-configured in ControlPlane.
+	// If DownloadBinaryAssets is true, the downloaded paths will always be used.
+	// If DownloadBinaryAssets is false and paths are not pre-configured (default is empty), they will be
+	// automatically resolved using BinaryAssetsDirectory.
+	ControlPlane controlplane.ControlPlane
+
+	// Scheme is used to determine if conversion webhooks should be enabled
+	// for a particular CRD / object.
+	//
+	// Conversion webhooks are going to be enabled if an object in the scheme
+	// implements Hub and Spoke conversions.
+	//
+	// If nil, scheme.Scheme is used.
+	Scheme *runtime.Scheme
+
+	// Config can be used to talk to the apiserver.  It's automatically
+	// populated if not set using the standard controller-runtime config
+	// loading.
+	Config *rest.Config
+
+	// KubeConfig provides []byte of a kubeconfig file to talk to the apiserver
+	// It's automatically populated if not set based on the `Config`
+	KubeConfig []byte
+
+	// CRDInstallOptions are the options for installing CRDs.
+	CRDInstallOptions CRDInstallOptions
+
+	// WebhookInstallOptions are the options for installing webhooks.
+	WebhookInstallOptions WebhookInstallOptions
+
+	// ErrorIfCRDPathMissing provides an interface for the underlying
+	// CRDInstallOptions.ErrorIfPathMissing. It prevents silent failures
+	// for missing CRD paths.
+	ErrorIfCRDPathMissing bool
+
+	// CRDs is a list of CRDs to install.
+	// If both this field and CRDs field in CRDInstallOptions are specified, the
+	// values are merged.
+	CRDs []*apiextensionsv1.CustomResourceDefinition
+
+	// CRDDirectoryPaths is a list of paths containing CRD yaml or json configs.
+	// If both this field and Paths field in CRDInstallOptions are specified, the
+	// values are merged.
+	CRDDirectoryPaths []string
+
+	// DownloadBinaryAssets indicates that the envtest binaries should be downloaded.
+	// If BinaryAssetsDirectory is also set, it is used to store the downloaded binaries,
+	// otherwise a tmp directory is created.
+	DownloadBinaryAssets bool
+
+	// DownloadBinaryAssetsVersion is the version of envtest binaries to download.
+	// Defaults to the latest stable version (i.e. excluding alpha / beta / RC versions).
+	DownloadBinaryAssetsVersion string
+
+	// DownloadBinaryAssetsIndexURL is the index used to discover envtest binaries to download.
+	// Defaults to https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/HEAD/envtest-releases.yaml.
+	DownloadBinaryAssetsIndexURL string
+
+	// BinaryAssetsDirectory is the path where the binaries required for the envtest are
+	// located in the local environment. This field can be overridden by setting KUBEBUILDER_ASSETS.
+	// Set this field to SetupEnvtestDefaultBinaryAssetsDirectory() to share binaries with setup-envtest.
+	BinaryAssetsDirectory string
+
+	// UseExistingCluster indicates that this environments should use an
+	// existing kubeconfig, instead of trying to stand up a new control plane.
+	// This is useful in cases that need aggregated API servers and the like.
+	UseExistingCluster *bool
+
+	// ControlPlaneStartTimeout is the maximum duration each controlplane component
+	// may take to start. It defaults to the KUBEBUILDER_CONTROLPLANE_START_TIMEOUT
+	// environment variable or 20 seconds if unspecified
+	ControlPlaneStartTimeout time.Duration
+
+	// ControlPlaneStopTimeout is the maximum duration each controlplane component
+	// may take to stop. It defaults to the KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT
+	// environment variable or 20 seconds if unspecified
+	ControlPlaneStopTimeout time.Duration
+
+	// AttachControlPlaneOutput indicates if control plane output will be attached to os.Stdout and os.Stderr.
+	// Enable this to get more visibility of the testing control plane.
+	// It respect KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT environment variable.
+	AttachControlPlaneOutput bool
+}
+
+// Stop stops a running server.
+// Previously installed CRDs, as listed in CRDInstallOptions.CRDs, will be uninstalled
+// if CRDInstallOptions.CleanUpAfterUse are set to true.
+func (te *Environment) Stop() error {
+	if te.CRDInstallOptions.CleanUpAfterUse {
+		if err := UninstallCRDs(te.Config, te.CRDInstallOptions); err != nil {
+			return err
+		}
+	}
+
+	if err := te.WebhookInstallOptions.Cleanup(); err != nil {
+		return err
+	}
+
+	if te.useExistingCluster() {
+		return nil
+	}
+
+	return te.ControlPlane.Stop()
+}
+
+// configureBinaryPaths configures the binary paths for the API server, etcd, and kubectl.
+// If DownloadBinaryAssets is true, it downloads and uses those paths.
+// If DownloadBinaryAssets is false, it only sets paths that are not already configured (empty).
+func (te *Environment) configureBinaryPaths() error {
+	apiServer := te.ControlPlane.GetAPIServer()
+
+	if te.ControlPlane.Etcd == nil {
+		te.ControlPlane.Etcd = &controlplane.Etcd{}
+	}
+
+	if te.DownloadBinaryAssets {
+		apiServerPath, etcdPath, kubectlPath, err := downloadBinaryAssets(context.TODO(),
+			te.BinaryAssetsDirectory, te.DownloadBinaryAssetsVersion, te.DownloadBinaryAssetsIndexURL)
+		if err != nil {
+			return err
+		}
+
+		apiServer.Path = apiServerPath
+		te.ControlPlane.Etcd.Path = etcdPath
+		te.ControlPlane.KubectlPath = kubectlPath
+	} else {
+		if apiServer.Path == "" {
+			apiServer.Path = process.BinPathFinder("kube-apiserver", te.BinaryAssetsDirectory)
+		}
+		if te.ControlPlane.Etcd.Path == "" {
+			te.ControlPlane.Etcd.Path = process.BinPathFinder("etcd", te.BinaryAssetsDirectory)
+		}
+		if te.ControlPlane.KubectlPath == "" {
+			te.ControlPlane.KubectlPath = process.BinPathFinder("kubectl", te.BinaryAssetsDirectory)
+		}
+	}
+	return nil
+}
+
+// Start starts a local Kubernetes server and updates te.ApiserverPort with the port it is listening on.
+func (te *Environment) Start() (*rest.Config, error) {
+	if te.useExistingCluster() {
+		log.V(1).Info("using existing cluster")
+		if te.Config == nil {
+			// we want to allow people to pass in their own config, so
+			// only load a config if it hasn't already been set.
+			log.V(1).Info("automatically acquiring client configuration")
+
+			var err error
+			te.Config, err = config.GetConfig()
+			if err != nil {
+				return nil, fmt.Errorf("unable to get configuration for existing cluster: %w", err)
+			}
+		}
+	} else {
+		apiServer := te.ControlPlane.GetAPIServer()
+
+		if os.Getenv(envAttachOutput) == "true" {
+			te.AttachControlPlaneOutput = true
+		}
+		if te.AttachControlPlaneOutput {
+			if apiServer.Out == nil {
+				apiServer.Out = os.Stdout
+			}
+			if apiServer.Err == nil {
+				apiServer.Err = os.Stderr
+			}
+			if te.ControlPlane.Etcd == nil {
+				te.ControlPlane.Etcd = &controlplane.Etcd{}
+			}
+			if te.ControlPlane.Etcd.Out == nil {
+				te.ControlPlane.Etcd.Out = os.Stdout
+			}
+			if te.ControlPlane.Etcd.Err == nil {
+				te.ControlPlane.Etcd.Err = os.Stderr
+			}
+		}
+
+		if err := te.configureBinaryPaths(); err != nil {
+			return nil, fmt.Errorf("failed to configure binary paths: %w", err)
+		}
+
+		if err := te.defaultTimeouts(); err != nil {
+			return nil, fmt.Errorf("failed to default controlplane timeouts: %w", err)
+		}
+		te.ControlPlane.Etcd.StartTimeout = te.ControlPlaneStartTimeout
+		te.ControlPlane.Etcd.StopTimeout = te.ControlPlaneStopTimeout
+		apiServer.StartTimeout = te.ControlPlaneStartTimeout
+		apiServer.StopTimeout = te.ControlPlaneStopTimeout
+
+		log.V(1).Info("starting control plane")
+		if err := te.startControlPlane(); err != nil {
+			return nil, fmt.Errorf("unable to start control plane itself: %w", err)
+		}
+
+		// Create the *rest.Config for creating new clients
+		baseConfig := &rest.Config{
+			// gotta go fast during tests -- we don't really care about overwhelming our test API server
+			QPS:   1000.0,
+			Burst: 2000.0,
+		}
+
+		adminInfo := User{Name: "admin", Groups: []string{"system:masters"}}
+		adminUser, err := te.ControlPlane.AddUser(adminInfo, baseConfig)
+		if err != nil {
+			return te.Config, fmt.Errorf("unable to provision admin user: %w", err)
+		}
+		te.Config = adminUser.Config()
+	}
+
+	if len(te.KubeConfig) == 0 {
+		var err error
+		te.KubeConfig, err = controlplane.KubeConfigFromREST(te.Config)
+		if err != nil {
+			return nil, fmt.Errorf("unable to set KubeConfig field: %w", err)
+		}
+	}
+
+	// Set the default scheme if nil.
+	if te.Scheme == nil {
+		te.Scheme = scheme.Scheme
+	}
+
+	// If we are bringing etcd up for the first time, it can take some time for the
+	// default namespace to actually be created and seen as available to the apiserver
+	if err := te.waitForDefaultNamespace(te.Config); err != nil {
+		return nil, fmt.Errorf("default namespace didn't register within deadline: %w", err)
+	}
+
+	// Call PrepWithoutInstalling to setup certificates first
+	// and have them available to patch CRD conversion webhook as well.
+	if err := te.WebhookInstallOptions.PrepWithoutInstalling(); err != nil {
+		return nil, err
+	}
+
+	log.V(1).Info("installing CRDs")
+	if te.CRDInstallOptions.Scheme == nil {
+		te.CRDInstallOptions.Scheme = te.Scheme
+	}
+	te.CRDInstallOptions.CRDs = mergeCRDs(te.CRDInstallOptions.CRDs, te.CRDs)
+	te.CRDInstallOptions.Paths = mergePaths(te.CRDInstallOptions.Paths, te.CRDDirectoryPaths)
+	te.CRDInstallOptions.ErrorIfPathMissing = te.ErrorIfCRDPathMissing
+	te.CRDInstallOptions.WebhookOptions = te.WebhookInstallOptions
+	crds, err := InstallCRDs(te.Config, te.CRDInstallOptions)
+	if err != nil {
+		return te.Config, fmt.Errorf("unable to install CRDs onto control plane: %w", err)
+	}
+	te.CRDs = crds
+
+	log.V(1).Info("installing webhooks")
+	if err := te.WebhookInstallOptions.Install(te.Config); err != nil {
+		return nil, fmt.Errorf("unable to install webhooks onto control plane: %w", err)
+	}
+	return te.Config, nil
+}
+
+// AddUser provisions a new user for connecting to this Environment.  The user will
+// have the specified name & belong to the specified groups.
+//
+// If you specify a "base" config, the returned REST Config will contain those
+// settings as well as any required by the authentication method.  You can use
+// this to easily specify options like QPS.
+//
+// This is effectively a convinience alias for ControlPlane.AddUser -- see that
+// for more low-level details.
+func (te *Environment) AddUser(user User, baseConfig *rest.Config) (*AuthenticatedUser, error) {
+	return te.ControlPlane.AddUser(user, baseConfig)
+}
+
+func (te *Environment) startControlPlane() error {
+	numTries, maxRetries := 0, 5
+	var err error
+	for ; numTries < maxRetries; numTries++ {
+		// Start the control plane - retry if it fails
+		err = te.ControlPlane.Start()
+		if err == nil {
+			break
+		}
+		log.Error(err, "unable to start the controlplane", "tries", numTries)
+	}
+	if numTries == maxRetries {
+		return fmt.Errorf("failed to start the controlplane. retried %d times: %w", numTries, err)
+	}
+	return nil
+}
+
+func (te *Environment) waitForDefaultNamespace(config *rest.Config) error {
+	cs, err := client.New(config, client.Options{})
+	if err != nil {
+		return fmt.Errorf("unable to create client: %w", err)
+	}
+	// It shouldn't take longer than 5s for the default namespace to be brought up in etcd
+	return wait.PollUntilContextTimeout(context.TODO(), time.Millisecond*50, time.Second*5, true, func(ctx context.Context) (bool, error) {
+		if err = cs.Get(ctx, types.NamespacedName{Name: "default"}, &corev1.Namespace{}); err != nil {
+			return false, nil //nolint:nilerr
+		}
+		return true, nil
+	})
+}
+
+func (te *Environment) defaultTimeouts() error {
+	var err error
+	if te.ControlPlaneStartTimeout == 0 {
+		if envVal := os.Getenv(envStartTimeout); envVal != "" {
+			te.ControlPlaneStartTimeout, err = time.ParseDuration(envVal)
+			if err != nil {
+				return err
+			}
+		} else {
+			te.ControlPlaneStartTimeout = defaultKubebuilderControlPlaneStartTimeout
+		}
+	}
+
+	if te.ControlPlaneStopTimeout == 0 {
+		if envVal := os.Getenv(envStopTimeout); envVal != "" {
+			te.ControlPlaneStopTimeout, err = time.ParseDuration(envVal)
+			if err != nil {
+				return err
+			}
+		} else {
+			te.ControlPlaneStopTimeout = defaultKubebuilderControlPlaneStopTimeout
+		}
+	}
+	return nil
+}
+
+func (te *Environment) useExistingCluster() bool {
+	if te.UseExistingCluster == nil {
+		return strings.ToLower(os.Getenv(envUseExistingCluster)) == "true"
+	}
+	return *te.UseExistingCluster
+}
+
+// DefaultKubeAPIServerFlags exposes the default args for the APIServer so that
+// you can use those to append your own additional arguments.
+//
+// Deprecated: use APIServer.Configure() instead.
+var DefaultKubeAPIServerFlags = controlplane.APIServerDefaultArgs //nolint:staticcheck

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/webhook.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/webhook.go
@@ -1,0 +1,449 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envtest
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/yaml"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/addr"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/certs"
+)
+
+// WebhookInstallOptions are the options for installing mutating or validating webhooks.
+type WebhookInstallOptions struct {
+	// Paths is a list of paths to the directories or files containing the mutating or validating webhooks yaml or json configs.
+	Paths []string
+
+	// MutatingWebhooks is a list of MutatingWebhookConfigurations to install
+	MutatingWebhooks []*admissionv1.MutatingWebhookConfiguration
+
+	// ValidatingWebhooks is a list of ValidatingWebhookConfigurations to install
+	ValidatingWebhooks []*admissionv1.ValidatingWebhookConfiguration
+
+	// IgnoreSchemeConvertible, will modify any CRD conversion webhook to use the local serving host and port,
+	// bypassing the need to have the types registered in the Scheme. This is useful for testing CRD conversion webhooks
+	// with unregistered or unstructured types.
+	IgnoreSchemeConvertible bool
+
+	// IgnoreErrorIfPathMissing will ignore an error if a DirectoryPath does not exist when set to true
+	IgnoreErrorIfPathMissing bool
+
+	// LocalServingHost is the host for serving webhooks on.
+	// it will be automatically populated
+	LocalServingHost string
+
+	// LocalServingPort is the allocated port for serving webhooks on.
+	// it will be automatically populated by a random available local port
+	LocalServingPort int
+
+	// LocalServingCertDir is the allocated directory for serving certificates.
+	// it will be automatically populated by the local temp dir
+	LocalServingCertDir string
+
+	// CAData is the CA that can be used to trust the serving certificates in LocalServingCertDir.
+	LocalServingCAData []byte
+
+	// LocalServingHostExternalName is the hostname to use to reach the webhook server.
+	LocalServingHostExternalName string
+
+	// MaxTime is the max time to wait
+	MaxTime time.Duration
+
+	// PollInterval is the interval to check
+	PollInterval time.Duration
+}
+
+// ModifyWebhookDefinitions modifies webhook definitions by:
+// - applying CABundle based on the provided tinyca
+// - if webhook client config uses service spec, it's removed and replaced with direct url.
+func (o *WebhookInstallOptions) ModifyWebhookDefinitions() error {
+	caData := o.LocalServingCAData
+
+	// generate host port.
+	hostPort, err := o.generateHostPort()
+	if err != nil {
+		return err
+	}
+
+	for i := range o.MutatingWebhooks {
+		for j := range o.MutatingWebhooks[i].Webhooks {
+			updateClientConfig(&o.MutatingWebhooks[i].Webhooks[j].ClientConfig, hostPort, caData)
+		}
+	}
+
+	for i := range o.ValidatingWebhooks {
+		for j := range o.ValidatingWebhooks[i].Webhooks {
+			updateClientConfig(&o.ValidatingWebhooks[i].Webhooks[j].ClientConfig, hostPort, caData)
+		}
+	}
+	return nil
+}
+
+func updateClientConfig(cc *admissionv1.WebhookClientConfig, hostPort string, caData []byte) {
+	cc.CABundle = caData
+	if cc.Service != nil && cc.Service.Path != nil {
+		url := fmt.Sprintf("https://%s/%s", hostPort, *cc.Service.Path)
+		cc.URL = &url
+		cc.Service = nil
+	}
+}
+
+func (o *WebhookInstallOptions) generateHostPort() (string, error) {
+	if o.LocalServingPort == 0 {
+		port, host, err := addr.Suggest(o.LocalServingHost)
+		if err != nil {
+			return "", fmt.Errorf("unable to grab random port for serving webhooks on: %w", err)
+		}
+		o.LocalServingPort = port
+		o.LocalServingHost = host
+	}
+	host := o.LocalServingHostExternalName
+	if host == "" {
+		host = o.LocalServingHost
+	}
+	return net.JoinHostPort(host, fmt.Sprintf("%d", o.LocalServingPort)), nil
+}
+
+// PrepWithoutInstalling does the setup parts of Install (populating host-port,
+// setting up CAs, etc), without actually truing to do anything with webhook
+// definitions.  This is largely useful for internal testing of
+// controller-runtime, where we need a random host-port & caData for webhook
+// tests, but may be useful in similar scenarios.
+func (o *WebhookInstallOptions) PrepWithoutInstalling() error {
+	if err := o.setupCA(); err != nil {
+		return err
+	}
+
+	if err := parseWebhook(o); err != nil {
+		return err
+	}
+
+	return o.ModifyWebhookDefinitions()
+}
+
+// Install installs specified webhooks to the API server.
+func (o *WebhookInstallOptions) Install(config *rest.Config) error {
+	defaultWebhookOptions(o)
+
+	if len(o.LocalServingCAData) == 0 {
+		if err := o.PrepWithoutInstalling(); err != nil {
+			return err
+		}
+	}
+
+	if err := createWebhooks(config, o.MutatingWebhooks, o.ValidatingWebhooks); err != nil {
+		return err
+	}
+
+	return WaitForWebhooks(config, o.MutatingWebhooks, o.ValidatingWebhooks, *o)
+}
+
+// Cleanup cleans up cert directories.
+func (o *WebhookInstallOptions) Cleanup() error {
+	if o.LocalServingCertDir != "" {
+		return os.RemoveAll(o.LocalServingCertDir)
+	}
+	return nil
+}
+
+// defaultWebhookOptions sets the default values for Webhooks.
+func defaultWebhookOptions(o *WebhookInstallOptions) {
+	if o.MaxTime == 0 {
+		o.MaxTime = defaultMaxWait
+	}
+	if o.PollInterval == 0 {
+		o.PollInterval = defaultPollInterval
+	}
+}
+
+// WaitForWebhooks waits for the Webhooks to be available through API server.
+func WaitForWebhooks(config *rest.Config,
+	mutatingWebhooks []*admissionv1.MutatingWebhookConfiguration,
+	validatingWebhooks []*admissionv1.ValidatingWebhookConfiguration,
+	options WebhookInstallOptions,
+) error {
+	waitingFor := map[schema.GroupVersionKind]*sets.Set[string]{}
+
+	for _, hook := range mutatingWebhooks {
+		h := hook
+		gvk, err := apiutil.GVKForObject(h, scheme.Scheme)
+		if err != nil {
+			return fmt.Errorf("unable to get gvk for MutatingWebhookConfiguration %s: %w", hook.GetName(), err)
+		}
+
+		if _, ok := waitingFor[gvk]; !ok {
+			waitingFor[gvk] = &sets.Set[string]{}
+		}
+		waitingFor[gvk].Insert(h.GetName())
+	}
+
+	for _, hook := range validatingWebhooks {
+		h := hook
+		gvk, err := apiutil.GVKForObject(h, scheme.Scheme)
+		if err != nil {
+			return fmt.Errorf("unable to get gvk for ValidatingWebhookConfiguration %s: %w", hook.GetName(), err)
+		}
+
+		if _, ok := waitingFor[gvk]; !ok {
+			waitingFor[gvk] = &sets.Set[string]{}
+		}
+		waitingFor[gvk].Insert(hook.GetName())
+	}
+
+	// Poll until all resources are found in discovery
+	p := &webhookPoller{config: config, waitingFor: waitingFor}
+	return wait.PollUntilContextTimeout(context.TODO(), options.PollInterval, options.MaxTime, true, p.poll)
+}
+
+// poller checks if all the resources have been found in discovery, and returns false if not.
+type webhookPoller struct {
+	// config is used to get discovery
+	config *rest.Config
+
+	// waitingFor is the map of resources keyed by group version that have not yet been found in discovery
+	waitingFor map[schema.GroupVersionKind]*sets.Set[string]
+}
+
+// poll checks if all the resources have been found in discovery, and returns false if not.
+func (p *webhookPoller) poll(ctx context.Context) (done bool, err error) {
+	// Create a new clientset to avoid any client caching of discovery
+	c, err := client.New(p.config, client.Options{})
+	if err != nil {
+		return false, err
+	}
+
+	allFound := true
+	for gvk, names := range p.waitingFor {
+		if names.Len() == 0 {
+			delete(p.waitingFor, gvk)
+			continue
+		}
+		for _, name := range names.UnsortedList() {
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(gvk)
+			err := c.Get(context.Background(), client.ObjectKey{
+				Namespace: "",
+				Name:      name,
+			}, obj)
+
+			if err == nil {
+				names.Delete(name)
+			}
+
+			if apierrors.IsNotFound(err) {
+				allFound = false
+			}
+			if err != nil {
+				return false, err
+			}
+		}
+	}
+	return allFound, nil
+}
+
+// setupCA creates CA for testing and writes them to disk.
+func (o *WebhookInstallOptions) setupCA() error {
+	hookCA, err := certs.NewTinyCA()
+	if err != nil {
+		return fmt.Errorf("unable to set up webhook CA: %w", err)
+	}
+
+	names := []string{"localhost", o.LocalServingHost, o.LocalServingHostExternalName}
+	hookCert, err := hookCA.NewServingCert(names...)
+	if err != nil {
+		return fmt.Errorf("unable to set up webhook serving certs: %w", err)
+	}
+
+	localServingCertsDir, err := os.MkdirTemp("", "envtest-serving-certs-")
+	o.LocalServingCertDir = localServingCertsDir
+	if err != nil {
+		return fmt.Errorf("unable to create directory for webhook serving certs: %w", err)
+	}
+
+	certData, keyData, err := hookCert.AsBytes()
+	if err != nil {
+		return fmt.Errorf("unable to marshal webhook serving certs: %w", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(localServingCertsDir, "tls.crt"), certData, 0640); err != nil {
+		return fmt.Errorf("unable to write webhook serving cert to disk: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(localServingCertsDir, "tls.key"), keyData, 0640); err != nil {
+		return fmt.Errorf("unable to write webhook serving key to disk: %w", err)
+	}
+
+	o.LocalServingCAData = certData
+	return err
+}
+
+func createWebhooks(config *rest.Config, mutHooks []*admissionv1.MutatingWebhookConfiguration, valHooks []*admissionv1.ValidatingWebhookConfiguration) error {
+	cs, err := client.New(config, client.Options{})
+	if err != nil {
+		return err
+	}
+
+	// Create each webhook
+	for _, hook := range mutHooks {
+		log.V(1).Info("installing mutating webhook", "webhook", hook.GetName())
+		if err := ensureCreated(cs, hook); err != nil {
+			return err
+		}
+	}
+	for _, hook := range valHooks {
+		log.V(1).Info("installing validating webhook", "webhook", hook.GetName())
+		if err := ensureCreated(cs, hook); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ensureCreated creates or update object if already exists in the cluster.
+func ensureCreated(cs client.Client, obj client.Object) error {
+	existing := obj.DeepCopyObject().(client.Object)
+	err := cs.Get(context.Background(), client.ObjectKey{Name: obj.GetName()}, existing)
+	switch {
+	case apierrors.IsNotFound(err):
+		if err := cs.Create(context.Background(), obj); err != nil {
+			return err
+		}
+	case err != nil:
+		return err
+	default:
+		log.V(1).Info("Webhook configuration already exists, updating", "webhook", obj.GetName())
+		obj.SetResourceVersion(existing.GetResourceVersion())
+		if err := cs.Update(context.Background(), obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// parseWebhook reads the directories or files of Webhooks in options.Paths and adds the Webhook structs to options.
+func parseWebhook(options *WebhookInstallOptions) error {
+	if len(options.Paths) > 0 {
+		for _, path := range options.Paths {
+			_, err := os.Stat(path)
+			if options.IgnoreErrorIfPathMissing && os.IsNotExist(err) {
+				continue // skip this path
+			}
+			if !options.IgnoreErrorIfPathMissing && os.IsNotExist(err) {
+				return err // treat missing path as error
+			}
+			mutHooks, valHooks, err := readWebhooks(path)
+			if err != nil {
+				return err
+			}
+			options.MutatingWebhooks = append(options.MutatingWebhooks, mutHooks...)
+			options.ValidatingWebhooks = append(options.ValidatingWebhooks, valHooks...)
+		}
+	}
+	return nil
+}
+
+// readWebhooks reads the Webhooks from files and Unmarshals them into structs
+// returns slice of mutating and validating webhook configurations.
+func readWebhooks(path string) ([]*admissionv1.MutatingWebhookConfiguration, []*admissionv1.ValidatingWebhookConfiguration, error) {
+	// Get the webhook files
+	var files []string
+	var err error
+	log.V(1).Info("reading Webhooks from path", "path", path)
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !info.IsDir() {
+		path, files = filepath.Dir(path), []string{info.Name()}
+	} else {
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, e := range entries {
+			files = append(files, e.Name())
+		}
+	}
+
+	// file extensions that may contain Webhooks
+	resourceExtensions := sets.NewString(".json", ".yaml", ".yml")
+
+	var mutHooks []*admissionv1.MutatingWebhookConfiguration
+	var valHooks []*admissionv1.ValidatingWebhookConfiguration
+	for _, file := range files {
+		// Only parse allowlisted file types
+		if !resourceExtensions.Has(filepath.Ext(file)) {
+			continue
+		}
+
+		// Unmarshal Webhooks from file into structs
+		docs, err := readDocuments(filepath.Join(path, file))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		for _, doc := range docs {
+			var generic metav1.PartialObjectMetadata
+			if err = yaml.Unmarshal(doc, &generic); err != nil {
+				return nil, nil, err
+			}
+
+			const (
+				admissionregv1 = "admissionregistration.k8s.io/v1"
+			)
+			switch generic.Kind {
+			case "MutatingWebhookConfiguration":
+				if generic.APIVersion != admissionregv1 {
+					return nil, nil, fmt.Errorf("only v1 is supported right now for MutatingWebhookConfiguration (name: %s)", generic.Name)
+				}
+				hook := &admissionv1.MutatingWebhookConfiguration{}
+				if err := yaml.Unmarshal(doc, hook); err != nil {
+					return nil, nil, err
+				}
+				mutHooks = append(mutHooks, hook)
+			case "ValidatingWebhookConfiguration":
+				if generic.APIVersion != admissionregv1 {
+					return nil, nil, fmt.Errorf("only v1 is supported right now for ValidatingWebhookConfiguration (name: %s)", generic.Name)
+				}
+				hook := &admissionv1.ValidatingWebhookConfiguration{}
+				if err := yaml.Unmarshal(doc, hook); err != nil {
+					return nil, nil, err
+				}
+				valHooks = append(valHooks, hook)
+			default:
+				continue
+			}
+		}
+
+		log.V(1).Info("read webhooks from file", "file", file)
+	}
+	return mutHooks, valHooks, nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/flock/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/flock/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package flock is copied from k8s.io/kubernetes/pkg/util/flock to avoid
+// importing k8s.io/kubernetes as a dependency.
+//
+// Provides file locking functionalities on unix systems.
+package flock

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/flock/errors.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/flock/errors.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flock
+
+import "errors"
+
+var (
+	// ErrAlreadyLocked is returned when the file is already locked.
+	ErrAlreadyLocked = errors.New("the file is already locked")
+)

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/flock/flock_other.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/flock/flock_other.go
@@ -1,0 +1,24 @@
+//go:build !linux && !darwin && !freebsd && !openbsd && !netbsd && !dragonfly
+
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flock
+
+// Acquire is not implemented on non-unix systems.
+func Acquire(path string) error {
+	return nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/flock/flock_unix.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/flock/flock_unix.go
@@ -1,0 +1,47 @@
+//go:build linux || darwin || freebsd || openbsd || netbsd || dragonfly
+
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// Acquire acquires a lock on a file for the duration of the process. This method
+// is reentrant.
+func Acquire(path string) error {
+	fd, err := unix.Open(path, unix.O_CREAT|unix.O_RDWR|unix.O_CLOEXEC, 0600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("cannot lock file %q: %w", path, ErrAlreadyLocked)
+		}
+		return err
+	}
+
+	// We don't need to close the fd since we should hold
+	// it until the process exits.
+	err = unix.Flock(fd, unix.LOCK_NB|unix.LOCK_EX)
+	if errors.Is(err, unix.EWOULDBLOCK) { // This condition requires LOCK_NB.
+		return fmt.Errorf("cannot lock file %q: %w", path, ErrAlreadyLocked)
+	}
+	return err
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/addr/manager.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/addr/manager.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addr
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/internal/flock"
+)
+
+// TODO(directxman12): interface / release functionality for external port managers
+
+const (
+	portReserveTime   = 2 * time.Minute
+	portConflictRetry = 100
+	portFilePrefix    = "port-"
+)
+
+var (
+	cacheDir string
+)
+
+func init() {
+	baseDir, err := os.UserCacheDir()
+	if err == nil {
+		cacheDir = filepath.Join(baseDir, "kubebuilder-envtest")
+		err = os.MkdirAll(cacheDir, 0o750)
+	}
+	if err != nil {
+		// Either we didn't get a cache directory, or we can't use it
+		baseDir = os.TempDir()
+		cacheDir = filepath.Join(baseDir, "kubebuilder-envtest")
+		err = os.MkdirAll(cacheDir, 0o750)
+	}
+	if err != nil {
+		panic(err)
+	}
+}
+
+type portCache struct{}
+
+func (c *portCache) add(port int) (bool, error) {
+	// Remove outdated ports.
+	if err := fs.WalkDir(os.DirFS(cacheDir), ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !d.Type().IsRegular() || !strings.HasPrefix(path, portFilePrefix) {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			// No-op if file no longer exists; may have been deleted by another
+			// process/thread trying to allocate ports.
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		if time.Since(info.ModTime()) > portReserveTime {
+			if err := os.Remove(filepath.Join(cacheDir, path)); err != nil {
+				// No-op if file no longer exists; may have been deleted by another
+				// process/thread trying to allocate ports.
+				if os.IsNotExist(err) {
+					return nil
+				}
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return false, err
+	}
+	// Try allocating new port, by acquiring a file.
+	path := fmt.Sprintf("%s/%s%d", cacheDir, portFilePrefix, port)
+	if err := flock.Acquire(path); errors.Is(err, flock.ErrAlreadyLocked) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+var cache = &portCache{}
+
+func suggest(listenHost string) (*net.TCPListener, int, string, error) {
+	if listenHost == "" {
+		listenHost = "localhost"
+	}
+	addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(listenHost, "0"))
+	if err != nil {
+		return nil, -1, "", err
+	}
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return nil, -1, "", err
+	}
+	return l, l.Addr().(*net.TCPAddr).Port,
+		addr.IP.String(),
+		nil
+}
+
+// Suggest suggests an address a process can listen on. It returns
+// a tuple consisting of a free port and the hostname resolved to its IP.
+// It makes sure that new port allocated does not conflict with old ports
+// allocated within 2 minute.
+func Suggest(listenHost string) (int, string, error) {
+	for range portConflictRetry {
+		listener, port, resolvedHost, err := suggest(listenHost)
+		if err != nil {
+			return -1, "", err
+		}
+		if err := listener.Close(); err != nil {
+			return -1, "", err
+		}
+		if ok, err := cache.add(port); ok {
+			return port, resolvedHost, nil
+		} else if err != nil {
+			return -1, "", err
+		}
+	}
+	return -1, "", fmt.Errorf("no free ports found after %d retries", portConflictRetry)
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/certs/tinyca.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/certs/tinyca.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certs
+
+// NB(directxman12): nothing has verified that this has good settings.  In fact,
+// the setting generated here are probably terrible, but they're fine for integration
+// tests.  These ABSOLUTELY SHOULD NOT ever be exposed in the public API.  They're
+// ONLY for use with envtest's ability to configure webhook testing.
+// If I didn't otherwise not want to add a dependency on cfssl, I'd just use that.
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	crand "crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+
+	certutil "k8s.io/client-go/util/cert"
+)
+
+var (
+	ellipticCurve = elliptic.P256()
+	bigOne        = big.NewInt(1)
+)
+
+// CertPair is a private key and certificate for use for client auth, as a CA, or serving.
+type CertPair struct {
+	Key  crypto.Signer
+	Cert *x509.Certificate
+}
+
+// CertBytes returns the PEM-encoded version of the certificate for this pair.
+func (k CertPair) CertBytes() []byte {
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: k.Cert.Raw,
+	})
+}
+
+// AsBytes encodes keypair in the appropriate formats for on-disk storage (PEM and
+// PKCS8, respectively).
+func (k CertPair) AsBytes() (cert []byte, key []byte, err error) {
+	cert = k.CertBytes()
+
+	rawKeyData, err := x509.MarshalPKCS8PrivateKey(k.Key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to encode private key: %w", err)
+	}
+
+	key = pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: rawKeyData,
+	})
+
+	return cert, key, nil
+}
+
+// TinyCA supports signing serving certs and client-certs,
+// and can be used as an auth mechanism with envtest.
+type TinyCA struct {
+	CA      CertPair
+	orgName string
+
+	nextSerial *big.Int
+}
+
+// newPrivateKey generates a new private key of a relatively sane size (see
+// rsaKeySize).
+func newPrivateKey() (crypto.Signer, error) {
+	return ecdsa.GenerateKey(ellipticCurve, crand.Reader)
+}
+
+// NewTinyCA creates a new a tiny CA utility for provisioning serving certs and client certs FOR TESTING ONLY.
+// Don't use this for anything else!
+func NewTinyCA() (*TinyCA, error) {
+	caPrivateKey, err := newPrivateKey()
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate private key for CA: %w", err)
+	}
+	caCfg := certutil.Config{CommonName: "envtest-environment", Organization: []string{"envtest"}}
+	caCert, err := certutil.NewSelfSignedCACert(caCfg, caPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate certificate for CA: %w", err)
+	}
+
+	return &TinyCA{
+		CA:         CertPair{Key: caPrivateKey, Cert: caCert},
+		orgName:    "envtest",
+		nextSerial: big.NewInt(1),
+	}, nil
+}
+
+func (c *TinyCA) makeCert(cfg certutil.Config) (CertPair, error) {
+	now := time.Now()
+
+	key, err := newPrivateKey()
+	if err != nil {
+		return CertPair{}, fmt.Errorf("unable to create private key: %w", err)
+	}
+
+	serial := new(big.Int).Set(c.nextSerial)
+	c.nextSerial.Add(c.nextSerial, bigOne)
+
+	template := x509.Certificate{
+		Subject:      pkix.Name{CommonName: cfg.CommonName, Organization: cfg.Organization},
+		DNSNames:     cfg.AltNames.DNSNames,
+		IPAddresses:  cfg.AltNames.IPs,
+		SerialNumber: serial,
+
+		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: cfg.Usages,
+
+		// technically not necessary for testing, but let's set anyway just in case.
+		NotBefore: now.UTC(),
+		// 1 week -- the default for cfssl, and just long enough for a
+		// long-term test, but not too long that anyone would try to use this
+		// seriously.
+		NotAfter: now.Add(168 * time.Hour).UTC(),
+	}
+
+	certRaw, err := x509.CreateCertificate(crand.Reader, &template, c.CA.Cert, key.Public(), c.CA.Key)
+	if err != nil {
+		return CertPair{}, fmt.Errorf("unable to create certificate: %w", err)
+	}
+
+	cert, err := x509.ParseCertificate(certRaw)
+	if err != nil {
+		return CertPair{}, fmt.Errorf("generated invalid certificate, could not parse: %w", err)
+	}
+
+	return CertPair{
+		Key:  key,
+		Cert: cert,
+	}, nil
+}
+
+// NewServingCert returns a new CertPair for a serving HTTPS on localhost (or other specified names).
+func (c *TinyCA) NewServingCert(names ...string) (CertPair, error) {
+	if len(names) == 0 {
+		names = []string{"localhost"}
+	}
+	dnsNames, ips, err := resolveNames(names)
+	if err != nil {
+		return CertPair{}, err
+	}
+
+	return c.makeCert(certutil.Config{
+		CommonName:   "localhost",
+		Organization: []string{c.orgName},
+		AltNames: certutil.AltNames{
+			DNSNames: dnsNames,
+			IPs:      ips,
+		},
+		Usages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+}
+
+// ClientInfo describes some Kubernetes user for the purposes of creating
+// client certificates.
+type ClientInfo struct {
+	// Name is the user name (embedded as the cert's CommonName)
+	Name string
+	// Groups are the groups to which this user belongs (embedded as the cert's
+	// Organization)
+	Groups []string
+}
+
+// NewClientCert produces a new CertPair suitable for use with Kubernetes
+// client cert auth with an API server validating based on this CA.
+func (c *TinyCA) NewClientCert(user ClientInfo) (CertPair, error) {
+	return c.makeCert(certutil.Config{
+		CommonName:   user.Name,
+		Organization: user.Groups,
+		Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+}
+
+func resolveNames(names []string) ([]string, []net.IP, error) {
+	dnsNames := []string{}
+	ips := []net.IP{}
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		ip := net.ParseIP(name)
+		if ip == nil {
+			dnsNames = append(dnsNames, name)
+			// Also resolve to IPs.
+			nameIPs, err := net.LookupHost(name)
+			if err != nil {
+				return nil, nil, err
+			}
+			for _, nameIP := range nameIPs {
+				ip = net.ParseIP(nameIP)
+				if ip != nil {
+					ips = append(ips, ip)
+				}
+			}
+		} else {
+			ips = append(ips, ip)
+		}
+	}
+	return dnsNames, ips, nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/controlplane/apiserver.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/controlplane/apiserver.go
@@ -1,0 +1,476 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/addr"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/certs"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/process"
+)
+
+const (
+	// saKeyFile is the name of the service account signing private key file.
+	saKeyFile = "sa-signer.key"
+	// saKeyFile is the name of the service account signing public key (cert) file.
+	saCertFile = "sa-signer.crt"
+)
+
+// SecureServing provides/configures how the API server serves on the secure port.
+type SecureServing struct {
+	// ListenAddr contains the host & port to serve on.
+	//
+	// Configurable.  If unset, it will be defaulted.
+	process.ListenAddr
+	// CA contains the CA that signed the API server's serving certificates.
+	//
+	// Read-only.
+	CA []byte
+	// Authn can be used to provision users, and override what type of
+	// authentication is used to provision users.
+	//
+	// Configurable.  If unset, it will be defaulted.
+	Authn
+}
+
+// APIServer knows how to run a kubernetes apiserver.
+type APIServer struct {
+	// URL is the address the ApiServer should listen on for client
+	// connections.
+	//
+	// If set, this will configure the *insecure* serving details.
+	// If unset, it will contain the insecure port if insecure serving is enabled,
+	// and otherwise will contain the secure port.
+	//
+	// If this is not specified, we default to a random free port on localhost.
+	//
+	// Deprecated: use InsecureServing (for the insecure URL) or SecureServing, ideally.
+	URL *url.URL
+
+	// SecurePort is the additional secure port that the APIServer should listen on.
+	//
+	// If set, this will override SecureServing.Port.
+	//
+	// Deprecated: use SecureServing.
+	SecurePort int
+
+	// SecureServing indicates how the API server will serve on the secure port.
+	//
+	// Some parts are configurable.  Will be defaulted if unset.
+	SecureServing
+
+	// InsecureServing indicates how the API server will serve on the insecure port.
+	//
+	// If unset, the insecure port will be disabled.  Set to an empty struct to get
+	// default values.
+	//
+	// Deprecated: does not work with Kubernetes versions 1.20 and above.  Use secure
+	// serving instead.
+	InsecureServing *process.ListenAddr
+
+	// Path is the path to the apiserver binary.
+	//
+	// If this is left as the empty string, we will attempt to locate a binary,
+	// by checking for the TEST_ASSET_KUBE_APISERVER environment variable, and
+	// the default test assets directory. See the "Binaries" section above (in
+	// doc.go) for details.
+	Path string
+
+	// Args is a list of arguments which will passed to the APIServer binary.
+	// Before they are passed on, they will be evaluated as go-template strings.
+	// This means you can use fields which are defined and exported on this
+	// APIServer struct (e.g. "--cert-dir={{ .Dir }}").
+	// Those templates will be evaluated after the defaulting of the APIServer's
+	// fields has already happened and just before the binary actually gets
+	// started. Thus you have access to calculated fields like `URL` and others.
+	//
+	// If not specified, the minimal set of arguments to run the APIServer will
+	// be used.
+	//
+	// They will be loaded into the same argument set as Configure.  Each flag
+	// will be Append-ed to the configured arguments just before launch.
+	//
+	// Deprecated: use Configure instead.
+	Args []string
+
+	// CertDir is a path to a directory containing whatever certificates the
+	// APIServer will need.
+	//
+	// If left unspecified, then the Start() method will create a fresh temporary
+	// directory, and the Stop() method will clean it up.
+	CertDir string
+
+	// EtcdURL is the URL of the Etcd the APIServer should use.
+	//
+	// If this is not specified, the Start() method will return an error.
+	EtcdURL *url.URL
+
+	// StartTimeout, StopTimeout specify the time the APIServer is allowed to
+	// take when starting and stoppping before an error is emitted.
+	//
+	// If not specified, these default to 20 seconds.
+	StartTimeout time.Duration
+	StopTimeout  time.Duration
+
+	// Out, Err specify where APIServer should write its StdOut, StdErr to.
+	//
+	// If not specified, the output will be discarded.
+	Out io.Writer
+	Err io.Writer
+
+	processState *process.State
+
+	// args contains the structured arguments to use for running the API server
+	// Lazily initialized by .Configure(), Defaulted eventually with .defaultArgs()
+	args *process.Arguments
+}
+
+// Configure returns Arguments that may be used to customize the
+// flags used to launch the API server.  A set of defaults will
+// be applied underneath.
+func (s *APIServer) Configure() *process.Arguments {
+	if s.args == nil {
+		s.args = process.EmptyArguments()
+	}
+	return s.args
+}
+
+// Start starts the apiserver, waits for it to come up, and returns an error,
+// if occurred.
+func (s *APIServer) Start() error {
+	if err := s.prepare(); err != nil {
+		return err
+	}
+	return s.processState.Start(s.Out, s.Err)
+}
+
+func (s *APIServer) prepare() error {
+	if err := s.setProcessState(); err != nil {
+		return err
+	}
+	return s.Authn.Start()
+}
+
+// configurePorts configures the serving ports for this API server.
+//
+// Most of this method currently deals with making the deprecated fields
+// take precedence over the new fields.
+func (s *APIServer) configurePorts() error {
+	// prefer the old fields to the new fields if a user set one,
+	// otherwise, default the new fields and populate the old ones.
+
+	// Insecure: URL, InsecureServing
+	if s.URL != nil {
+		s.InsecureServing = &process.ListenAddr{
+			Address: s.URL.Hostname(),
+			Port:    s.URL.Port(),
+		}
+	} else if insec := s.InsecureServing; insec != nil {
+		if insec.Port == "" || insec.Address == "" {
+			port, host, err := addr.Suggest("")
+			if err != nil {
+				return fmt.Errorf("unable to provision unused insecure port: %w", err)
+			}
+			s.InsecureServing.Port = strconv.Itoa(port)
+			s.InsecureServing.Address = host
+		}
+		s.URL = s.InsecureServing.URL("http", "")
+	}
+
+	// Secure: SecurePort, SecureServing
+	if s.SecurePort != 0 {
+		s.SecureServing.Port = strconv.Itoa(s.SecurePort)
+		// if we don't have an address, try the insecure address, and otherwise
+		// default to loopback.
+		if s.SecureServing.Address == "" {
+			if s.InsecureServing != nil {
+				s.SecureServing.Address = s.InsecureServing.Address
+			} else {
+				s.SecureServing.Address = "127.0.0.1"
+			}
+		}
+	} else if s.SecureServing.Port == "" || s.SecureServing.Address == "" {
+		port, host, err := addr.Suggest("")
+		if err != nil {
+			return fmt.Errorf("unable to provision unused secure port: %w", err)
+		}
+		s.SecureServing.Port = strconv.Itoa(port)
+		s.SecureServing.Address = host
+		s.SecurePort = port
+	}
+
+	return nil
+}
+
+func (s *APIServer) setProcessState() error {
+	if s.EtcdURL == nil {
+		return fmt.Errorf("expected EtcdURL to be configured")
+	}
+
+	var err error
+
+	// unconditionally re-set this so we can successfully restart
+	// TODO(directxman12): we supported this in the past, but do we actually
+	// want to support re-using an API server object to restart?  The loss
+	// of provisioned users is surprising to say the least.
+	s.processState = &process.State{
+		Dir:          s.CertDir,
+		Path:         s.Path,
+		StartTimeout: s.StartTimeout,
+		StopTimeout:  s.StopTimeout,
+	}
+	if err := s.processState.Init("kube-apiserver"); err != nil {
+		return err
+	}
+
+	if err := s.configurePorts(); err != nil {
+		return err
+	}
+
+	// the secure port will always be on, so use that
+	s.processState.HealthCheck.URL = *s.SecureServing.URL("https", "/healthz")
+
+	s.CertDir = s.processState.Dir
+	s.Path = s.processState.Path
+	s.StartTimeout = s.processState.StartTimeout
+	s.StopTimeout = s.processState.StopTimeout
+
+	if err := s.populateAPIServerCerts(); err != nil {
+		return err
+	}
+
+	if s.SecureServing.Authn == nil {
+		authn, err := NewCertAuthn()
+		if err != nil {
+			return err
+		}
+		s.SecureServing.Authn = authn
+	}
+
+	if err := s.Authn.Configure(s.CertDir, s.Configure()); err != nil {
+		return err
+	}
+
+	// NB(directxman12): insecure port is a mess:
+	// - 1.19 and below have the `--insecure-port` flag, and require it to be set to zero to
+	//   disable it, otherwise the default will be used and we'll conflict.
+	// - 1.20 requires the flag to be unset or set to zero, and yells at you if you configure it
+	// - 1.24 won't have the flag at all...
+	//
+	// In an effort to automatically do the right thing during this mess, we do feature discovery
+	// on the flags, and hope that we've "parsed" them properly.
+	//
+	// TODO(directxman12): once we support 1.20 as the min version (might be when 1.24 comes out,
+	// might be around 1.25 or 1.26), remove this logic and the corresponding line in API server's
+	// default args.
+	if err := s.discoverFlags(); err != nil {
+		return err
+	}
+
+	s.processState.Args, s.Args, err = process.TemplateAndArguments(s.Args, s.Configure(), process.TemplateDefaults{ //nolint:staticcheck
+		Data:     s,
+		Defaults: s.defaultArgs(),
+		MinimalDefaults: map[string][]string{
+			// as per kubernetes-sigs/controller-runtime#641, we need this (we
+			// probably need other stuff too, but this is the only thing that was
+			// previously considered a "minimal default")
+			"service-cluster-ip-range": {"10.0.0.0/24"},
+
+			// we need *some* authorization mode for health checks on the secure port,
+			// so default to RBAC unless the user set something else (in which case
+			// this'll be ignored due to SliceToArguments using AppendNoDefaults).
+			"authorization-mode": {"RBAC"},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// discoverFlags checks for certain flags that *must* be set in certain
+// versions, and *must not* be set in others.
+func (s *APIServer) discoverFlags() error {
+	// Present: <1.24, Absent: >= 1.24
+	present, err := s.processState.CheckFlag("insecure-port")
+	if err != nil {
+		return err
+	}
+
+	if !present {
+		s.Configure().Disable("insecure-port")
+	}
+
+	return nil
+}
+
+func (s *APIServer) defaultArgs() map[string][]string {
+	args := map[string][]string{
+		"service-cluster-ip-range": {"10.0.0.0/24"},
+		"allow-privileged":         {"true"},
+		// we're keeping this disabled because if enabled, default SA is
+		// missing which would force all tests to create one in normal
+		// apiserver operation this SA is created by controller, but that is
+		// not run in integration environment
+		"disable-admission-plugins": {"ServiceAccount"},
+		"cert-dir":                  {s.CertDir},
+		"authorization-mode":        {"RBAC"},
+		"secure-port":               {s.SecureServing.Port},
+		// NB(directxman12): previously we didn't set the bind address for the secure
+		// port.  It *shouldn't* make a difference unless people are doing something really
+		// funky, but if you start to get bug reports look here ;-)
+		"bind-address": {s.SecureServing.Address},
+
+		// required on 1.20+, fine to leave on for <1.20
+		"service-account-issuer":           {s.SecureServing.URL("https", "/").String()},
+		"service-account-key-file":         {filepath.Join(s.CertDir, saCertFile)},
+		"service-account-signing-key-file": {filepath.Join(s.CertDir, saKeyFile)},
+	}
+	if s.EtcdURL != nil {
+		args["etcd-servers"] = []string{s.EtcdURL.String()}
+	}
+	if s.URL != nil {
+		args["insecure-port"] = []string{s.URL.Port()}
+		args["insecure-bind-address"] = []string{s.URL.Hostname()}
+	} else {
+		// TODO(directxman12): remove this once 1.21 is the lowest version we support
+		// (this might be a while, but this line'll break as of 1.24, so see the comment
+		// in Start
+		args["insecure-port"] = []string{"0"}
+	}
+	return args
+}
+
+func (s *APIServer) populateAPIServerCerts() error {
+	_, statErr := os.Stat(filepath.Join(s.CertDir, "apiserver.crt"))
+	if !os.IsNotExist(statErr) {
+		return statErr
+	}
+
+	ca, err := certs.NewTinyCA()
+	if err != nil {
+		return err
+	}
+
+	servingAddresses := []string{"localhost"}
+	if s.SecureServing.ListenAddr.Address != "" {
+		servingAddresses = append(servingAddresses, s.SecureServing.ListenAddr.Address)
+	}
+
+	servingCerts, err := ca.NewServingCert(servingAddresses...)
+	if err != nil {
+		return err
+	}
+
+	certData, keyData, err := servingCerts.AsBytes()
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filepath.Join(s.CertDir, "apiserver.crt"), certData, 0o640); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(s.CertDir, "apiserver.key"), keyData, 0o640); err != nil {
+		return err
+	}
+
+	s.SecureServing.CA = ca.CA.CertBytes()
+
+	// service account signing files too
+	saCA, err := certs.NewTinyCA()
+	if err != nil {
+		return err
+	}
+
+	saCert, saKey, err := saCA.CA.AsBytes()
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filepath.Join(s.CertDir, saCertFile), saCert, 0o640); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(s.CertDir, saKeyFile), saKey, 0o640)
+}
+
+// Stop stops this process gracefully, waits for its termination, and cleans up
+// the CertDir if necessary.
+func (s *APIServer) Stop() error {
+	if s.processState != nil {
+		if s.processState.DirNeedsCleaning {
+			s.CertDir = "" // reset the directory if it was randomly allocated, so that we can safely restart
+		}
+		if err := s.processState.Stop(); err != nil {
+			return err
+		}
+	}
+	if s.Authn == nil {
+		return nil
+	}
+	return s.Authn.Stop()
+}
+
+// APIServerDefaultArgs exposes the default args for the APIServer so that you
+// can use those to append your own additional arguments.
+//
+// Note that these arguments don't handle newer API servers well to due the more
+// complex feature detection neeeded.  It's recommended that you switch to .Configure
+// as you upgrade API server versions.
+//
+// Deprecated: use APIServer.Configure().
+var APIServerDefaultArgs = []string{
+	"--advertise-address=127.0.0.1",
+	"--etcd-servers={{ if .EtcdURL }}{{ .EtcdURL.String }}{{ end }}",
+	"--cert-dir={{ .CertDir }}",
+	"--insecure-port={{ if .URL }}{{ .URL.Port }}{{else}}0{{ end }}",
+	"{{ if .URL }}--insecure-bind-address={{ .URL.Hostname }}{{ end }}",
+	"--secure-port={{ if .SecurePort }}{{ .SecurePort }}{{ end }}",
+	// we're keeping this disabled because if enabled, default SA is missing which would force all tests to create one
+	// in normal apiserver operation this SA is created by controller, but that is not run in integration environment
+	"--disable-admission-plugins=ServiceAccount",
+	"--service-cluster-ip-range=10.0.0.0/24",
+	"--allow-privileged=true",
+	// NB(directxman12): we also enable RBAC if nothing else was enabled
+}
+
+// PrepareAPIServer is an internal-only (NEVER SHOULD BE EXPOSED)
+// function that sets up the API server just before starting it,
+// without actually starting it.  This saves time on tests.
+//
+// NB(directxman12): do not expose this outside of internal -- it's unsafe to
+// use, because things like port allocation could race even more than they
+// currently do if you later call start!
+func PrepareAPIServer(s *APIServer) error {
+	return s.prepare()
+}
+
+// APIServerArguments is an internal-only (NEVER SHOULD BE EXPOSED)
+// function that sets up the API server just before starting it,
+// without actually starting it.  It's public to make testing easier.
+//
+// NB(directxman12): do not expose this outside of internal.
+func APIServerArguments(s *APIServer) []string {
+	return s.processState.Args
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/controlplane/auth.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/controlplane/auth.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/certs"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/process"
+)
+
+// User represents a Kubernetes user.
+type User struct {
+	// Name is the user's Name.
+	Name string
+	// Groups are the groups to which the user belongs.
+	Groups []string
+}
+
+// Authn knows how to configure an API server for a particular type of authentication,
+// and provision users under that authentication scheme.
+//
+// The methods must be called in the following order (as presented below in the interface
+// for a mnemonic):
+//
+// 1. Configure
+// 2. Start
+// 3. AddUsers (0+ calls)
+// 4. Stop.
+type Authn interface {
+	// Configure provides the working directory to this authenticator,
+	// and configures the given API server arguments to make use of this authenticator.
+	//
+	// Should be called first.
+	Configure(workDir string, args *process.Arguments) error
+	// Start runs this authenticator.  Will be called just before API server start.
+	//
+	// Must be called after Configure.
+	Start() error
+	// AddUser provisions a user, returning a copy of the given base rest.Config
+	// configured to authenticate as that users.
+	//
+	// May only be called while the authenticator is "running".
+	AddUser(user User, baseCfg *rest.Config) (*rest.Config, error)
+	// Stop shuts down this authenticator.
+	Stop() error
+}
+
+// CertAuthn is an authenticator (Authn) that makes use of client certificate authn.
+type CertAuthn struct {
+	// ca is the CA used to sign the client certs
+	ca *certs.TinyCA
+	// certDir is the directory used to write the CA crt file
+	// so that the API server can read it.
+	certDir string
+}
+
+// NewCertAuthn creates a new client-cert-based Authn with a new CA.
+func NewCertAuthn() (*CertAuthn, error) {
+	ca, err := certs.NewTinyCA()
+	if err != nil {
+		return nil, fmt.Errorf("unable to provision client certificate auth CA: %w", err)
+	}
+	return &CertAuthn{
+		ca: ca,
+	}, nil
+}
+
+// AddUser provisions a new user that's authenticated via certificates, with
+// the given uesrname and groups embedded in the certificate as expected by the
+// API server.
+func (c *CertAuthn) AddUser(user User, baseCfg *rest.Config) (*rest.Config, error) {
+	certs, err := c.ca.NewClientCert(certs.ClientInfo{
+		Name:   user.Name,
+		Groups: user.Groups,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to create client certificates for %s: %w", user.Name, err)
+	}
+
+	crt, key, err := certs.AsBytes()
+	if err != nil {
+		return nil, fmt.Errorf("unable to serialize client certificates for %s: %w", user.Name, err)
+	}
+
+	cfg := rest.CopyConfig(baseCfg)
+	cfg.CertData = crt
+	cfg.KeyData = key
+
+	return cfg, nil
+}
+
+// caCrtPath returns the path to the on-disk client-cert CA crt file.
+func (c *CertAuthn) caCrtPath() string {
+	return filepath.Join(c.certDir, "client-cert-auth-ca.crt")
+}
+
+// Configure provides the working directory to this authenticator,
+// and configures the given API server arguments to make use of this authenticator.
+func (c *CertAuthn) Configure(workDir string, args *process.Arguments) error {
+	c.certDir = workDir
+	args.Set("client-ca-file", c.caCrtPath())
+	return nil
+}
+
+// Start runs this authenticator.  Will be called just before API server start.
+//
+// Must be called after Configure.
+func (c *CertAuthn) Start() error {
+	if len(c.certDir) == 0 {
+		return fmt.Errorf("start called before configure")
+	}
+	caCrt := c.ca.CA.CertBytes()
+	if err := os.WriteFile(c.caCrtPath(), caCrt, 0640); err != nil {
+		return fmt.Errorf("unable to save the client certificate CA to %s: %w", c.caCrtPath(), err)
+	}
+
+	return nil
+}
+
+// Stop shuts down this authenticator.
+func (c *CertAuthn) Stop() error {
+	// no-op -- our workdir is cleaned up for us automatically
+	return nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/controlplane/etcd.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/controlplane/etcd.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"io"
+	"net"
+	"net/url"
+	"strconv"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/addr"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/process"
+)
+
+// Etcd knows how to run an etcd server.
+type Etcd struct {
+	// URL is the address the Etcd should listen on for client connections.
+	//
+	// If this is not specified, we default to a random free port on localhost.
+	URL *url.URL
+
+	// Path is the path to the etcd binary.
+	//
+	// If this is left as the empty string, we will attempt to locate a binary,
+	// by checking for the TEST_ASSET_ETCD environment variable, and the default
+	// test assets directory. See the "Binaries" section above (in doc.go) for
+	// details.
+	Path string
+
+	// Args is a list of arguments which will passed to the Etcd binary. Before
+	// they are passed on, the`y will be evaluated as go-template strings. This
+	// means you can use fields which are defined and exported on this Etcd
+	// struct (e.g. "--data-dir={{ .Dir }}").
+	// Those templates will be evaluated after the defaulting of the Etcd's
+	// fields has already happened and just before the binary actually gets
+	// started. Thus you have access to calculated fields like `URL` and others.
+	//
+	// If not specified, the minimal set of arguments to run the Etcd will be
+	// used.
+	//
+	// They will be loaded into the same argument set as Configure.  Each flag
+	// will be Append-ed to the configured arguments just before launch.
+	//
+	// Deprecated: use Configure instead.
+	Args []string
+
+	// DataDir is a path to a directory in which etcd can store its state.
+	//
+	// If left unspecified, then the Start() method will create a fresh temporary
+	// directory, and the Stop() method will clean it up.
+	DataDir string
+
+	// StartTimeout, StopTimeout specify the time the Etcd is allowed to
+	// take when starting and stopping before an error is emitted.
+	//
+	// If not specified, these default to 20 seconds.
+	StartTimeout time.Duration
+	StopTimeout  time.Duration
+
+	// Out, Err specify where Etcd should write its StdOut, StdErr to.
+	//
+	// If not specified, the output will be discarded.
+	Out io.Writer
+	Err io.Writer
+
+	// processState contains the actual details about this running process
+	processState *process.State
+
+	// args contains the structured arguments to use for running etcd.
+	// Lazily initialized by .Configure(), Defaulted eventually with .defaultArgs()
+	args *process.Arguments
+
+	// listenPeerURL is the address the Etcd should listen on for peer connections.
+	// It's automatically generated and a random port is picked during execution.
+	listenPeerURL *url.URL
+}
+
+// Start starts the etcd, waits for it to come up, and returns an error, if one
+// occurred.
+func (e *Etcd) Start() error {
+	if err := e.setProcessState(); err != nil {
+		return err
+	}
+	return e.processState.Start(e.Out, e.Err)
+}
+
+func (e *Etcd) setProcessState() error {
+	e.processState = &process.State{
+		Dir:          e.DataDir,
+		Path:         e.Path,
+		StartTimeout: e.StartTimeout,
+		StopTimeout:  e.StopTimeout,
+	}
+
+	// unconditionally re-set this so we can successfully restart
+	// TODO(directxman12): we supported this in the past, but do we actually
+	// want to support re-using an API server object to restart?  The loss
+	// of provisioned users is surprising to say the least.
+	if err := e.processState.Init("etcd"); err != nil {
+		return err
+	}
+
+	// Set the listen url.
+	if e.URL == nil {
+		port, host, err := addr.Suggest("")
+		if err != nil {
+			return err
+		}
+		e.URL = &url.URL{
+			Scheme: "http",
+			Host:   net.JoinHostPort(host, strconv.Itoa(port)),
+		}
+	}
+
+	// Set the listen peer URL.
+	{
+		port, host, err := addr.Suggest("")
+		if err != nil {
+			return err
+		}
+		e.listenPeerURL = &url.URL{
+			Scheme: "http",
+			Host:   net.JoinHostPort(host, strconv.Itoa(port)),
+		}
+	}
+
+	// can use /health as of etcd 3.3.0
+	e.processState.HealthCheck.URL = *e.URL
+	e.processState.HealthCheck.Path = "/health"
+
+	e.DataDir = e.processState.Dir
+	e.Path = e.processState.Path
+	e.StartTimeout = e.processState.StartTimeout
+	e.StopTimeout = e.processState.StopTimeout
+
+	var err error
+	e.processState.Args, e.Args, err = process.TemplateAndArguments(e.Args, e.Configure(), process.TemplateDefaults{ //nolint:staticcheck
+		Data:     e,
+		Defaults: e.defaultArgs(),
+	})
+	return err
+}
+
+// Stop stops this process gracefully, waits for its termination, and cleans up
+// the DataDir if necessary.
+func (e *Etcd) Stop() error {
+	if e.processState == nil {
+		return nil
+	}
+
+	if e.processState.DirNeedsCleaning {
+		e.DataDir = "" // reset the directory if it was randomly allocated, so that we can safely restart
+	}
+	return e.processState.Stop()
+}
+
+func (e *Etcd) defaultArgs() map[string][]string {
+	args := map[string][]string{
+		"listen-peer-urls": {e.listenPeerURL.String()},
+		"data-dir":         {e.DataDir},
+	}
+	if e.URL != nil {
+		args["advertise-client-urls"] = []string{e.URL.String()}
+		args["listen-client-urls"] = []string{e.URL.String()}
+	}
+
+	// Add unsafe no fsync, available from etcd 3.5
+	if ok, _ := e.processState.CheckFlag("unsafe-no-fsync"); ok {
+		args["unsafe-no-fsync"] = []string{"true"}
+	}
+	return args
+}
+
+// Configure returns Arguments that may be used to customize the
+// flags used to launch etcd.  A set of defaults will
+// be applied underneath.
+func (e *Etcd) Configure() *process.Arguments {
+	if e.args == nil {
+		e.args = process.EmptyArguments()
+	}
+	return e.args
+}
+
+// EtcdDefaultArgs exposes the default args for Etcd so that you
+// can use those to append your own additional arguments.
+var EtcdDefaultArgs = []string{
+	"--listen-peer-urls=http://localhost:0",
+	"--advertise-client-urls={{ if .URL }}{{ .URL.String }}{{ end }}",
+	"--listen-client-urls={{ if .URL }}{{ .URL.String }}{{ end }}",
+	"--data-dir={{ .DataDir }}",
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/controlplane/kubectl.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/controlplane/kubectl.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/url"
+	"os/exec"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	kcapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/process"
+)
+
+const (
+	envtestName = "envtest"
+)
+
+// KubeConfigFromREST reverse-engineers a kubeconfig file from a rest.Config.
+// The options are tailored towards the rest.Configs we generate, so they're
+// not broadly applicable.
+//
+// This is not intended to be exposed beyond internal for the above reasons.
+func KubeConfigFromREST(cfg *rest.Config) ([]byte, error) {
+	kubeConfig := kcapi.NewConfig()
+	protocol := "https"
+	if !rest.IsConfigTransportTLS(*cfg) {
+		protocol = "http"
+	}
+
+	// cfg.Host is a URL, so we need to parse it so we can properly append the API path
+	baseURL, err := url.Parse(cfg.Host)
+	if err != nil {
+		return nil, fmt.Errorf("unable to interpret config's host value as a URL: %w", err)
+	}
+
+	kubeConfig.Clusters[envtestName] = &kcapi.Cluster{
+		// TODO(directxman12): if client-go ever decides to expose defaultServerUrlFor(config),
+		// we can just use that.  Note that this is not the same as the public DefaultServerURL,
+		// which requires us to pass a bunch of stuff in manually.
+		Server:                   (&url.URL{Scheme: protocol, Host: baseURL.Host, Path: cfg.APIPath}).String(),
+		CertificateAuthorityData: cfg.CAData,
+	}
+	kubeConfig.AuthInfos[envtestName] = &kcapi.AuthInfo{
+		// try to cover all auth strategies that aren't plugins
+		ClientCertificateData: cfg.CertData,
+		ClientKeyData:         cfg.KeyData,
+		Token:                 cfg.BearerToken,
+		Username:              cfg.Username,
+		Password:              cfg.Password,
+	}
+	kcCtx := kcapi.NewContext()
+	kcCtx.Cluster = envtestName
+	kcCtx.AuthInfo = envtestName
+	kubeConfig.Contexts[envtestName] = kcCtx
+	kubeConfig.CurrentContext = envtestName
+
+	contents, err := clientcmd.Write(*kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to serialize kubeconfig file: %w", err)
+	}
+	return contents, nil
+}
+
+// KubeCtl is a wrapper around the kubectl binary.
+type KubeCtl struct {
+	// Path where the kubectl binary can be found.
+	//
+	// If this is left empty, we will attempt to locate a binary, by checking for
+	// the TEST_ASSET_KUBECTL environment variable, and the default test assets
+	// directory. See the "Binaries" section above (in doc.go) for details.
+	Path string
+
+	// Opts can be used to configure additional flags which will be used each
+	// time the wrapped binary is called.
+	//
+	// For example, you might want to use this to set the URL of the APIServer to
+	// connect to.
+	Opts []string
+}
+
+// Run executes the wrapped binary with some preconfigured options and the
+// arguments given to this method. It returns Readers for the stdout and
+// stderr.
+func (k *KubeCtl) Run(args ...string) (stdout, stderr io.Reader, err error) {
+	if k.Path == "" {
+		k.Path = process.BinPathFinder("kubectl", "")
+	}
+
+	stdoutBuffer := &bytes.Buffer{}
+	stderrBuffer := &bytes.Buffer{}
+	allArgs := append(k.Opts, args...)
+
+	cmd := exec.Command(k.Path, allArgs...)
+	cmd.Stdout = stdoutBuffer
+	cmd.Stderr = stderrBuffer
+	cmd.SysProcAttr = process.GetSysProcAttr()
+
+	err = cmd.Run()
+
+	return stdoutBuffer, stderrBuffer, err
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/controlplane/plane.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/controlplane/plane.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/certs"
+)
+
+// NewTinyCA creates a new a tiny CA utility for provisioning serving certs and client certs FOR TESTING ONLY.
+// Don't use this for anything else!
+var NewTinyCA = certs.NewTinyCA
+
+// ControlPlane is a struct that knows how to start your test control plane.
+//
+// Right now, that means Etcd and your APIServer. This is likely to increase in
+// future.
+type ControlPlane struct {
+	APIServer *APIServer
+	Etcd      *Etcd
+
+	// Kubectl will override the default asset search path for kubectl
+	KubectlPath string
+
+	// for the deprecated methods (Kubectl, etc)
+	defaultUserCfg     *rest.Config
+	defaultUserKubectl *KubeCtl
+}
+
+// Start will start your control plane processes. To stop them, call Stop().
+func (f *ControlPlane) Start() (retErr error) {
+	if f.Etcd == nil {
+		f.Etcd = &Etcd{}
+	}
+	if err := f.Etcd.Start(); err != nil {
+		return err
+	}
+	defer func() {
+		if retErr != nil {
+			_ = f.Etcd.Stop()
+		}
+	}()
+
+	if f.APIServer == nil {
+		f.APIServer = &APIServer{}
+	}
+	f.APIServer.EtcdURL = f.Etcd.URL
+	if err := f.APIServer.Start(); err != nil {
+		return err
+	}
+	defer func() {
+		if retErr != nil {
+			_ = f.APIServer.Stop()
+		}
+	}()
+
+	// provision the default user -- can be removed when the related
+	// methods are removed.  The default user has admin permissions to
+	// mimic legacy no-authz setups.
+	user, err := f.AddUser(User{Name: "default", Groups: []string{"system:masters"}}, &rest.Config{})
+	if err != nil {
+		return fmt.Errorf("unable to provision the default (legacy) user: %w", err)
+	}
+	kubectl, err := user.Kubectl()
+	if err != nil {
+		return fmt.Errorf("unable to provision the default (legacy) kubeconfig: %w", err)
+	}
+	f.defaultUserCfg = user.Config()
+	f.defaultUserKubectl = kubectl
+	return nil
+}
+
+// Stop will stop your control plane processes, and clean up their data.
+func (f *ControlPlane) Stop() error {
+	var errList []error
+
+	if f.APIServer != nil {
+		if err := f.APIServer.Stop(); err != nil {
+			errList = append(errList, err)
+		}
+	}
+
+	if f.Etcd != nil {
+		if err := f.Etcd.Stop(); err != nil {
+			errList = append(errList, err)
+		}
+	}
+
+	return kerrors.NewAggregate(errList)
+}
+
+// APIURL returns the URL you should connect to to talk to your API server.
+//
+// If insecure serving is configured, this will contain the insecure port.
+// Otherwise, it will contain the secure port.
+//
+// Deprecated: use AddUser instead, or APIServer.{Ins|S}ecureServing.URL if
+// you really want just the URL.
+func (f *ControlPlane) APIURL() *url.URL {
+	return f.APIServer.URL
+}
+
+// KubeCtl returns a pre-configured KubeCtl, ready to connect to this
+// ControlPlane.
+//
+// Deprecated: use AddUser & AuthenticatedUser.Kubectl instead.
+func (f *ControlPlane) KubeCtl() *KubeCtl {
+	return f.defaultUserKubectl
+}
+
+// RESTClientConfig returns a pre-configured restconfig, ready to connect to
+// this ControlPlane.
+//
+// Deprecated: use AddUser & AuthenticatedUser.Config instead.
+func (f *ControlPlane) RESTClientConfig() (*rest.Config, error) {
+	return f.defaultUserCfg, nil
+}
+
+// AuthenticatedUser contains access information for an provisioned user,
+// including REST config, kubeconfig contents, and access to a KubeCtl instance.
+//
+// It's not "safe" to use the methods on this till after the API server has been
+// started (due to certificate initialization and such).  The various methods will
+// panic if this is done.
+type AuthenticatedUser struct {
+	// cfg is the rest.Config for connecting to the API server.  It's lazily initialized.
+	cfg *rest.Config
+	// cfgIsComplete indicates the cfg has had late-initialized fields (e.g.
+	// API server CA data) initialized.
+	cfgIsComplete bool
+
+	// apiServer is a handle to the APIServer that's used when finalizing cfg
+	// and producing the kubectl instance.
+	plane *ControlPlane
+
+	// kubectl is our existing, provisioned kubectl.  We don't provision one
+	// till someone actually asks for it.
+	kubectl *KubeCtl
+}
+
+// Config returns the REST config that can be used to connect to the API server
+// as this user.
+//
+// Will panic if used before the API server is started.
+func (u *AuthenticatedUser) Config() *rest.Config {
+	// NB(directxman12): we choose to panic here for ergonomics sake, and because there's
+	// not really much you can do to "handle" this error.  This machinery is intended to be
+	// used in tests anyway, so panicing is not a particularly big deal.
+	if u.cfgIsComplete {
+		return u.cfg
+	}
+	if len(u.plane.APIServer.SecureServing.CA) == 0 {
+		panic("the API server has not yet been started, please do that before accessing connection details")
+	}
+
+	u.cfg.CAData = u.plane.APIServer.SecureServing.CA
+	u.cfg.Host = u.plane.APIServer.SecureServing.URL("https", "/").String()
+	u.cfgIsComplete = true
+	return u.cfg
+}
+
+// KubeConfig returns a KubeConfig that's roughly equivalent to this user's REST config.
+//
+// Will panic if used before the API server is started.
+func (u AuthenticatedUser) KubeConfig() ([]byte, error) {
+	// NB(directxman12): we don't return the actual API object to avoid yet another
+	// piece of kubernetes API in our public API, and also because generally the thing
+	// you want to do with this is just write it out to a file for external debugging
+	// purposes, etc.
+	return KubeConfigFromREST(u.Config())
+}
+
+// Kubectl returns a KubeCtl instance for talking to the API server as this user.  It uses
+// a kubeconfig equivalent to that returned by .KubeConfig.
+//
+// Will panic if used before the API server is started.
+func (u *AuthenticatedUser) Kubectl() (*KubeCtl, error) {
+	if u.kubectl != nil {
+		return u.kubectl, nil
+	}
+	if len(u.plane.APIServer.CertDir) == 0 {
+		panic("the API server has not yet been started, please do that before accessing connection details")
+	}
+
+	// cleaning this up is handled when our tmpDir is deleted
+	out, err := os.CreateTemp(u.plane.APIServer.CertDir, "*.kubecfg")
+	if err != nil {
+		return nil, fmt.Errorf("unable to create file for kubeconfig: %w", err)
+	}
+	defer out.Close()
+	contents, err := KubeConfigFromREST(u.Config())
+	if err != nil {
+		return nil, err
+	}
+	if _, err := out.Write(contents); err != nil {
+		return nil, fmt.Errorf("unable to write kubeconfig to disk at %s: %w", out.Name(), err)
+	}
+	k := &KubeCtl{
+		Path: u.plane.KubectlPath,
+	}
+	k.Opts = append(k.Opts, fmt.Sprintf("--kubeconfig=%s", out.Name()))
+	u.kubectl = k
+	return k, nil
+}
+
+// AddUser provisions a new user in the cluster.  It uses the APIServer's authentication
+// strategy -- see APIServer.SecureServing.Authn.
+//
+// Unlike AddUser, it's safe to pass a nil rest.Config here if you have no
+// particular opinions about the config.
+//
+// The default authentication strategy is not guaranteed to any specific strategy, but it is
+// guaranteed to be callable both before and after Start has been called (but, as noted in the
+// AuthenticatedUser docs, the given user objects are only valid after Start has been called).
+func (f *ControlPlane) AddUser(user User, baseConfig *rest.Config) (*AuthenticatedUser, error) {
+	if f.GetAPIServer().SecureServing.Authn == nil {
+		return nil, fmt.Errorf("no API server authentication is configured yet.  The API server defaults one when Start is called, did you mean to use that?")
+	}
+
+	if baseConfig == nil {
+		baseConfig = &rest.Config{}
+	}
+	cfg, err := f.GetAPIServer().SecureServing.AddUser(user, baseConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AuthenticatedUser{
+		cfg:   cfg,
+		plane: f,
+	}, nil
+}
+
+// GetAPIServer returns this ControlPlane's APIServer, initializing it if necessary.
+func (f *ControlPlane) GetAPIServer() *APIServer {
+	if f.APIServer == nil {
+		f.APIServer = &APIServer{}
+	}
+	return f.APIServer
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/process/arguments.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/process/arguments.go
@@ -1,0 +1,340 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"bytes"
+	"html/template"
+	"slices"
+	"strings"
+)
+
+// RenderTemplates returns an []string to render the templates
+//
+// Deprecated: will be removed in favor of Arguments.
+func RenderTemplates(argTemplates []string, data any) (args []string, err error) {
+	var t *template.Template
+
+	for _, arg := range argTemplates {
+		t, err = template.New(arg).Parse(arg)
+		if err != nil {
+			args = nil
+			return
+		}
+
+		buf := &bytes.Buffer{}
+		err = t.Execute(buf, data)
+		if err != nil {
+			args = nil
+			return
+		}
+		args = append(args, buf.String())
+	}
+
+	return
+}
+
+// SliceToArguments converts a slice of arguments to structured arguments,
+// appending each argument that starts with `--` and contains an `=` to the
+// argument set (ignoring defaults), returning the rest.
+//
+// Deprecated: will be removed when RenderTemplates is removed.
+func SliceToArguments(sliceArgs []string, args *Arguments) []string {
+	var rest []string
+	for i, arg := range sliceArgs {
+		if arg == "--" {
+			rest = append(rest, sliceArgs[i:]...)
+			return rest
+		}
+		// skip non-flag arguments, skip arguments w/o equals because we
+		// can't tell if the next argument should take a value
+		if !strings.HasPrefix(arg, "--") || !strings.Contains(arg, "=") {
+			rest = append(rest, arg)
+			continue
+		}
+
+		parts := strings.SplitN(arg[2:], "=", 2)
+		name := parts[0]
+		val := parts[1]
+
+		args.AppendNoDefaults(name, val)
+	}
+
+	return rest
+}
+
+// TemplateDefaults specifies defaults to be used for joining structured arguments with templates.
+//
+// Deprecated: will be removed when RenderTemplates is removed.
+type TemplateDefaults struct {
+	// Data will be used to render the template.
+	Data any
+	// Defaults will be used to default structured arguments if no template is passed.
+	Defaults map[string][]string
+	// MinimalDefaults will be used to default structured arguments if a template is passed.
+	// Use this for flags which *must* be present.
+	MinimalDefaults map[string][]string // for api server service-cluster-ip-range
+}
+
+// TemplateAndArguments joins structured arguments and non-structured arguments, preserving existing
+// behavior.  Namely:
+//
+//  1. if templ has len > 0, it will be rendered against data
+//  2. the rendered template values that look like `--foo=bar` will be split
+//     and appended to args, the rest will be kept around
+//  3. the given args will be rendered as string form.  If a template is given,
+//     no defaults will be used, otherwise defaults will be used
+//  4. a result of [args..., rest...] will be returned
+//
+// It returns the resulting rendered arguments, plus the arguments that were
+// not transferred to `args` during rendering.
+//
+// Deprecated: will be removed when RenderTemplates is removed.
+func TemplateAndArguments(templ []string, args *Arguments, data TemplateDefaults) (allArgs []string, nonFlagishArgs []string, err error) {
+	if len(templ) == 0 { // 3 & 4 (no template case)
+		return args.AsStrings(data.Defaults), nil, nil
+	}
+
+	// 1: render the template
+	rendered, err := RenderTemplates(templ, data.Data)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// 2: filter out structured args and add them to args
+	rest := SliceToArguments(rendered, args)
+
+	// 3 (template case): render structured args, no defaults (matching the
+	// legacy case where if Args was specified, no defaults were used)
+	res := args.AsStrings(data.MinimalDefaults)
+
+	// 4: return the rendered structured args + all non-structured args
+	return append(res, rest...), rest, nil
+}
+
+// EmptyArguments constructs an empty set of flags with no defaults.
+func EmptyArguments() *Arguments {
+	return &Arguments{
+		values: make(map[string]Arg),
+	}
+}
+
+// Arguments are structured, overridable arguments.
+// Each Arguments object contains some set of default arguments, which may
+// be appended to, or overridden.
+//
+// When ready, you can serialize them to pass to exec.Command and friends using
+// AsStrings.
+//
+// All flag-setting methods return the *same* instance of Arguments so that you
+// can chain calls.
+type Arguments struct {
+	// values contains the user-set values for the arguments.
+	// `values[key] = dontPass` means "don't pass this flag"
+	// `values[key] = passAsName` means "pass this flag without args like --key`
+	// `values[key] = []string{a, b, c}` means "--key=a --key=b --key=c`
+	// any values not explicitly set here will be copied from defaults on final rendering.
+	values map[string]Arg
+}
+
+// Arg is an argument that has one or more values,
+// and optionally falls back to default values.
+type Arg interface {
+	// Append adds new values to this argument, returning
+	// a new instance contain the new value.  The intermediate
+	// argument should generally be assumed to be consumed.
+	Append(vals ...string) Arg
+	// Get returns the full set of values, optionally including
+	// the passed in defaults.  If it returns nil, this will be
+	// skipped.  If it returns a non-nil empty slice, it'll be
+	// assumed that the argument should be passed as name-only.
+	Get(defaults []string) []string
+}
+
+type userArg []string
+
+func (a userArg) Append(vals ...string) Arg {
+	return userArg(append(a, vals...)) //nolint:unconvert
+}
+func (a userArg) Get(_ []string) []string {
+	return []string(a)
+}
+
+type defaultedArg []string
+
+func (a defaultedArg) Append(vals ...string) Arg {
+	return defaultedArg(append(a, vals...)) //nolint:unconvert
+}
+func (a defaultedArg) Get(defaults []string) []string {
+	res := append([]string(nil), defaults...)
+	return append(res, a...)
+}
+
+type dontPassArg struct{}
+
+func (a dontPassArg) Append(vals ...string) Arg {
+	return userArg(vals)
+}
+func (dontPassArg) Get(_ []string) []string {
+	return nil
+}
+
+type passAsNameArg struct{}
+
+func (a passAsNameArg) Append(_ ...string) Arg {
+	return passAsNameArg{}
+}
+func (passAsNameArg) Get(_ []string) []string {
+	return []string{}
+}
+
+var (
+	// DontPass indicates that the given argument will not actually be
+	// rendered.
+	DontPass Arg = dontPassArg{}
+	// PassAsName indicates that the given flag will be passed as `--key`
+	// without any value.
+	PassAsName Arg = passAsNameArg{}
+)
+
+// AsStrings serializes this set of arguments to a slice of strings appropriate
+// for passing to exec.Command and friends, making use of the given defaults
+// as indicated for each particular argument.
+//
+//   - Any flag in defaults that's not in Arguments will be present in the output
+//   - Any flag that's present in Arguments will be passed the corresponding
+//     defaults to do with as it will (ignore, append-to, suppress, etc).
+func (a *Arguments) AsStrings(defaults map[string][]string) []string {
+	// sort for deterministic ordering
+	keysInOrder := make([]string, 0, len(defaults)+len(a.values))
+	for key := range defaults {
+		if _, userSet := a.values[key]; userSet {
+			continue
+		}
+		keysInOrder = append(keysInOrder, key)
+	}
+	for key := range a.values {
+		keysInOrder = append(keysInOrder, key)
+	}
+	slices.Sort(keysInOrder)
+
+	var res []string
+	for _, key := range keysInOrder {
+		vals := a.Get(key).Get(defaults[key])
+		switch {
+		case vals == nil: // don't pass
+			continue
+		case len(vals) == 0: // pass as name
+			res = append(res, "--"+key)
+		default:
+			for _, val := range vals {
+				res = append(res, "--"+key+"="+val)
+			}
+		}
+	}
+
+	return res
+}
+
+// Get returns the value of the given flag.  If nil,
+// it will not be passed in AsString, otherwise:
+//
+// len == 0 --> `--key`, len > 0 --> `--key=val1 --key=val2 ...`.
+func (a *Arguments) Get(key string) Arg {
+	if vals, ok := a.values[key]; ok {
+		return vals
+	}
+	return defaultedArg(nil)
+}
+
+// Enable configures the given key to be passed as a "name-only" flag,
+// like, `--key`.
+func (a *Arguments) Enable(key string) *Arguments {
+	a.values[key] = PassAsName
+	return a
+}
+
+// Disable prevents this flag from be passed.
+func (a *Arguments) Disable(key string) *Arguments {
+	a.values[key] = DontPass
+	return a
+}
+
+// Append adds additional values to this flag.  If this flag has
+// yet to be set, initial values will include defaults.  If you want
+// to intentionally ignore defaults/start from scratch, call AppendNoDefaults.
+//
+// Multiple values will look like `--key=value1 --key=value2 ...`.
+func (a *Arguments) Append(key string, values ...string) *Arguments {
+	vals, present := a.values[key]
+	if !present {
+		vals = defaultedArg{}
+	}
+	a.values[key] = vals.Append(values...)
+	return a
+}
+
+// AppendNoDefaults adds additional values to this flag.  However,
+// unlike Append, it will *not* copy values from defaults.
+func (a *Arguments) AppendNoDefaults(key string, values ...string) *Arguments {
+	vals, present := a.values[key]
+	if !present {
+		vals = userArg{}
+	}
+	a.values[key] = vals.Append(values...)
+	return a
+}
+
+// Set resets the given flag to the specified values, ignoring any existing
+// values or defaults.
+func (a *Arguments) Set(key string, values ...string) *Arguments {
+	a.values[key] = userArg(values)
+	return a
+}
+
+// SetRaw sets the given flag to the given Arg value directly.  Use this if
+// you need to do some complicated deferred logic or something.
+//
+// Otherwise behaves like Set.
+func (a *Arguments) SetRaw(key string, val Arg) *Arguments {
+	a.values[key] = val
+	return a
+}
+
+// FuncArg is a basic implementation of Arg that can be used for custom argument logic,
+// like pulling values out of APIServer, or dynamically calculating values just before
+// launch.
+//
+// The given function will be mapped directly to Arg#Get, and will generally be
+// used in conjunction with SetRaw.  For example, to set `--some-flag` to the
+// API server's CertDir, you could do:
+//
+//	server.Configure().SetRaw("--some-flag", FuncArg(func(defaults []string) []string {
+//	    return []string{server.CertDir}
+//	}))
+//
+// FuncArg ignores Appends; if you need to support appending values too, consider implementing
+// Arg directly.
+type FuncArg func([]string) []string
+
+// Append is a no-op for FuncArg, and just returns itself.
+func (a FuncArg) Append(vals ...string) Arg { return a }
+
+// Get delegates functionality to the FuncArg function itself.
+func (a FuncArg) Get(defaults []string) []string {
+	return a(defaults)
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/process/bin_path_finder.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/process/bin_path_finder.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const (
+	// EnvAssetsPath is the environment variable that stores the global test
+	// binary location override.
+	EnvAssetsPath = "KUBEBUILDER_ASSETS"
+	// EnvAssetOverridePrefix is the environment variable prefix for per-binary
+	// location overrides.
+	EnvAssetOverridePrefix = "TEST_ASSET_"
+	// AssetsDefaultPath is the default location to look for test binaries in,
+	// if no override was provided.
+	AssetsDefaultPath = "/usr/local/kubebuilder/bin"
+)
+
+// BinPathFinder finds the path to the given named binary, using the following locations
+// in order of precedence (highest first).  Notice that the various env vars only need
+// to be set -- the asset is not checked for existence on the filesystem.
+//
+// 1. TEST_ASSET_{tr/a-z-/A-Z_/} (if set; asset overrides -- EnvAssetOverridePrefix)
+// 1. KUBEBUILDER_ASSETS (if set; global asset path -- EnvAssetsPath)
+// 3. assetDirectory (if set; per-config asset directory)
+// 4. /usr/local/kubebuilder/bin (AssetsDefaultPath).
+func BinPathFinder(symbolicName, assetDirectory string) (binPath string) {
+	punctuationPattern := regexp.MustCompile("[^A-Z0-9]+")
+	sanitizedName := punctuationPattern.ReplaceAllString(strings.ToUpper(symbolicName), "_")
+	leadingNumberPattern := regexp.MustCompile("^[0-9]+")
+	sanitizedName = leadingNumberPattern.ReplaceAllString(sanitizedName, "")
+	envVar := EnvAssetOverridePrefix + sanitizedName
+
+	// TEST_ASSET_XYZ
+	if val, ok := os.LookupEnv(envVar); ok {
+		return val
+	}
+
+	// KUBEBUILDER_ASSETS
+	if val, ok := os.LookupEnv(EnvAssetsPath); ok {
+		return filepath.Join(val, symbolicName)
+	}
+
+	// assetDirectory
+	if assetDirectory != "" {
+		return filepath.Join(assetDirectory, symbolicName)
+	}
+
+	// default path
+	return filepath.Join(AssetsDefaultPath, symbolicName)
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/process/procattr_other.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/process/procattr_other.go
@@ -1,0 +1,27 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !zos
+
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import "syscall"
+
+// GetSysProcAttr returns the SysProcAttr to use for the process,
+// for non-unix systems this returns nil.
+func GetSysProcAttr() *syscall.SysProcAttr {
+	return nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/process/procattr_unix.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/process/procattr_unix.go
@@ -1,0 +1,32 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// GetSysProcAttr returns the SysProcAttr to use for the process,
+// for unix systems this returns a SysProcAttr with Setpgid set to true,
+// which inherits the parent's process group id.
+func GetSysProcAttr() *unix.SysProcAttr {
+	return &unix.SysProcAttr{
+		Setpgid: true,
+	}
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/process/process.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/process/process.go
@@ -1,0 +1,276 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"regexp"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// ListenAddr represents some listening address and port.
+type ListenAddr struct {
+	Address string
+	Port    string
+}
+
+// URL returns a URL for this address with the given scheme and subpath.
+func (l *ListenAddr) URL(scheme string, path string) *url.URL {
+	return &url.URL{
+		Scheme: scheme,
+		Host:   l.HostPort(),
+		Path:   path,
+	}
+}
+
+// HostPort returns the joined host-port pair for this address.
+func (l *ListenAddr) HostPort() string {
+	return net.JoinHostPort(l.Address, l.Port)
+}
+
+// HealthCheck describes the information needed to health-check a process via
+// some health-check URL.
+type HealthCheck struct {
+	url.URL
+
+	// HealthCheckPollInterval is the interval which will be used for polling the
+	// endpoint described by Host, Port, and Path.
+	//
+	// If left empty it will default to 100 Milliseconds.
+	PollInterval time.Duration
+}
+
+// State define the state of the process.
+type State struct {
+	Cmd *exec.Cmd
+
+	// HealthCheck describes how to check if this process is up.  If we get an http.StatusOK,
+	// we assume the process is ready to operate.
+	//
+	// For example, the /healthz endpoint of the k8s API server, or the /health endpoint of etcd.
+	HealthCheck HealthCheck
+
+	Args []string
+
+	StopTimeout  time.Duration
+	StartTimeout time.Duration
+
+	Dir              string
+	DirNeedsCleaning bool
+	Path             string
+
+	// ready holds whether the process is currently in ready state (hit the ready condition) or not.
+	// It will be set to true on a successful `Start()` and set to false on a successful `Stop()`
+	ready bool
+
+	// waitDone is closed when our call to wait finishes up, and indicates that
+	// our process has terminated.
+	waitDone chan struct{}
+	errMu    sync.Mutex
+	exitErr  error
+	exited   bool
+}
+
+// Init sets up this process, configuring binary paths if missing, initializing
+// temporary directories, etc.
+//
+// This defaults all defaultable fields.
+func (ps *State) Init(name string) error {
+	if ps.Path == "" {
+		if name == "" {
+			return fmt.Errorf("must have at least one of name or path")
+		}
+		ps.Path = BinPathFinder(name, "")
+	}
+
+	if ps.Dir == "" {
+		newDir, err := os.MkdirTemp("", "k8s_test_framework_")
+		if err != nil {
+			return err
+		}
+		ps.Dir = newDir
+		ps.DirNeedsCleaning = true
+	}
+
+	if ps.StartTimeout == 0 {
+		ps.StartTimeout = 20 * time.Second
+	}
+
+	if ps.StopTimeout == 0 {
+		ps.StopTimeout = 20 * time.Second
+	}
+	return nil
+}
+
+type stopChannel chan struct{}
+
+// CheckFlag checks the help output of this command for the presence of the given flag, specified
+// without the leading `--` (e.g. `CheckFlag("insecure-port")` checks for `--insecure-port`),
+// returning true if the flag is present.
+func (ps *State) CheckFlag(flag string) (bool, error) {
+	cmd := exec.Command(ps.Path, "--help")
+	outContents, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("unable to run command %q to check for flag %q: %w", ps.Path, flag, err)
+	}
+	pat := `(?m)^\s*--` + flag + `\b` // (m --> multi-line --> ^ matches start of line)
+	matched, err := regexp.Match(pat, outContents)
+	if err != nil {
+		return false, fmt.Errorf("unable to check command %q for flag %q in help output: %w", ps.Path, flag, err)
+	}
+	return matched, nil
+}
+
+// Start starts the apiserver, waits for it to come up, and returns an error,
+// if occurred.
+func (ps *State) Start(stdout, stderr io.Writer) (err error) {
+	if ps.ready {
+		return nil
+	}
+
+	ps.Cmd = exec.Command(ps.Path, ps.Args...)
+	ps.Cmd.Stdout = stdout
+	ps.Cmd.Stderr = stderr
+	ps.Cmd.SysProcAttr = GetSysProcAttr()
+
+	ready := make(chan bool)
+	timedOut := time.After(ps.StartTimeout)
+	pollerStopCh := make(stopChannel)
+	go pollURLUntilOK(ps.HealthCheck.URL, ps.HealthCheck.PollInterval, ready, pollerStopCh)
+
+	ps.waitDone = make(chan struct{})
+
+	if err := ps.Cmd.Start(); err != nil {
+		ps.errMu.Lock()
+		defer ps.errMu.Unlock()
+		ps.exited = true
+		return err
+	}
+	go func() {
+		defer close(ps.waitDone)
+		err := ps.Cmd.Wait()
+
+		ps.errMu.Lock()
+		defer ps.errMu.Unlock()
+		ps.exitErr = err
+		ps.exited = true
+	}()
+
+	select {
+	case <-ready:
+		ps.ready = true
+		return nil
+	case <-ps.waitDone:
+		close(pollerStopCh)
+		return fmt.Errorf("timeout waiting for process %s to start successfully "+
+			"(it may have failed to start, or stopped unexpectedly before becoming ready)",
+			path.Base(ps.Path))
+	case <-timedOut:
+		close(pollerStopCh)
+		if ps.Cmd != nil {
+			// intentionally ignore this -- we might've crashed, failed to start, etc
+			ps.Cmd.Process.Signal(syscall.SIGTERM) //nolint:errcheck
+		}
+		return fmt.Errorf("timeout waiting for process %s to start", path.Base(ps.Path))
+	}
+}
+
+// Exited returns true if the process exited, and may also
+// return an error (as per Cmd.Wait) if the process did not
+// exit with error code 0.
+func (ps *State) Exited() (bool, error) {
+	ps.errMu.Lock()
+	defer ps.errMu.Unlock()
+	return ps.exited, ps.exitErr
+}
+
+func pollURLUntilOK(url url.URL, interval time.Duration, ready chan bool, stopCh stopChannel) {
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				// there's probably certs *somewhere*,
+				// but it's fine to just skip validating
+				// them for health checks during testing
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+	if interval <= 0 {
+		interval = 100 * time.Millisecond
+	}
+	for {
+		res, err := client.Get(url.String())
+		if err == nil {
+			res.Body.Close()
+			if res.StatusCode == http.StatusOK {
+				ready <- true
+				return
+			}
+		}
+
+		select {
+		case <-stopCh:
+			return
+		default:
+			time.Sleep(interval)
+		}
+	}
+}
+
+// Stop stops this process gracefully, waits for its termination, and cleans up
+// the CertDir if necessary.
+func (ps *State) Stop() error {
+	// Always clear the directory if we need to.
+	defer func() {
+		if ps.DirNeedsCleaning {
+			_ = os.RemoveAll(ps.Dir)
+		}
+	}()
+	if ps.Cmd == nil {
+		return nil
+	}
+	if done, _ := ps.Exited(); done {
+		return nil
+	}
+	if err := ps.Cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("unable to signal for process %s to stop: %w", ps.Path, err)
+	}
+
+	timedOut := time.After(ps.StopTimeout)
+
+	select {
+	case <-ps.waitDone:
+		break
+	case <-timedOut:
+		if err := ps.Cmd.Process.Signal(syscall.SIGKILL); err != nil {
+			return fmt.Errorf("unable to kill process %s: %w", ps.Path, err)
+		}
+		return fmt.Errorf("timeout waiting for process %s to stop", path.Base(ps.Path))
+	}
+	ps.ready = false
+	return nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/client_go_adapter.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/client_go_adapter.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	clientmetrics "k8s.io/client-go/tools/metrics"
+)
+
+// this file contains setup logic to initialize the myriad of places
+// that client-go registers metrics.  We copy the names and formats
+// from Kubernetes so that we match the core controllers.
+
+var (
+	// client metrics.
+
+	requestResult = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "rest_client_requests_total",
+			Help: "Number of HTTP requests, partitioned by status code, method, and host.",
+		},
+		[]string{"code", "method", "host"},
+	)
+)
+
+func init() {
+	registerClientMetrics()
+}
+
+// registerClientMetrics sets up the client latency metrics from client-go.
+func registerClientMetrics() {
+	// register the metrics with our registry
+	Registry.MustRegister(requestResult)
+
+	// register the metrics with client-go
+	clientmetrics.Register(clientmetrics.RegisterOpts{
+		RequestResult: &resultAdapter{metric: requestResult},
+	})
+}
+
+// this section contains adapters, implementations, and other sundry organic, artisanally
+// hand-crafted syntax trees required to convince client-go that it actually wants to let
+// someone use its metrics.
+
+// Client metrics adapters (method #1 for client-go metrics),
+// copied (more-or-less directly) from k8s.io/kubernetes setup code
+// (which isn't anywhere in an easily-importable place).
+
+type resultAdapter struct {
+	metric *prometheus.CounterVec
+}
+
+func (r *resultAdapter) Increment(_ context.Context, code, method, host string) {
+	r.metric.WithLabelValues(code, method, host).Inc()
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package metrics contains controller related metrics utilities
+*/
+package metrics

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/leaderelection.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/leaderelection.go
@@ -1,0 +1,47 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/tools/leaderelection"
+)
+
+// This file is copied and adapted from k8s.io/component-base/metrics/prometheus/clientgo/leaderelection
+// which registers metrics to the k8s legacy Registry. We require very
+// similar functionality, but must register metrics to a different Registry.
+
+var (
+	leaderGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "leader_election_master_status",
+		Help: "Gauge of if the reporting system is master of the relevant lease, 0 indicates backup, 1 indicates master. 'name' is the string used to identify the lease. Please make sure to group by name.",
+	}, []string{"name"})
+
+	leaderSlowpathCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "leader_election_slowpath_total",
+		Help: "Total number of slow path exercised in renewing leader leases. 'name' is the string used to identify the lease. Please make sure to group by name.",
+	}, []string{"name"})
+)
+
+func init() {
+	Registry.MustRegister(leaderGauge)
+	leaderelection.SetProvider(leaderelectionMetricsProvider{})
+}
+
+type leaderelectionMetricsProvider struct{}
+
+func (leaderelectionMetricsProvider) NewLeaderMetric() leaderelection.LeaderMetric {
+	return leaderElectionPrometheusAdapter{}
+}
+
+type leaderElectionPrometheusAdapter struct{}
+
+func (s leaderElectionPrometheusAdapter) On(name string) {
+	leaderGauge.WithLabelValues(name).Set(1.0)
+}
+
+func (s leaderElectionPrometheusAdapter) Off(name string) {
+	leaderGauge.WithLabelValues(name).Set(0.0)
+}
+
+func (leaderElectionPrometheusAdapter) SlowpathExercised(name string) {
+	leaderSlowpathCounter.WithLabelValues(name).Inc()
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/registry.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/registry.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// RegistererGatherer combines both parts of the API of a Prometheus
+// registry, both the Registerer and the Gatherer interfaces.
+type RegistererGatherer interface {
+	prometheus.Registerer
+	prometheus.Gatherer
+}
+
+// Registry is a prometheus registry for storing metrics within the
+// controller-runtime.
+var Registry RegistererGatherer = prometheus.NewRegistry()

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/workqueue.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/workqueue.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+// Metrics subsystem and all keys used by the workqueue.
+const (
+	WorkQueueSubsystem         = "workqueue"
+	DepthKey                   = "depth"
+	AddsKey                    = "adds_total"
+	QueueLatencyKey            = "queue_duration_seconds"
+	WorkDurationKey            = "work_duration_seconds"
+	UnfinishedWorkKey          = "unfinished_work_seconds"
+	LongestRunningProcessorKey = "longest_running_processor_seconds"
+	RetriesKey                 = "retries_total"
+)

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/conversion/conversion.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/conversion/conversion.go
@@ -1,0 +1,365 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package conversion provides implementation for CRD conversion webhook that implements handler for version conversion requests for types that are convertible.
+
+See pkg/conversion for interface definitions required to ensure an API Type is convertible.
+*/
+package conversion
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	apix "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	conversionmetrics "sigs.k8s.io/controller-runtime/pkg/webhook/conversion/metrics"
+)
+
+var (
+	log = logf.Log.WithName("conversion-webhook")
+)
+
+func NewWebhookHandler(scheme *runtime.Scheme, registry Registry) http.Handler {
+	return &webhook{scheme: scheme, decoder: NewDecoder(scheme), registry: registry}
+}
+
+// webhook implements a CRD conversion webhook HTTP handler.
+type webhook struct {
+	scheme   *runtime.Scheme
+	decoder  *Decoder
+	registry Registry
+}
+
+// ensure Webhook implements http.Handler
+var _ http.Handler = &webhook{}
+
+func (wh *webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	convertReview := &apix.ConversionReview{}
+	err := json.NewDecoder(r.Body).Decode(convertReview)
+	if err != nil {
+		log.Error(err, "failed to read conversion request")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if convertReview.Request == nil {
+		log.Error(nil, "conversion request is nil")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// TODO(droot): may be move the conversion logic to a separate module to
+	// decouple it from the http layer ?
+	resp, err := wh.handleConvertRequest(ctx, convertReview.Request)
+	if err != nil {
+		log.Error(err, "failed to convert", "request", convertReview.Request.UID)
+		convertReview.Response = errored(err)
+	} else {
+		convertReview.Response = resp
+	}
+	convertReview.Response.UID = convertReview.Request.UID
+	convertReview.Request = nil
+
+	err = json.NewEncoder(w).Encode(convertReview)
+	if err != nil {
+		log.Error(err, "failed to write response")
+		return
+	}
+}
+
+// handles a version conversion request.
+func (wh *webhook) handleConvertRequest(ctx context.Context, req *apix.ConversionRequest) (_ *apix.ConversionResponse, retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			conversionmetrics.WebhookPanics.WithLabelValues().Inc()
+
+			for _, fn := range utilruntime.PanicHandlers {
+				fn(ctx, r)
+			}
+			retErr = errors.New("internal error occurred during conversion")
+			return
+		}
+	}()
+	if req == nil {
+		return nil, fmt.Errorf("conversion request is nil")
+	}
+	var objects []runtime.RawExtension
+
+	for _, obj := range req.Objects {
+		src, gvk, err := wh.decoder.Decode(obj.Raw)
+		if err != nil {
+			return nil, err
+		}
+		dst, err := wh.allocateDstObject(req.DesiredAPIVersion, gvk.Kind)
+		if err != nil {
+			return nil, err
+		}
+		err = wh.convertObject(ctx, src, dst)
+		if err != nil {
+			return nil, err
+		}
+		objects = append(objects, runtime.RawExtension{Object: dst})
+	}
+	return &apix.ConversionResponse{
+		UID:              req.UID,
+		ConvertedObjects: objects,
+		Result: metav1.Status{
+			Status: metav1.StatusSuccess,
+		},
+	}, nil
+}
+
+// convertObject will convert given a src object to dst object.
+// Note(droot): couldn't find a way to reduce the cyclomatic complexity under 10
+// without compromising readability, so disabling gocyclo linter
+func (wh *webhook) convertObject(ctx context.Context, src, dst runtime.Object) error {
+	srcGVK := src.GetObjectKind().GroupVersionKind()
+	dstGVK := dst.GetObjectKind().GroupVersionKind()
+
+	if srcGVK.GroupKind() != dstGVK.GroupKind() {
+		return fmt.Errorf("src %T and dst %T does not belong to same API Group", src, dst)
+	}
+
+	if srcGVK == dstGVK {
+		return fmt.Errorf("conversion is not allowed between same type %T", src)
+	}
+
+	if converter, ok := wh.registry.GetConverter(srcGVK.GroupKind()); ok {
+		return converter.ConvertObject(ctx, src, dst)
+	}
+
+	srcIsHub, dstIsHub := isHub(src), isHub(dst)
+	srcIsConvertible, dstIsConvertible := isConvertible(src), isConvertible(dst)
+
+	switch {
+	case srcIsHub && dstIsConvertible:
+		return dst.(conversion.Convertible).ConvertFrom(src.(conversion.Hub))
+	case dstIsHub && srcIsConvertible:
+		return src.(conversion.Convertible).ConvertTo(dst.(conversion.Hub))
+	case srcIsConvertible && dstIsConvertible:
+		return wh.convertViaHub(src.(conversion.Convertible), dst.(conversion.Convertible))
+	default:
+		return fmt.Errorf("%T is not convertible to %T", src, dst)
+	}
+}
+
+func (wh *webhook) convertViaHub(src, dst conversion.Convertible) error {
+	hub, err := wh.getHub(src)
+	if err != nil {
+		return err
+	}
+
+	if hub == nil {
+		return fmt.Errorf("%s does not have any Hub defined", src)
+	}
+
+	err = src.ConvertTo(hub)
+	if err != nil {
+		return fmt.Errorf("%T failed to convert to hub version %T : %w", src, hub, err)
+	}
+
+	err = dst.ConvertFrom(hub)
+	if err != nil {
+		return fmt.Errorf("%T failed to convert from hub version %T : %w", dst, hub, err)
+	}
+
+	return nil
+}
+
+// getHub returns an instance of the Hub for passed-in object's group/kind.
+func (wh *webhook) getHub(obj runtime.Object) (conversion.Hub, error) {
+	gvks, err := objectGVKs(wh.scheme, obj)
+	if err != nil {
+		return nil, err
+	}
+	if len(gvks) == 0 {
+		return nil, fmt.Errorf("error retrieving gvks for object : %v", obj)
+	}
+
+	var hub conversion.Hub
+	var hubFoundAlready bool
+	for _, gvk := range gvks {
+		instance, err := wh.scheme.New(gvk)
+		if err != nil {
+			return nil, fmt.Errorf("failed to allocate an instance for gvk %v: %w", gvk, err)
+		}
+		if val, isHub := instance.(conversion.Hub); isHub {
+			if hubFoundAlready {
+				return nil, fmt.Errorf("multiple hub version defined for %T", obj)
+			}
+			hubFoundAlready = true
+			hub = val
+		}
+	}
+	return hub, nil
+}
+
+// allocateDstObject returns an instance for a given GVK.
+func (wh *webhook) allocateDstObject(apiVersion, kind string) (runtime.Object, error) {
+	gvk := schema.FromAPIVersionAndKind(apiVersion, kind)
+
+	obj, err := wh.scheme.New(gvk)
+	if err != nil {
+		return obj, err
+	}
+
+	t, err := meta.TypeAccessor(obj)
+	if err != nil {
+		return obj, err
+	}
+
+	t.SetAPIVersion(apiVersion)
+	t.SetKind(kind)
+
+	return obj, nil
+}
+
+// IsConvertible determines if given type is convertible or not. For a type
+// to be convertible, the group-kind needs to have a Hub type defined and all
+// non-hub types must be able to convert to/from Hub.
+func IsConvertible(scheme *runtime.Scheme, obj runtime.Object) (bool, error) {
+	var hubs, spokes, nonSpokes []runtime.Object
+
+	gvks, err := objectGVKs(scheme, obj)
+	if err != nil {
+		return false, err
+	}
+	if len(gvks) == 0 {
+		return false, fmt.Errorf("error retrieving gvks for object : %v", obj)
+	}
+
+	for _, gvk := range gvks {
+		instance, err := scheme.New(gvk)
+		if err != nil {
+			return false, fmt.Errorf("failed to allocate an instance for gvk %v: %w", gvk, err)
+		}
+
+		if isHub(instance) {
+			hubs = append(hubs, instance)
+			continue
+		}
+
+		if !isConvertible(instance) {
+			nonSpokes = append(nonSpokes, instance)
+			continue
+		}
+
+		spokes = append(spokes, instance)
+	}
+
+	if len(gvks) == 1 {
+		return false, nil // single version
+	}
+
+	if len(hubs) == 0 && len(spokes) == 0 {
+		// multiple version detected with no conversion implementation. This is
+		// true for multi-version built-in types.
+		return false, nil
+	}
+
+	if len(hubs) == 1 && len(nonSpokes) == 0 { // convertible
+		return true, nil
+	}
+
+	return false, PartialImplementationError{
+		hubs:      hubs,
+		nonSpokes: nonSpokes,
+		spokes:    spokes,
+	}
+}
+
+// objectGVKs returns all (Group,Version,Kind) for the Group/Kind of given object.
+func objectGVKs(scheme *runtime.Scheme, obj runtime.Object) ([]schema.GroupVersionKind, error) {
+	// NB: we should not use `obj.GetObjectKind().GroupVersionKind()` to get the
+	// GVK here, since it is parsed from apiVersion and kind fields and it may
+	// return empty GVK if obj is an uninitialized object.
+	objGVKs, _, err := scheme.ObjectKinds(obj)
+	if err != nil {
+		return nil, err
+	}
+	if len(objGVKs) != 1 {
+		return nil, fmt.Errorf("expect to get only one GVK for %v", obj)
+	}
+	objGVK := objGVKs[0]
+	knownTypes := scheme.AllKnownTypes()
+
+	var gvks []schema.GroupVersionKind
+	for gvk := range knownTypes {
+		if objGVK.GroupKind() == gvk.GroupKind() {
+			gvks = append(gvks, gvk)
+		}
+	}
+	return gvks, nil
+}
+
+// PartialImplementationError represents an error due to partial conversion
+// implementation such as hub without spokes, multiple hubs or spokes without hub.
+type PartialImplementationError struct {
+	gvk       schema.GroupVersionKind
+	hubs      []runtime.Object
+	nonSpokes []runtime.Object
+	spokes    []runtime.Object
+}
+
+func (e PartialImplementationError) Error() string {
+	if len(e.hubs) == 0 {
+		return fmt.Sprintf("no hub defined for gvk %s", e.gvk)
+	}
+	if len(e.hubs) > 1 {
+		return fmt.Sprintf("multiple(%d) hubs defined for group-kind '%s' ",
+			len(e.hubs), e.gvk.GroupKind())
+	}
+	if len(e.nonSpokes) > 0 {
+		return fmt.Sprintf("%d inconvertible types detected for group-kind '%s'",
+			len(e.nonSpokes), e.gvk.GroupKind())
+	}
+	return ""
+}
+
+// isHub determines if passed-in object is a Hub or not.
+func isHub(obj runtime.Object) bool {
+	_, yes := obj.(conversion.Hub)
+	return yes
+}
+
+// isConvertible determines if passed-in object is a convertible.
+func isConvertible(obj runtime.Object) bool {
+	_, yes := obj.(conversion.Convertible)
+	return yes
+}
+
+// helper to construct error response.
+func errored(err error) *apix.ConversionResponse {
+	return &apix.ConversionResponse{
+		Result: metav1.Status{
+			Status:  metav1.StatusFailure,
+			Message: err.Error(),
+		},
+	}
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/conversion/conversion_hubspoke.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/conversion/conversion_hubspoke.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conversion
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+func NewHubSpokeConverter[hubObject runtime.Object](hub hubObject, spokeConverter ...SpokeConverter[hubObject]) func(scheme *runtime.Scheme) (Converter, error) {
+	return func(scheme *runtime.Scheme) (Converter, error) {
+		hubGVK, err := apiutil.GVKForObject(hub, scheme)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create hub spoke converter: failed to get GroupVersionKind for hub: %w", err)
+		}
+		allGVKs, err := objectGVKs(scheme, hub)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create hub spoke converter for %s: %w", hubGVK.Kind, err)
+		}
+		spokeVersions := sets.New[string]()
+		for _, gvk := range allGVKs {
+			if gvk != hubGVK {
+				spokeVersions.Insert(gvk.Version)
+			}
+		}
+
+		c := &hubSpokeConverter[hubObject]{
+			scheme:              scheme,
+			hubGVK:              hubGVK,
+			spokeConverterByGVK: map[schema.GroupVersionKind]SpokeConverter[hubObject]{},
+		}
+
+		spokeConverterVersions := sets.New[string]()
+		for _, sc := range spokeConverter {
+			spokeGVK, err := apiutil.GVKForObject(sc.GetSpoke(), scheme)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create hub spoke converter for %s: "+
+					"failed to get GroupVersionKind for spoke converter: %w",
+					hubGVK.Kind, err)
+			}
+			if hubGVK.GroupKind() != spokeGVK.GroupKind() {
+				return nil, fmt.Errorf("failed to create hub spoke converter for %s: "+
+					"spoke converter GroupKind %s does not match hub GroupKind %s",
+					hubGVK.Kind, spokeGVK.GroupKind(), hubGVK.GroupKind())
+			}
+
+			if _, ok := c.spokeConverterByGVK[spokeGVK]; ok {
+				return nil, fmt.Errorf("failed to create hub spoke converter for %s: "+
+					"duplicate spoke converter for version %s",
+					hubGVK.Kind, spokeGVK.Version)
+			}
+			c.spokeConverterByGVK[spokeGVK] = sc
+			spokeConverterVersions.Insert(spokeGVK.Version)
+		}
+
+		if !spokeConverterVersions.Equal(spokeVersions) {
+			return nil, fmt.Errorf("failed to create hub spoke converter for %s: "+
+				"expected spoke converter for %s got spoke converter for %s",
+				hubGVK.Kind, sortAndJoin(spokeVersions), sortAndJoin(spokeConverterVersions))
+		}
+
+		return c, nil
+	}
+}
+
+func sortAndJoin(set sets.Set[string]) string {
+	list := set.UnsortedList()
+	slices.Sort(list)
+	return strings.Join(list, ",")
+}
+
+type hubSpokeConverter[hubObject runtime.Object] struct {
+	scheme              *runtime.Scheme
+	hubGVK              schema.GroupVersionKind
+	spokeConverterByGVK map[schema.GroupVersionKind]SpokeConverter[hubObject]
+}
+
+func (c hubSpokeConverter[hubObject]) ConvertObject(ctx context.Context, src, dst runtime.Object) error {
+	srcGVK := src.GetObjectKind().GroupVersionKind()
+	dstGVK := dst.GetObjectKind().GroupVersionKind()
+
+	if srcGVK.GroupKind() != dstGVK.GroupKind() {
+		return fmt.Errorf("src %T and dst %T does not belong to same API Group", src, dst)
+	}
+
+	if srcGVK == dstGVK {
+		return fmt.Errorf("conversion is not allowed between same type %T", src)
+	}
+
+	srcIsHub := c.hubGVK == srcGVK
+	dstIsHub := c.hubGVK == dstGVK
+	_, srcIsConvertible := c.spokeConverterByGVK[srcGVK]
+	_, dstIsConvertible := c.spokeConverterByGVK[dstGVK]
+
+	switch {
+	case srcIsHub && dstIsConvertible:
+		return c.spokeConverterByGVK[dstGVK].ConvertHubToSpoke(ctx, src.(hubObject), dst)
+	case dstIsHub && srcIsConvertible:
+		return c.spokeConverterByGVK[srcGVK].ConvertSpokeToHub(ctx, src, dst.(hubObject))
+	case srcIsConvertible && dstIsConvertible:
+		hub, err := c.scheme.New(c.hubGVK)
+		if err != nil {
+			return fmt.Errorf("failed to allocate an instance for GroupVersionKind %s: %w", c.hubGVK, err)
+		}
+		if err := c.spokeConverterByGVK[srcGVK].ConvertSpokeToHub(ctx, src, hub.(hubObject)); err != nil {
+			return fmt.Errorf("failed to convert spoke %s to hub %s : %w", srcGVK, c.hubGVK, err)
+		}
+		if err := c.spokeConverterByGVK[dstGVK].ConvertHubToSpoke(ctx, hub.(hubObject), dst); err != nil {
+			return fmt.Errorf("failed to convert hub %s to spoke %s : %w", c.hubGVK, dstGVK, err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("failed to convert %s to %s: not convertible", srcGVK, dstGVK)
+	}
+}
+
+type SpokeConverter[hubObject runtime.Object] interface {
+	GetSpoke() runtime.Object
+	ConvertHubToSpoke(ctx context.Context, hub hubObject, spoke runtime.Object) error
+	ConvertSpokeToHub(ctx context.Context, spoke runtime.Object, hub hubObject) error
+}
+
+func NewSpokeConverter[hubObject, spokeObject client.Object](
+	spoke spokeObject,
+	convertHubToSpokeFunc func(ctx context.Context, src hubObject, dst spokeObject) error,
+	convertSpokeToHubFunc func(ctx context.Context, src spokeObject, dst hubObject) error,
+) SpokeConverter[hubObject] {
+	return &spokeConverter[hubObject, spokeObject]{
+		spoke:                 spoke,
+		convertSpokeToHubFunc: convertSpokeToHubFunc,
+		convertHubToSpokeFunc: convertHubToSpokeFunc,
+	}
+}
+
+type spokeConverter[hubObject, spokeObject runtime.Object] struct {
+	spoke                 spokeObject
+	convertHubToSpokeFunc func(ctx context.Context, src hubObject, dst spokeObject) error
+	convertSpokeToHubFunc func(ctx context.Context, src spokeObject, dst hubObject) error
+}
+
+func (c spokeConverter[hubObject, spokeObject]) GetSpoke() runtime.Object {
+	return c.spoke
+}
+
+func (c spokeConverter[hubObject, spokeObject]) ConvertHubToSpoke(ctx context.Context, hub hubObject, spoke runtime.Object) error {
+	return c.convertHubToSpokeFunc(ctx, hub, spoke.(spokeObject))
+}
+
+func (c spokeConverter[hubObject, spokeObject]) ConvertSpokeToHub(ctx context.Context, spoke runtime.Object, hub hubObject) error {
+	return c.convertSpokeToHubFunc(ctx, spoke.(spokeObject), hub)
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/conversion/conversion_registry.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/conversion/conversion_registry.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conversion
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type Converter interface {
+	ConvertObject(ctx context.Context, src, dst runtime.Object) error
+}
+
+type Registry interface {
+	RegisterConverter(gk schema.GroupKind, converter Converter) error
+	GetConverter(gk schema.GroupKind) (Converter, bool)
+}
+
+type registry struct {
+	converterByGK map[schema.GroupKind]Converter
+}
+
+func NewRegistry() Registry {
+	return registry{
+		converterByGK: map[schema.GroupKind]Converter{},
+	}
+}
+func (r registry) RegisterConverter(gk schema.GroupKind, converter Converter) error {
+	if _, ok := r.converterByGK[gk]; ok {
+		return fmt.Errorf("failed to register Converter for GroupKind %s: converter already registered", gk)
+	}
+
+	r.converterByGK[gk] = converter
+	return nil
+}
+
+func (r registry) GetConverter(gk schema.GroupKind) (Converter, bool) {
+	c, ok := r.converterByGK[gk]
+	return c, ok
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/conversion/decoder.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/conversion/decoder.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conversion
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+// Decoder knows how to decode the contents of a CRD version conversion
+// request into a concrete object.
+// TODO(droot): consider reusing decoder from admission pkg for this.
+type Decoder struct {
+	codecs serializer.CodecFactory
+}
+
+// NewDecoder creates a Decoder given the runtime.Scheme
+func NewDecoder(scheme *runtime.Scheme) *Decoder {
+	if scheme == nil {
+		panic("scheme should never be nil")
+	}
+	return &Decoder{codecs: serializer.NewCodecFactory(scheme)}
+}
+
+// Decode decodes the inlined object.
+func (d *Decoder) Decode(content []byte) (runtime.Object, *schema.GroupVersionKind, error) {
+	deserializer := d.codecs.UniversalDeserializer()
+	return deserializer.Decode(content, nil, nil)
+}
+
+// DecodeInto decodes the inlined object in the into the passed-in runtime.Object.
+func (d *Decoder) DecodeInto(content []byte, into runtime.Object) error {
+	deserializer := d.codecs.UniversalDeserializer()
+	return runtime.DecodeInto(deserializer, content, into)
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/conversion/metrics/metrics.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/conversion/metrics/metrics.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// WebhookPanics is a prometheus counter metrics which holds the total
+	// number of panics from conversion webhooks.
+	WebhookPanics = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "controller_runtime_conversion_webhook_panics_total",
+		Help: "Total number of conversion webhook panics",
+	}, []string{})
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		WebhookPanics,
+	)
+	// Init metric.
+	WebhookPanics.WithLabelValues().Add(0)
+}


### PR DESCRIPTION
Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test suite validating AdmissionFairSharing configuration rules. Covers missing configuration fields, unqualified resource identifiers, non-numeric and negative weights, and confirms successful updates when resource names are fully qualified and weights are valid. The suite runs against a temporary control plane to exercise real validation behavior and cleans up the test environment after completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->