### PR TITLE
OCPKUEUE-625: Enable ElasticJobsViaWorkloadSlices for Ray integrations

### DIFF
--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -217,6 +217,19 @@ func buildFeatureGates(resources kueue.Resources, frameworks []kueue.KueueIntegr
 		}
 	}
 
+	// ElasticJobsViaWorkloadSlices is Alpha in Kueue, so we explicitly enable it
+	// when any Ray integration (RayJob, RayCluster, or RayService) is in the
+	// frameworks list. Once it graduates to Beta in upstream Kueue, it will be
+	// enabled by default and this explicit enablement won't be necessary.
+	for _, f := range frameworks {
+		switch f {
+		case kueue.KueueIntegrationRayJob,
+			kueue.KueueIntegrationRayCluster,
+			kueue.KueueIntegrationRayService:
+			featureGates["ElasticJobsViaWorkloadSlices"] = true
+		}
+	}
+
 	// ShortWorkloadNames is Alpha in Kueue. Enable it when external frameworks
 	// are configured to prevent workload names from exceeding the 63-character
 	// Kubernetes label value limit in the MultiKueue external frameworks adapter.

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -115,6 +115,8 @@ controller:
     Pod: 5
     ResourceFlavor.kueue.x-k8s.io: 1
     Workload.kueue.x-k8s.io: 5
+featureGates:
+  ElasticJobsViaWorkloadSlices: true
 health:
   healthProbeBindAddress: :8081
 integrations:
@@ -885,6 +887,220 @@ integrations:
   - pipelineruns.v1.tekton.dev
   frameworks:
   - batch/job
+internalCertManagement:
+  enable: false
+kind: Configuration
+leaderElection:
+  leaderElect: true
+  leaseDuration: 2m17s
+  renewDeadline: 1m47s
+  resourceLock: ""
+  resourceName: ""
+  resourceNamespace: ""
+  retryPeriod: 26s
+manageJobsWithoutQueueName: false
+managedJobsNamespaceSelector:
+  matchLabels:
+    kueue.openshift.io/managed: "true"
+metrics:
+  bindAddress: :8443
+  enableClusterQueueResources: true
+namespace: test
+webhook:
+  port: 9443
+`,
+				},
+			},
+			wantErr: nil,
+		},
+		"ray job enables elastic workload slices": {
+			configuration: kueue.KueueConfiguration{
+				Integrations: kueue.Integrations{
+					Frameworks: []kueue.KueueIntegration{kueue.KueueIntegrationRayJob},
+				},
+			},
+			wantCfgMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+clientConnection:
+  burst: 100
+  qps: 50
+controller:
+  groupKindConcurrency:
+    ClusterQueue.kueue.x-k8s.io: 1
+    Job.batch: 5
+    LocalQueue.kueue.x-k8s.io: 1
+    Pod: 5
+    ResourceFlavor.kueue.x-k8s.io: 1
+    Workload.kueue.x-k8s.io: 5
+featureGates:
+  ElasticJobsViaWorkloadSlices: true
+health:
+  healthProbeBindAddress: :8081
+integrations:
+  frameworks:
+  - ray.io/rayjob
+internalCertManagement:
+  enable: false
+kind: Configuration
+leaderElection:
+  leaderElect: true
+  leaseDuration: 2m17s
+  renewDeadline: 1m47s
+  resourceLock: ""
+  resourceName: ""
+  resourceNamespace: ""
+  retryPeriod: 26s
+manageJobsWithoutQueueName: false
+managedJobsNamespaceSelector:
+  matchLabels:
+    kueue.openshift.io/managed: "true"
+metrics:
+  bindAddress: :8443
+  enableClusterQueueResources: true
+namespace: test
+webhook:
+  port: 9443
+`,
+				},
+			},
+			wantErr: nil,
+		},
+		"ray cluster enables elastic workload slices": {
+			configuration: kueue.KueueConfiguration{
+				Integrations: kueue.Integrations{
+					Frameworks: []kueue.KueueIntegration{kueue.KueueIntegrationRayCluster},
+				},
+			},
+			wantCfgMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+clientConnection:
+  burst: 100
+  qps: 50
+controller:
+  groupKindConcurrency:
+    ClusterQueue.kueue.x-k8s.io: 1
+    Job.batch: 5
+    LocalQueue.kueue.x-k8s.io: 1
+    Pod: 5
+    ResourceFlavor.kueue.x-k8s.io: 1
+    Workload.kueue.x-k8s.io: 5
+featureGates:
+  ElasticJobsViaWorkloadSlices: true
+health:
+  healthProbeBindAddress: :8081
+integrations:
+  frameworks:
+  - ray.io/raycluster
+internalCertManagement:
+  enable: false
+kind: Configuration
+leaderElection:
+  leaderElect: true
+  leaseDuration: 2m17s
+  renewDeadline: 1m47s
+  resourceLock: ""
+  resourceName: ""
+  resourceNamespace: ""
+  retryPeriod: 26s
+manageJobsWithoutQueueName: false
+managedJobsNamespaceSelector:
+  matchLabels:
+    kueue.openshift.io/managed: "true"
+metrics:
+  bindAddress: :8443
+  enableClusterQueueResources: true
+namespace: test
+webhook:
+  port: 9443
+`,
+				},
+			},
+			wantErr: nil,
+		},
+		"ray service enables elastic workload slices": {
+			configuration: kueue.KueueConfiguration{
+				Integrations: kueue.Integrations{
+					Frameworks: []kueue.KueueIntegration{kueue.KueueIntegrationRayService},
+				},
+			},
+			wantCfgMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+clientConnection:
+  burst: 100
+  qps: 50
+controller:
+  groupKindConcurrency:
+    ClusterQueue.kueue.x-k8s.io: 1
+    Job.batch: 5
+    LocalQueue.kueue.x-k8s.io: 1
+    Pod: 5
+    ResourceFlavor.kueue.x-k8s.io: 1
+    Workload.kueue.x-k8s.io: 5
+featureGates:
+  ElasticJobsViaWorkloadSlices: true
+health:
+  healthProbeBindAddress: :8081
+integrations:
+  frameworks:
+  - ray.io/rayservice
+internalCertManagement:
+  enable: false
+kind: Configuration
+leaderElection:
+  leaderElect: true
+  leaseDuration: 2m17s
+  renewDeadline: 1m47s
+  resourceLock: ""
+  resourceName: ""
+  resourceNamespace: ""
+  retryPeriod: 26s
+manageJobsWithoutQueueName: false
+managedJobsNamespaceSelector:
+  matchLabels:
+    kueue.openshift.io/managed: "true"
+metrics:
+  bindAddress: :8443
+  enableClusterQueueResources: true
+namespace: test
+webhook:
+  port: 9443
+`,
+				},
+			},
+			wantErr: nil,
+		},
+		"spark and ray enables both feature gates": {
+			configuration: kueue.KueueConfiguration{
+				Integrations: kueue.Integrations{
+					Frameworks: []kueue.KueueIntegration{kueue.KueueIntegrationSparkApplication, kueue.KueueIntegrationRayJob},
+				},
+			},
+			wantCfgMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+clientConnection:
+  burst: 100
+  qps: 50
+controller:
+  groupKindConcurrency:
+    ClusterQueue.kueue.x-k8s.io: 1
+    Job.batch: 5
+    LocalQueue.kueue.x-k8s.io: 1
+    Pod: 5
+    ResourceFlavor.kueue.x-k8s.io: 1
+    Workload.kueue.x-k8s.io: 5
+featureGates:
+  ElasticJobsViaWorkloadSlices: true
+  SparkApplicationIntegration: true
+health:
+  healthProbeBindAddress: :8081
+integrations:
+  frameworks:
+  - sparkoperator.k8s.io/sparkapplication
+  - ray.io/rayjob
 internalCertManagement:
   enable: false
 kind: Configuration


### PR DESCRIPTION
## Summary
- Automatically enable the `ElasticJobsViaWorkloadSlices` Kueue feature gate when any Ray integration (RayJob, RayCluster, or RayService) is configured in the frameworks list
- Follows the same pattern used for `SparkApplicationIntegration` feature gate enablement

## Details
The `ElasticJobsViaWorkloadSlices` feature gate is Alpha in upstream Kueue (since 0.13) and enables elastic workload slicing needed for Ray's elastic scaling support. Once it graduates to Beta upstream, this explicit enablement will become a no-op and can be removed.

JIRA: https://redhat.atlassian.net/browse/OCPKUEUE-625

## Test plan
- [x] Unit test: RayJob alone enables the feature gate
- [x] Unit test: RayService alone enables the feature gate
- [x] Unit test: RayCluster (via existing rhoai example) enables the feature gate
- [x] Unit test: SparkApplication + RayJob enables both feature gates
- [x] Existing negative tests (batch job, ibm example) confirm non-Ray frameworks do not enable it

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI (Claude Code by Anthropic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Ray integrations (RayJob, RayCluster, RayService) now automatically enable the ElasticJobsViaWorkloadSlices feature gate.
  * When Ray integrations are enabled alongside Spark integration, both relevant feature gates are enabled.

* **Tests**
  * Expanded coverage for Ray-only, combined Ray+Spark, and multiple Ray integration scenarios; corrected expected YAML output for an integration case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->