### PR TITLE
add test prow image for golang 1.26

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 RUN dnf install -y jq
 WORKDIR /go/src/github.com/openshift/kueue-operator
 COPY . .

--- a/Dockerfile.ci.kueue
+++ b/Dockerfile.ci.kueue
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21 AS build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 as build
 
 WORKDIR /workspace
 COPY . .


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ART-17446

Looks like there is a test prow image we can use for golang 1.26.

We will need to switch this to production but our prow images are not official so I think its okay to merge this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI build infrastructure with newer containerized base images and Go 1.26 runtime environment. These infrastructure improvements enhance build system compatibility with current platform versions, strengthen system security, and optimize build performance and reliability across continuous integration pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->