### PR TITLE
update konflux images to golang-1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 as builder
 WORKDIR /go/src/github.com/openshift/kueue-operator
 COPY . .
 RUN make build --warn-undefined-variables

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 RUN dnf install -y jq
 WORKDIR /go/src/github.com/openshift/kueue-operator
 COPY . .

--- a/Dockerfile.ci.kueue
+++ b/Dockerfile.ci.kueue
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21 AS build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 as build
 
 WORKDIR /workspace
 COPY . .

--- a/Dockerfile.kueue
+++ b/Dockerfile.kueue
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS build
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS build
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPKUEUE-627

This is blocked by https://redhat.atlassian.net/browse/OCPKUEUE-627.

Opening this up when its available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated builder and CI container images to newer Go/OpenShift minor versions to keep builds current and maintain compatibility; no functional or runtime behavior changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->