### PR TITLE
NO-JIRA: Update kueue submodule to 5252f419e

### DIFF
--- a/bindata/assets/kueue-operator/crds/crd-clusterqueues.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-clusterqueues.kueue.x-k8s.io-v1beta2.yaml
@@ -935,6 +935,53 @@ spec:
                 maxLength: 253
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
+              concurrentAdmissionPolicy:
+                description: |-
+                  concurrentAdmissionPolicy defines the configuration for ConcurrentAdmission feature.
+                  Its main capability is to allow Workloads pursuing multiple flavors at the same time, and starting on the first flavor that led to admission.
+                  Additionally after the admission, Workloads can still try to pursue capacity on the more preferable flavors while running.
+                  It enables them to migrate to more preferable, whenever capacity appears.
+                properties:
+                  migration:
+                    description: |-
+                      migration defines the constraints on Workload's migration.
+                      The mechanism itself creates "Variants" of the same Workload, each pursuing a different flavor.
+                      All Variants belong to the same "Parent" Workload, and are picked up by Kueue scheduler independently.
+                      Once one of the Variants is admitted, the Parent Workload gets also admitted. The Variants that pursue more
+                      favorable flavors keep trying to get admitted and if they succeed, the Workload migrates to the new flavor.
+                      The Variants that pursue less favorable flavors are deactivated.
+                      Flavor preferences are expressed through the order of flavors in the ClusterQueue.
+                    properties:
+                      constraints:
+                        description: constraints defines the constraints of Workload's
+                          migration.
+                        properties:
+                          minPreferredFlavorName:
+                            description: |-
+                              minPreferredFlavorName defines the minimal flavor a Workload can migrate to.
+                              The order is based on the order of flavors in ClusterQueue.
+                              It can only be used if the Mode is `TryPreferredFlavors`.
+                              If the Mode is `TryPreferredFlavors` and MinPreferredFlavorName is not specified, then
+                              Workload can migrate to any flavor that is more preferable than the one it was admitted to.
+                            maxLength: 253
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                        type: object
+                      mode:
+                        description: |-
+                          mode defines the mode of Workload's migration.
+                          The possible values are:
+                          - `TryPreferredFlavors` (default): a Workload will try to migrate to the preferred flavor after it's admitted and running.
+                        enum:
+                        - TryPreferredFlavors
+                        maxLength: 253
+                        type: string
+                    required:
+                    - mode
+                    type: object
+                required:
+                - migration
+                type: object
               fairSharing:
                 description: |-
                   fairSharing defines the properties of the ClusterQueue when


### PR DESCRIPTION
## Summary
- Update kueue submodule from `df4b1c04a` to `5252f419ec2610443a8f8af67bdb3af84b172094`
- Synced manifests — updated ClusterQueue CRD with new `concurrentAdmissionPolicy` field

## Upstream changes (df4b1c04a..5252f419e)

### Features
- Introduce MVP version of Concurrent Admission feature (#10610)
- Add metrics for age of pending workloads and time to preemption (#10323)
- Allow mutating queue-name label in LeaderWorkerSet (#4932)
- Relax PodSpec validation for LeaderWorkerSet (#10275)
- Add RayService e2e autoscaling test (#10252)

### Promotions to Stable
- Promote MultiKueueRedoAdmissionOnEvictionInWorker to stable (#10695)
- Promote MultiKueueWaitForWorkloadAdmitted to stable (#10656)
- Promote SkipFinalizersForPodsSuspendedByParent to stable (#10645)
- Fix TLSOptions version to GA (#10722)

### Bug Fixes
- Fix ClusterQueue finalizer after admission failure (#10821)
- TAS: NodeHotSwap should not add "late pods" to UnhealthyNodes (#10760)
- Fix TAS stateWithLeader aggregation for grouped podsets (#10783)
- Fix nil panic in TAS node controller when referencing nil .status.admission (#10641)
- Forcefully delete Failed/Succeeded pods stuck on unreachable nodes (#10853)
- Fix Dockerfile cross-compilation for multi-arch builds (#10775)
- Fix DRA resource usage affects AFS admission ordering test (#10691)
- Fix flaky preemption test cleanup (#10753)
- Update SubtreeQuota post cohort deletion (#10797)
- Downgrade TAS flavor mismatch log from Error to V(3) (#10636)
- Rename detailed_reason to underlying_cause in EvictedWorkloadsOnceTotal metric (#10637)
- Filter workload infos by namespace in pendingWorkloadsInLqREST (#10672)
- TAS: allow admitted workloads with unhealthy nodes to be evicted (#10666)
- Fix namespace mismatch in visibility cross-namespace e2e test (#10668)

### Dependency Updates
- Update Kueue to golang 1.26 (#10718)
- Update kuberay to 1.6.1 (#10742)
- Update appwrapper to v1.2.1 (#10898)
- Bump go.uber.org/zap to 1.28.0 (#10883)
- Bump github.com/onsi/ginkgo/v2 to 2.28.3 (#10882)
- Bump github.com/fsnotify/fsnotify to 1.10.0 (#10885)

### Other
- Add E2E regression tests for HA follower cache stale ghost workload bug (#10811)
- Various documentation, refactoring, and CI improvements

## Test plan
- [ ] Verify the ClusterQueue CRD update applies cleanly
- [ ] Run e2e tests to validate no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `concurrentAdmissionPolicy` configuration option to ClusterQueue, enabling migration behavior control with mode selection and optional constraints.

* **Chores**
  * Updated upstream kueue submodule to latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->