### PR TITLE
OCPBUGS-85644: Fix DRA e2e test failures on periodic CI jobs

### DIFF
--- a/test/e2e/e2e_dra_extended_resources_test.go
+++ b/test/e2e/e2e_dra_extended_resources_test.go
@@ -37,6 +37,7 @@ const (
 	erTestNamespacePrefix = "kueue-dra-er-test-"
 	erLocalQueueName      = "er-queue"
 	extendedResourceName  = "nvidia.com/gpu"
+	gpuDeviceType         = "gpu"
 )
 
 var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extended-resources"), Ordered, func() {
@@ -88,7 +89,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 						// with value "gpu" for full GPU devices. MIG slices have different type values.
 						// See: device.attributes['gpu.nvidia.com'].type in DeviceClass CEL selectors.
 						if typeAttr, ok := d.Attributes["type"]; ok {
-							if typeAttr.StringValue != nil && *typeAttr.StringValue == "gpu" {
+							if typeAttr.StringValue != nil && *typeAttr.StringValue == gpuDeviceType {
 								gpusPerNode[*s.Spec.NodeName]++
 							}
 						}
@@ -116,9 +117,11 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 		Expect(err).ToNot(HaveOccurred())
 		initialKueueInstance = kueueInstance.DeepCopy()
 
+		// Clear deviceClassMappings if set by a previous test suite
+		kueueInstance.Spec.Config.Resources.DeviceClassMappings = nil
 		applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
 
-		// Wait for DRA feature gates to be enabled in Kueue config
+		// Wait for DRA feature gates to be enabled and deviceClassMappings to be cleared
 		Eventually(func() error {
 			configMap, err := kubeClient.CoreV1().ConfigMaps(testutils.OperatorNamespace).Get(ctx, "kueue-manager-config", metav1.GetOptions{})
 			if err != nil {
@@ -130,6 +133,9 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 			}
 			if !strings.Contains(configData, "DRAExtendedResources: true") {
 				return fmt.Errorf("DRAExtendedResources not enabled yet")
+			}
+			if strings.Contains(configData, draLogicalResource) {
+				return fmt.Errorf("deviceClassMappings still contains %s, waiting for config reconciliation", draLogicalResource)
 			}
 			return nil
 		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())

--- a/test/e2e/e2e_dra_test.go
+++ b/test/e2e/e2e_dra_test.go
@@ -152,6 +152,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 	AfterAll(func(ctx context.Context) {
 		if initialKueueInstance != nil {
+			initialKueueInstance.Spec.Config.Resources.DeviceClassMappings = nil
 			applyKueueConfig(ctx, initialKueueInstance.Spec.Config, kubeClient)
 		}
 	})

--- a/test/e2e/e2e_dra_test.go
+++ b/test/e2e/e2e_dra_test.go
@@ -97,7 +97,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			if s.Spec.Driver == draDeviceClassName {
 				for _, d := range s.Spec.Devices {
 					if typeAttr, ok := d.Attributes["type"]; ok {
-						if typeAttr.StringValue != nil && *typeAttr.StringValue == "gpu" {
+						if typeAttr.StringValue != nil && *typeAttr.StringValue == gpuDeviceType {
 							gpuCount++
 						}
 					}
@@ -332,6 +332,22 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			Eventually(func() bool {
 				return testutils.IsJobPodRunning(ctx, kubeClient, ns.Name, createdJob1.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
+
+			By("Verifying ClusterQueue shows reservation before creating second job")
+			Eventually(func(g Gomega) {
+				cqObj, err := kueueClient.KueueV1beta2().ClusterQueues().Get(ctx, cq.Name, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cqObj.Status.FlavorsReservation).NotTo(BeEmpty())
+				found := false
+				for _, flavor := range cqObj.Status.FlavorsReservation {
+					for _, res := range flavor.Resources {
+						if res.Name == corev1.ResourceName(draLogicalResource) && res.Total.Cmp(resource.MustParse("1")) == 0 {
+							found = true
+						}
+					}
+				}
+				g.Expect(found).To(BeTrue(), "ClusterQueue should show 1 %s reserved before creating second job", draLogicalResource)
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Creating second job referencing same shared template (quota full, should be suspended)")
 			job2 := newDRAJob(builder, "dra-fill-job-2", "gpu-template-shared", draLocalQueueName)

--- a/test/e2e/e2e_dra_test.go
+++ b/test/e2e/e2e_dra_test.go
@@ -52,7 +52,6 @@ func setDRAJobCPU(job *batchv1.Job) {
 
 var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered, func() {
 	var (
-		draSupported         bool
 		gpuCount             int
 		initialKueueInstance *ssv1.Kueue
 	)
@@ -63,6 +62,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 	BeforeAll(func(ctx context.Context) {
 		// Check if DRA APIs are available
+		draSupported := false
 		apiResourceLists, err := kubeClient.Discovery().ServerResourcesForGroupVersion("resource.k8s.io/v1")
 		if err == nil {
 			for _, apiResource := range apiResourceLists.APIResources {
@@ -76,23 +76,20 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			Skip("DRA APIs (resource.k8s.io/v1) not available on this cluster")
 		}
 
-		// Wait for ResourceSlices to exist for gpu.nvidia.com (driver may still be deploying)
-		// and count GPUs (only devices with type=="gpu", excluding MIG slices)
-		Eventually(func() bool {
-			slices, err := kubeClient.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
-			if err != nil {
-				return false
-			}
-			for _, s := range slices.Items {
-				if s.Spec.Driver == draDeviceClassName {
-					return true
-				}
-			}
-			return false
-		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue(), "No ResourceSlices found for driver gpu.nvidia.com - NVIDIA DRA driver not running")
-
+		// Check if ResourceSlices exist for gpu.nvidia.com (NVIDIA DRA driver running)
 		slices, err := kubeClient.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		hasDriverSlices := false
+		for _, s := range slices.Items {
+			if s.Spec.Driver == draDeviceClassName {
+				hasDriverSlices = true
+				break
+			}
+		}
+		if !hasDriverSlices {
+			Skip("No ResourceSlices found for driver gpu.nvidia.com - NVIDIA DRA driver not running")
+		}
+
 		for _, s := range slices.Items {
 			if s.Spec.Driver == draDeviceClassName {
 				for _, d := range s.Spec.Devices {


### PR DESCRIPTION
  Since May 7, the periodic-ci-openshift-kueue-operator-main-test-e2e-dra-gpu-4-21 job has been failing on every daily run. Two problems have
  been identified:

**Problem 1** — ER resource naming mismatch (100% failure rate since May 7): The ER test creates ClusterQueues using nvidia.com/gpu, but Kueue translates it to nvidia-gpu because deviceClassMappings leaked from e2e_dra_test.go's BeforeAll, which runs first under the shared dra  label. Workloads can never match flavors.
  - Fix: Clear deviceClassMappings in ER test BeforeAll and wait for config reconciliation before proceeding.

**Problem 2** — DRA quota test race condition (intermittent, May 10-11): The quota enforcement test creates the second job before the ClusterQueue status reflects the first job's reservation.
  - Fix: Add Eventually check that FlavorsReservation shows the first job's reservation before creating the second job.

  Additionally, since May 8, periodic-ci-openshift-kueue-operator-main-test-e2e-downstream-4-22 has failed on every daily run:

 **Problem 3** — DRA Structured Parameters BeforeAll hard-fails without NVIDIA driver (100% failure rate since May 8): Uses Eventually with a 180s timeout waiting for ResourceSlices, failing hard on clusters without the NVIDIA DRA driver. The extended resources test handles this correctly with an immediate check and Skip().
  - Fix: Replace Eventually timeout with immediate check + Skip(), matching the extended resources test pattern. 
  
  Affected Prow Jobs:
  - [periodic-ci-openshift-kueue-operator-main-test-e2e-dra-gpu-4-21](https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/periodic-ci-openshift-kueue-operator-main-test-e2e-dra-gpu-4-21) (Problems 1, 2)
  - [periodic-ci-openshift-kueue-operator-main-test-e2e-downstream-4-22](https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/periodic-ci-openshift-kueue-operator-main-test-e2e-downstream-4-22) (Problem 3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced GPU device type detection validation in Dynamic Resource Allocation Extended Resources scenarios
  * Strengthened test configuration cleanup procedures to prevent interference between test suites
  * Added verification checks for resource reservations and device-class mapping reconciliation
  * Improved ResourceSlice validation before GPU resource counting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->