### PR TITLE
NO-JIRA: Update kueue submodule to 851a097d

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ e2e-upstream-test: ginkgo
 	@echo "Running e2e tests on OpenShift cluster ($(shell oc whoami --show-server))"
 	mkdir -p "$(ARTIFACT_DIR)"
 	IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(GINKGO_ARGS)" \
-	ARTIFACT_DIR=$(ARTIFACT_DIR) E2E_TARGET_FOLDERS="$${E2E_TARGET_FOLDERS:-singlecluster certmanager customconfigs}" \
+	ARTIFACT_DIR=$(ARTIFACT_DIR) E2E_TARGET_FOLDERS="$${E2E_TARGET_FOLDERS:-singlecluster certmanager sequential}" \
 	SKIP_DEPLOY=true \
 	./upstream/kueue/e2e-test-ocp.sh
 

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-clusterqueue-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-clusterqueue-editor-role.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/role: clusterqueue-editor
   name: kueue-clusterqueue-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-clusterqueue-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-clusterqueue-viewer-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/role: clusterqueue-viewer
   name: kueue-clusterqueue-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-cohort-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-cohort-editor-role.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/role: cohort-editor
   name: kueue-cohort-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-cohort-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-cohort-viewer-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/role: cohort-viewer
   name: kueue-cohort-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-jaxjob-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-jaxjob-editor-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: jaxjob-editor
   name: kueue-jaxjob-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-jaxjob-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-jaxjob-viewer-role.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: jaxjob-viewer
   name: kueue-jaxjob-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-job-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-job-editor-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: job-editor
   name: kueue-job-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-job-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-job-viewer-role.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: job-viewer
   name: kueue-job-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-jobset-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-jobset-editor-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: jobset-editor
   name: kueue-jobset-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-jobset-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-jobset-viewer-role.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: jobset-viewer
   name: kueue-jobset-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-leaderworkerset-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-leaderworkerset-editor-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: leaderworkerset-editor
   name: kueue-leaderworkerset-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-leaderworkerset-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-leaderworkerset-viewer-role.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: leaderworkerset-viewer
   name: kueue-leaderworkerset-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-localqueue-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-localqueue-editor-role.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/role: localqueue-editor
   name: kueue-localqueue-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-localqueue-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-localqueue-viewer-role.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: localqueue-viewer
   name: kueue-localqueue-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-manager-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-manager-role.yaml
@@ -11,15 +11,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - limitranges
   - namespaces
   - nodes
@@ -130,6 +121,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+  - watch
 - apiGroups:
   - flowcontrol.apiserver.k8s.io
   resources:
@@ -352,6 +352,7 @@ rules:
   - deviceclasses
   - resourceclaims
   - resourceclaimtemplates
+  - resourceslices
   verbs:
   - get
   - list

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-mpijob-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-mpijob-editor-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: mpijob-editor
   name: kueue-mpijob-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-mpijob-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-mpijob-viewer-role.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: mpijob-viewer
   name: kueue-mpijob-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-paddlejob-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-paddlejob-editor-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: paddlejob-editor
   name: kueue-paddlejob-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-paddlejob-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-paddlejob-viewer-role.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: paddlejob-viewer
   name: kueue-paddlejob-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-pending-workloads-cq-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-pending-workloads-cq-viewer-role.yaml
@@ -10,6 +10,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/role: pending-workloads-cq-viewer
   name: kueue-pending-workloads-cq-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-pending-workloads-lq-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-pending-workloads-lq-viewer-role.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: pending-workloads-lq-viewer
   name: kueue-pending-workloads-lq-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-pytorchjob-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-pytorchjob-editor-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: pytorchjob-editor
   name: kueue-pytorchjob-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-pytorchjob-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-pytorchjob-viewer-role.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: pytorchjob-viewer
   name: kueue-pytorchjob-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-raycluster-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-raycluster-editor-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: raycluster-editor
   name: kueue-raycluster-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-raycluster-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-raycluster-viewer-role.yaml
@@ -10,6 +10,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/role: raycluster-viewer
   name: kueue-raycluster-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-rayjob-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-rayjob-editor-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: rayjob-editor
   name: kueue-rayjob-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-rayjob-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-rayjob-viewer-role.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: rayjob-viewer
   name: kueue-rayjob-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-rayservice-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-rayservice-editor-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: rayservice-editor
   name: kueue-rayservice-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-rayservice-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-rayservice-viewer-role.yaml
@@ -10,6 +10,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/role: rayservice-viewer
   name: kueue-rayservice-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-resourceflavor-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-resourceflavor-editor-role.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/role: resourceflavor-editor
   name: kueue-resourceflavor-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-resourceflavor-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-resourceflavor-viewer-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/role: resourceflavor-viewer
   name: kueue-resourceflavor-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-sparkapplication-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-sparkapplication-editor-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: sparkapplication-editor
   name: kueue-sparkapplication-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-sparkapplication-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-sparkapplication-viewer-role.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: sparkapplication-viewer
   name: kueue-sparkapplication-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-tfjob-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-tfjob-editor-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: tfjob-editor
   name: kueue-tfjob-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-tfjob-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-tfjob-viewer-role.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: tfjob-viewer
   name: kueue-tfjob-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-topology-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-topology-editor-role.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/role: topology-editor
   name: kueue-topology-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-topology-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-topology-viewer-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/role: topology-viewer
   name: kueue-topology-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-trainjob-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-trainjob-editor-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: trainjob-editor
   name: kueue-trainjob-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-trainjob-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-trainjob-viewer-role.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: trainjob-viewer
   name: kueue-trainjob-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-workload-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-workload-editor-role.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: kueue
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/role: workload-editor
   name: kueue-workload-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-workload-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-workload-viewer-role.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: workload-viewer
   name: kueue-workload-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-xgboostjob-editor-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-xgboostjob-editor-role.yaml
@@ -8,6 +8,7 @@ metadata:
     control-plane: controller-manager
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: xgboostjob-editor
   name: kueue-xgboostjob-editor-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-xgboostjob-viewer-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-xgboostjob-viewer-role.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.kueue.x-k8s.io/role: xgboostjob-viewer
   name: kueue-xgboostjob-viewer-role
 rules:
 - apiGroups:

--- a/bindata/assets/kueue-operator/crds/crd-admissionchecks.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-admissionchecks.kueue.x-k8s.io-v1beta2.yaml
@@ -15,6 +15,8 @@ spec:
     kind: AdmissionCheck
     listKind: AdmissionCheckList
     plural: admissionchecks
+    shortNames:
+    - ac
     singular: admissioncheck
   scope: Cluster
   versions:

--- a/bindata/assets/kueue-operator/crds/crd-clusterqueues.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-clusterqueues.kueue.x-k8s.io-v1beta2.yaml
@@ -935,6 +935,55 @@ spec:
                 maxLength: 253
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
+              concurrentAdmissionPolicy:
+                description: |-
+                  concurrentAdmissionPolicy defines the configuration for ConcurrentAdmission feature.
+                  Its main capability is to allow Workloads pursuing multiple flavors at the same time, and starting on the first flavor that led to admission.
+                  Additionally after the admission, Workloads can still try to pursue capacity on the more preferable flavors while running.
+                  It enables them to migrate to more preferable, whenever capacity appears.
+                properties:
+                  migration:
+                    description: |-
+                      migration defines the constraints on Workload's migration.
+                      The mechanism itself creates "Variants" of the same Workload, each pursuing a different flavor.
+                      All Variants belong to the same "Parent" Workload, and are picked up by Kueue scheduler independently.
+                      Once one of the Variants is admitted, the Parent Workload gets also admitted. The Variants that pursue more
+                      favorable flavors keep trying to get admitted and if they succeed, the Workload migrates to the new flavor.
+                      The Variants that pursue less favorable flavors are deactivated.
+                      Flavor preferences are expressed through the order of flavors in the ClusterQueue.
+                    properties:
+                      constraints:
+                        description: constraints defines the constraints of Workload's
+                          migration.
+                        properties:
+                          lastAcceptableFlavorName:
+                            description: |-
+                              lastAcceptableFlavorName defines the last acceptable flavor a Workload can migrate to.
+                              The order is based on the order of flavors in ClusterQueue.
+                              It can only be used if the Mode is `TryPreferredFlavors`.
+                              If the Mode is `TryPreferredFlavors` and LastAcceptableFlavorName is not specified, then
+                              Workload can migrate to any flavor that is more preferable than the one it was admitted to.
+                            maxLength: 253
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                        type: object
+                      mode:
+                        description: |-
+                          mode defines the mode of Workload's migration.
+                          The possible values are:
+                          - `TryPreferredFlavors` (default): a Workload will try to migrate to the preferred flavor after it's admitted and running.
+                          - `RetainFirstAdmission`: a Workload, once admitted to a flavor, will stick to a flavor and will not be migrated.
+                        enum:
+                        - TryPreferredFlavors
+                        - RetainFirstAdmission
+                        maxLength: 253
+                        type: string
+                    required:
+                    - mode
+                    type: object
+                required:
+                - migration
+                type: object
               fairSharing:
                 description: |-
                   fairSharing defines the properties of the ClusterQueue when

--- a/bindata/assets/kueue-operator/crds/crd-cohorts.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-cohorts.kueue.x-k8s.io-v1beta2.yaml
@@ -25,6 +25,8 @@ spec:
     kind: Cohort
     listKind: CohortList
     plural: cohorts
+    shortNames:
+    - co
     singular: cohort
   scope: Cluster
   versions:

--- a/bindata/assets/kueue-operator/crds/crd-multikueueclusters.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-multikueueclusters.kueue.x-k8s.io-v1beta2.yaml
@@ -25,6 +25,8 @@ spec:
     kind: MultiKueueCluster
     listKind: MultiKueueClusterList
     plural: multikueueclusters
+    shortNames:
+    - mkc
     singular: multikueuecluster
   scope: Cluster
   versions:

--- a/bindata/assets/kueue-operator/crds/crd-multikueueconfigs.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-multikueueconfigs.kueue.x-k8s.io-v1beta2.yaml
@@ -15,6 +15,8 @@ spec:
     kind: MultiKueueConfig
     listKind: MultiKueueConfigList
     plural: multikueueconfigs
+    shortNames:
+    - mkconf
     singular: multikueueconfig
   scope: Cluster
   versions:
@@ -93,6 +95,18 @@ spec:
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: set
+              quotaManagement:
+                description: |-
+                  quotaManagement specifies the management of ClusterQueue quotas
+                  in the manager cluster.
+                  Supported modes:
+                  - `Manual`: Quota automation is manual.
+                  - `Automated`: Quota automation is enabled (provided that the MultiKueueManagerQuotaAutomation feature gate is enabled).
+                  If unspecified, defaults to `Manual`.
+                enum:
+                - Manual
+                - Automated
+                type: string
             required:
             - clusters
             type: object

--- a/bindata/assets/kueue-operator/crds/crd-provisioningrequestconfigs.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-provisioningrequestconfigs.kueue.x-k8s.io-v1beta2.yaml
@@ -15,6 +15,8 @@ spec:
     kind: ProvisioningRequestConfig
     listKind: ProvisioningRequestConfigList
     plural: provisioningrequestconfigs
+    shortNames:
+    - prc
     singular: provisioningrequestconfig
   scope: Cluster
   versions:

--- a/bindata/assets/kueue-operator/crds/crd-topologies.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-topologies.kueue.x-k8s.io-v1beta2.yaml
@@ -15,6 +15,8 @@ spec:
     kind: Topology
     listKind: TopologyList
     plural: topologies
+    shortNames:
+    - topo
     singular: topology
   scope: Cluster
   versions:

--- a/bindata/assets/kueue-operator/crds/crd-workloadpriorityclasses.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-workloadpriorityclasses.kueue.x-k8s.io-v1beta2.yaml
@@ -15,6 +15,8 @@ spec:
     kind: WorkloadPriorityClass
     listKind: WorkloadPriorityClassList
     plural: workloadpriorityclasses
+    shortNames:
+    - wpc
     singular: workloadpriorityclass
   scope: Cluster
   versions:

--- a/bindata/assets/kueue-operator/crds/crd-workloads.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-workloads.kueue.x-k8s.io-v1beta2.yaml
@@ -105,7 +105,7 @@ spec:
                 description: |-
                   podSets is a list of sets of homogeneous pods, each described by a Pod spec
                   and a count.
-                  There must be at least one element and at most 8.
+                  There must be at least one element and at most 10.
                   podSets cannot be changed.
                 items:
                   properties:
@@ -8811,7 +8811,7 @@ spec:
                   x-kubernetes-validations:
                   - message: minCount should be positive and less or equal to count
                     rule: 'has(self.minCount) ? self.minCount <= self.count : true'
-                maxItems: 8
+                maxItems: 10
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
@@ -9031,7 +9031,7 @@ spec:
                       required:
                       - name
                       type: object
-                    maxItems: 8
+                    maxItems: 10
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
@@ -9156,7 +9156,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 8
+                      maxItems: 10
                       type: array
                       x-kubernetes-list-type: atomic
                     requeueAfterSeconds:
@@ -9311,7 +9311,7 @@ spec:
                   - count
                   - name
                   type: object
-                maxItems: 8
+                maxItems: 10
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -9368,7 +9368,7 @@ spec:
                   required:
                   - name
                   type: object
-                maxItems: 8
+                maxItems: 10
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -9541,7 +9541,7 @@ spec:
                 description: |-
                   podSets is a list of sets of homogeneous pods, each described by a Pod spec
                   and a count.
-                  There must be at least one element and at most 8.
+                  There must be at least one element and at most 10.
                   podSets cannot be changed.
                 items:
                   properties:
@@ -18291,7 +18291,7 @@ spec:
                   x-kubernetes-validations:
                   - message: minCount should be positive and less or equal to count
                     rule: 'has(self.minCount) ? self.minCount <= self.count : true'
-                maxItems: 8
+                maxItems: 10
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
@@ -18637,8 +18637,7 @@ spec:
                                       x-kubernetes-validations:
                                       - message: exactly one of the fields in [universal
                                           individual] must be set
-                                        rule: '[has(self.universal),has(self.individual)].filter(x,x==true).size()
-                                          == 1'
+                                        rule: has(self.universal) != has(self.individual)
                                     maxItems: 16
                                     minItems: 1
                                     type: array
@@ -18670,7 +18669,7 @@ spec:
                               number of levels in this TopologyAssignment
                             rule: self.slices.all(x, size(x.valuesPerLevel) == size(self.levels))
                       type: object
-                    maxItems: 8
+                    maxItems: 10
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
@@ -18794,7 +18793,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 8
+                      maxItems: 10
                       type: array
                       x-kubernetes-list-type: atomic
                     requeueAfterSeconds:
@@ -18985,7 +18984,7 @@ spec:
                   - count
                   - name
                   type: object
-                maxItems: 8
+                maxItems: 10
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -19042,7 +19041,7 @@ spec:
                   required:
                   - name
                   type: object
-                maxItems: 8
+                maxItems: 10
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -19156,6 +19155,8 @@ spec:
             && self.status.conditions.exists(c, c.type == 'Admitted' && c.status ==
             'True')))?((has(oldSelf.spec.maximumExecutionTimeSeconds)?oldSelf.spec.maximumExecutionTimeSeconds:0)
             ==  (has(self.spec.maximumExecutionTimeSeconds)?self.spec.maximumExecutionTimeSeconds:0)):true
+    selectableFields:
+    - jsonPath: .status.admission.clusterQueue
     served: true
     storage: true
     subresources:

--- a/bindata/assets/kueue-operator/mutatingwebhook.yaml
+++ b/bindata/assets/kueue-operator/mutatingwebhook.yaml
@@ -14,89 +14,16 @@ webhooks:
     service:
       name: kueue-webhook-service
       namespace: openshift-kueue-operator
-      path: /mutate--v1-pod
-  failurePolicy: Fail
-  name: mpod.kb.io
-  namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: NotIn
-      values:
-      - kube-system
-      - openshift-kueue-operator
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - pods
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: kueue-webhook-service
-      namespace: openshift-kueue-operator
-      path: /mutate-apps-v1-deployment
-  failurePolicy: Fail
-  name: mdeployment.kb.io
-  namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: NotIn
-      values:
-      - kube-system
-      - openshift-kueue-operator
-  rules:
-  - apiGroups:
-    - apps
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - deployments
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: kueue-webhook-service
-      namespace: openshift-kueue-operator
-      path: /mutate-apps-v1-statefulset
-  failurePolicy: Fail
-  name: mstatefulset.kb.io
-  namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: NotIn
-      values:
-      - kube-system
-      - openshift-kueue-operator
-  rules:
-  - apiGroups:
-    - apps
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - statefulsets
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: kueue-webhook-service
-      namespace: openshift-kueue-operator
       path: /mutate-workload-codeflare-dev-v1beta2-appwrapper
   failurePolicy: Fail
   name: mappwrapper.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - workload.codeflare.dev
@@ -132,9 +59,43 @@ webhooks:
     service:
       name: kueue-webhook-service
       namespace: openshift-kueue-operator
+      path: /mutate-apps-v1-deployment
+  failurePolicy: Fail
+  name: mdeployment.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: openshift-kueue-operator
       path: /mutate-kubeflow-org-v1-jaxjob
   failurePolicy: Fail
   name: mjaxjob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - kubeflow.org
@@ -154,6 +115,13 @@ webhooks:
       path: /mutate-batch-v1-job
   failurePolicy: Fail
   name: mjob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - batch
@@ -173,6 +141,13 @@ webhooks:
       path: /mutate-jobset-x-k8s-io-v1alpha2-jobset
   failurePolicy: Fail
   name: mjobset.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - jobset.x-k8s.io
@@ -192,6 +167,13 @@ webhooks:
       path: /mutate-leaderworkerset-x-k8s-io-v1-leaderworkerset
   failurePolicy: Fail
   name: mleaderworkerset.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - leaderworkerset.x-k8s.io
@@ -212,6 +194,13 @@ webhooks:
       path: /mutate-kubeflow-org-v2beta1-mpijob
   failurePolicy: Fail
   name: mmpijob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - kubeflow.org
@@ -231,6 +220,13 @@ webhooks:
       path: /mutate-kubeflow-org-v1-paddlejob
   failurePolicy: Fail
   name: mpaddlejob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - kubeflow.org
@@ -247,9 +243,42 @@ webhooks:
     service:
       name: kueue-webhook-service
       namespace: openshift-kueue-operator
+      path: /mutate--v1-pod
+  failurePolicy: Fail
+  name: mpod.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: openshift-kueue-operator
       path: /mutate-kubeflow-org-v1-pytorchjob
   failurePolicy: Fail
   name: mpytorchjob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - kubeflow.org
@@ -269,6 +298,13 @@ webhooks:
       path: /mutate-ray-io-v1-raycluster
   failurePolicy: Fail
   name: mraycluster.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - ray.io
@@ -288,6 +324,13 @@ webhooks:
       path: /mutate-ray-io-v1-rayjob
   failurePolicy: Fail
   name: mrayjob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - ray.io
@@ -307,6 +350,13 @@ webhooks:
       path: /mutate-ray-io-v1-rayservice
   failurePolicy: Fail
   name: mrayservice.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - ray.io
@@ -345,6 +395,13 @@ webhooks:
       path: /mutate-sparkoperator-k8s-io-v1beta2-sparkapplication
   failurePolicy: Fail
   name: msparkapplication.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - sparkoperator.k8s.io
@@ -361,9 +418,43 @@ webhooks:
     service:
       name: kueue-webhook-service
       namespace: openshift-kueue-operator
+      path: /mutate-apps-v1-statefulset
+  failurePolicy: Fail
+  name: mstatefulset.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - statefulsets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: openshift-kueue-operator
       path: /mutate-kubeflow-org-v1-tfjob
   failurePolicy: Fail
   name: mtfjob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - kubeflow.org
@@ -383,6 +474,13 @@ webhooks:
       path: /mutate-trainer-kubeflow-org-v1alpha1-trainjob
   failurePolicy: Fail
   name: mtrainjob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - trainer.kubeflow.org
@@ -421,6 +519,13 @@ webhooks:
       path: /mutate-kubeflow-org-v1-xgboostjob
   failurePolicy: Fail
   name: mxgboostjob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - kubeflow.org

--- a/bindata/assets/kueue-operator/validatingwebhook.yaml
+++ b/bindata/assets/kueue-operator/validatingwebhook.yaml
@@ -41,63 +41,16 @@ webhooks:
     service:
       name: kueue-webhook-service
       namespace: openshift-kueue-operator
-      path: /validate-apps-v1-deployment
-  failurePolicy: Fail
-  name: vdeployment.kb.io
-  namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: NotIn
-      values:
-      - kube-system
-      - openshift-kueue-operator
-  rules:
-  - apiGroups:
-    - apps
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - deployments
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: kueue-webhook-service
-      namespace: openshift-kueue-operator
-      path: /validate-apps-v1-statefulset
-  failurePolicy: Fail
-  name: vstatefulset.kb.io
-  namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: NotIn
-      values:
-      - kube-system
-      - openshift-kueue-operator
-  rules:
-  - apiGroups:
-    - apps
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - statefulsets
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: kueue-webhook-service
-      namespace: openshift-kueue-operator
       path: /validate-workload-codeflare-dev-v1beta2-appwrapper
   failurePolicy: Fail
   name: vappwrapper.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - workload.codeflare.dev
@@ -155,9 +108,43 @@ webhooks:
     service:
       name: kueue-webhook-service
       namespace: openshift-kueue-operator
+      path: /validate-apps-v1-deployment
+  failurePolicy: Fail
+  name: vdeployment.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: openshift-kueue-operator
       path: /validate-kubeflow-org-v1-jaxjob
   failurePolicy: Fail
   name: vjaxjob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - kubeflow.org
@@ -178,6 +165,13 @@ webhooks:
       path: /validate-batch-v1-job
   failurePolicy: Fail
   name: vjob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - batch
@@ -198,6 +192,13 @@ webhooks:
       path: /validate-jobset-x-k8s-io-v1alpha2-jobset
   failurePolicy: Fail
   name: vjobset.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - jobset.x-k8s.io
@@ -218,6 +219,13 @@ webhooks:
       path: /validate-leaderworkerset-x-k8s-io-v1-leaderworkerset
   failurePolicy: Fail
   name: vleaderworkerset.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - leaderworkerset.x-k8s.io
@@ -238,6 +246,13 @@ webhooks:
       path: /validate-kubeflow-org-v2beta1-mpijob
   failurePolicy: Fail
   name: vmpijob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - kubeflow.org
@@ -258,6 +273,13 @@ webhooks:
       path: /validate-kubeflow-org-v1-paddlejob
   failurePolicy: Fail
   name: vpaddlejob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - kubeflow.org
@@ -278,6 +300,13 @@ webhooks:
       path: /validate-kubeflow-org-v1-pytorchjob
   failurePolicy: Fail
   name: vpytorchjob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - kubeflow.org
@@ -298,6 +327,13 @@ webhooks:
       path: /validate-ray-io-v1-raycluster
   failurePolicy: Fail
   name: vraycluster.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - ray.io
@@ -318,6 +354,13 @@ webhooks:
       path: /validate-ray-io-v1-rayjob
   failurePolicy: Fail
   name: vrayjob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - ray.io
@@ -338,6 +381,13 @@ webhooks:
       path: /validate-ray-io-v1-rayservice
   failurePolicy: Fail
   name: vrayservice.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - ray.io
@@ -378,6 +428,13 @@ webhooks:
       path: /validate-sparkoperator-k8s-io-v1beta2-sparkapplication
   failurePolicy: Fail
   name: vsparkapplication.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - sparkoperator.k8s.io
@@ -395,9 +452,43 @@ webhooks:
     service:
       name: kueue-webhook-service
       namespace: openshift-kueue-operator
+      path: /validate-apps-v1-statefulset
+  failurePolicy: Fail
+  name: vstatefulset.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - statefulsets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: openshift-kueue-operator
       path: /validate-kubeflow-org-v1-tfjob
   failurePolicy: Fail
   name: vtfjob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - kubeflow.org
@@ -418,6 +509,13 @@ webhooks:
       path: /validate-trainer-kubeflow-org-v1alpha1-trainjob
   failurePolicy: Fail
   name: vtrainjob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - trainer.kubeflow.org
@@ -459,6 +557,13 @@ webhooks:
       path: /validate-kubeflow-org-v1-xgboostjob
   failurePolicy: Fail
   name: vxgboostjob.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - openshift-kueue-operator
   rules:
   - apiGroups:
     - kubeflow.org

--- a/upstream/kueue/e2e-test-ocp.sh
+++ b/upstream/kueue/e2e-test-ocp.sh
@@ -55,7 +55,7 @@ function ginkgo_label_filter() {
     dra)
       echo ""
       ;;
-    customconfigs)
+    sequential)
       echo "feature:admissionfairsharing"
       ;;
     *)
@@ -90,8 +90,8 @@ allow_privileged_access
 function configure_kueue_for_folder() {
   local folder="$1"
   case "$folder" in
-    customconfigs)
-      echo "Patching cluster Kueue CR for customconfigs..."
+    sequential)
+      echo "Patching cluster Kueue CR for sequential (admissionFairSharing)..."
       $OC patch kueue.kueue.openshift.io/cluster --type=merge -p \
         '{"spec":{"config":{"admissionFairSharing":{"usageHalfLifeTimeSeconds":1,"usageSamplingIntervalSeconds":1}}}}'
       # Let's wait for the reconciliation to complete. The test suite checks if kueue-controller-manager is available.
@@ -103,7 +103,7 @@ function configure_kueue_for_folder() {
 function restore_kueue_for_folder() {
   local folder="$1"
   case "$folder" in
-    customconfigs)
+    sequential)
       echo "Removing admissionFairSharing from cluster Kueue CR..."
       $OC patch kueue.kueue.openshift.io/cluster --type=json -p \
         '[{"op":"remove","path":"/spec/config/admissionFairSharing"}]'

--- a/upstream/kueue/patch/e2e.patch
+++ b/upstream/kueue/patch/e2e.patch
@@ -1,8 +1,93 @@
-diff --git a/test/e2e/singlecluster/suite_test.go b/test/e2e/singlecluster/suite_test.go
-index 261c0bf41..a52391700 100644
---- a/test/e2e/singlecluster/suite_test.go
-+++ b/test/e2e/singlecluster/suite_test.go
-@@ -72,12 +72,12 @@ var _ = ginkgo.BeforeSuite(func() {
+diff --git a/test/e2e/certmanager/certmanager_test.go b/test/e2e/certmanager/certmanager_test.go
+index 192fc8916..2b8708ca0 100644
+--- a/test/e2e/certmanager/certmanager_test.go
++++ b/test/e2e/certmanager/certmanager_test.go
+@@ -40,7 +40,10 @@ var _ = ginkgo.Describe("CertManager", ginkgo.Ordered, func() {
+ 
+ 	ginkgo.BeforeEach(func() {
+ 		ns = &corev1.Namespace{
+-			ObjectMeta: metav1.ObjectMeta{GenerateName: "e2e-cert-manager-"},
++			ObjectMeta: metav1.ObjectMeta{
++				GenerateName: "e2e-cert-manager-",
++				Labels:       map[string]string{"kueue.openshift.io/managed": "true"},
++			},
+ 		}
+ 		util.MustCreate(ctx, k8sClient, ns)
+ 
+diff --git a/test/e2e/certmanager/metrics_test.go b/test/e2e/certmanager/metrics_test.go
+index 1ec80185e..63c816124 100644
+--- a/test/e2e/certmanager/metrics_test.go
++++ b/test/e2e/certmanager/metrics_test.go
+@@ -40,7 +40,7 @@ const (
+ 	serviceAccountName           = "kueue-controller-manager"
+ 	metricsReaderClusterRoleName = "kueue-metrics-reader"
+ 	metricsServiceName           = "kueue-controller-manager-metrics-service"
+-	certSecretName               = "kueue-metrics-server-cert"
++	certSecretName               = "metrics-server-cert"
+ 	certMountPath                = "/etc/kueue/metrics/certs"
+ )
+ 
+diff --git a/test/e2e/sequential/baseline/admission_fair_sharing_test.go b/test/e2e/sequential/baseline/admission_fair_sharing_test.go
+index 0cc1e5d47..3215c2f9a 100644
+--- a/test/e2e/sequential/baseline/admission_fair_sharing_test.go
++++ b/test/e2e/sequential/baseline/admission_fair_sharing_test.go
+@@ -17,8 +17,6 @@ limitations under the License.
+ package baseline
+ 
+ import (
+-	"time"
+-
+ 	"github.com/onsi/ginkgo/v2"
+ 	"github.com/onsi/gomega"
+ 	batchv1 "k8s.io/api/batch/v1"
+@@ -27,7 +25,6 @@ import (
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"sigs.k8s.io/controller-runtime/pkg/client"
+ 
+-	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+ 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+ 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+ 	jobtesting "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+@@ -41,12 +38,13 @@ var _ = ginkgo.Describe("Admission Fair Sharing", ginkgo.Label("feature:admissio
+ 	)
+ 
+ 	ginkgo.BeforeAll(func() {
+-		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
+-			cfg.AdmissionFairSharing = &configapi.AdmissionFairSharing{
+-				UsageHalfLifeTime:     metav1.Duration{Duration: 1 * time.Second},
+-				UsageSamplingInterval: metav1.Duration{Duration: 1 * time.Second},
+-			}
+-		})
++		// On OCP, admissionFairSharing is configured via the Kueue CR in e2e-test-ocp.sh
++		// util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
++		// 	cfg.AdmissionFairSharing = &configapi.AdmissionFairSharing{
++		// 		UsageHalfLifeTime:     metav1.Duration{Duration: 1 * time.Second},
++		// 		UsageSamplingInterval: metav1.Duration{Duration: 1 * time.Second},
++		// 	}
++		// })
+ 
+ 		rf = utiltestingapi.MakeResourceFlavor("afs-rf").Obj()
+ 		util.MustCreate(ctx, k8sClient, rf)
+diff --git a/test/e2e/sequential/baseline/suite_test.go b/test/e2e/sequential/baseline/suite_test.go
+index 13c60383a..bd787db80 100644
+--- a/test/e2e/sequential/baseline/suite_test.go
++++ b/test/e2e/sequential/baseline/suite_test.go
+@@ -68,6 +68,7 @@ var _ = ginkgo.BeforeSuite(func() {
+ 	defaultKueueCfg = util.GetKueueConfiguration(ctx, k8sClient)
+ })
+ 
+-var _ = ginkgo.AfterSuite(func() {
+-	util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
+-})
++// On OCP, kueue configuration is managed via the Kueue CR, not direct config updates.
++// var _ = ginkgo.AfterSuite(func() {
++// 	util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
++// })
+diff --git a/test/e2e/singlecluster/extended/suite_test.go b/test/e2e/singlecluster/extended/suite_test.go
+index 78be86a76..55d24706a 100644
+--- a/test/e2e/singlecluster/extended/suite_test.go
++++ b/test/e2e/singlecluster/extended/suite_test.go
+@@ -54,12 +54,12 @@ var _ = ginkgo.BeforeSuite(func() {
  	waitForAvailableStart := time.Now()
  	util.WaitForKueueAvailability(ctx, k8sClient)
  	labelFilter := ginkgo.GinkgoLabelFilter()
@@ -21,95 +106,3 @@ index 261c0bf41..a52391700 100644
  	if ginkgo.Label("feature:appwrapper").MatchesLabelFilter(labelFilter) {
  		util.WaitForAppWrapperAvailability(ctx, k8sClient)
  	}
-
-diff --git a/test/util/e2e.go b/test/util/e2e.go
-index cc7d1f901..a68b8b9f4 100644
---- a/test/util/e2e.go
-+++ b/test/util/e2e.go
-@@ -473,8 +473,14 @@ func CreateNamespaceFromPrefixWithLog(ctx context.Context, k8sClient client.Clie
- }
- 
- func CreateNamespaceFromObjectWithLog(ctx context.Context, k8sClient client.Client, ns *corev1.Namespace) *corev1.Namespace {
--	MustCreate(ctx, k8sClient, ns)
--	ginkgo.GinkgoLogr.Info("Created namespace", "namespace", ns.Name)
-+	ginkgo.GinkgoLogr.Info("Created namespace", "namespace", ns)
-+	// Add label to the namespace to mark it as managed by Kueue.
-+	if ns.Labels == nil {
-+		ns.Labels = make(map[string]string)
-+	}
-+	ns.Labels["kueue.openshift.io/managed"] = "true"
-+	gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
-+	ginkgo.GinkgoLogr.Info(fmt.Sprintf("Created namespace: %s", ns.Name))
- 	return ns
- }
-
-diff --git a/test/e2e/certmanager/certmanager_test.go b/test/e2e/certmanager/certmanager_test.go
-index b175863ca..ddefdb139 100644
---- a/test/e2e/certmanager/certmanager_test.go
-+++ b/test/e2e/certmanager/certmanager_test.go
-@@ -40,7 +40,10 @@ var _ = ginkgo.Describe("CertManager", ginkgo.Ordered, func() {
- 
- 	ginkgo.BeforeEach(func() {
- 		ns = &corev1.Namespace{
--			ObjectMeta: metav1.ObjectMeta{GenerateName: "e2e-cert-manager-"},
-+			ObjectMeta: metav1.ObjectMeta{
-+				GenerateName: "e2e-cert-manager-",
-+				Labels:       map[string]string{"kueue.openshift.io/managed": "true"},
-+			},
- 		}
- 		util.MustCreate(ctx, k8sClient, ns)
- 
-diff --git a/test/e2e/certmanager/metrics_test.go b/test/e2e/certmanager/metrics_test.go
-index 19f27e21c..bafcde7cf 100644
---- a/test/e2e/certmanager/metrics_test.go
-+++ b/test/e2e/certmanager/metrics_test.go
-@@ -40,7 +40,7 @@ const (
- 	serviceAccountName           = "kueue-controller-manager"
- 	metricsReaderClusterRoleName = "kueue-metrics-reader"
- 	metricsServiceName           = "kueue-controller-manager-metrics-service"
--	certSecretName               = "kueue-metrics-server-cert"
-+	certSecretName               = "metrics-server-cert"
- 	certMountPath                = "/etc/kueue/metrics/certs"
- )
-
-diff --git a/test/e2e/customconfigs/admission_fair_sharing_test.go b/test/e2e/customconfigs/admission_fair_sharing_test.go
-index d1acafd0e..5cc83705d 100644
---- a/test/e2e/customconfigs/admission_fair_sharing_test.go
-+++ b/test/e2e/customconfigs/admission_fair_sharing_test.go
-@@ -17,8 +17,6 @@ limitations under the License.
- package customconfigs
- 
- import (
--	"time"
--
- 	"github.com/onsi/ginkgo/v2"
- 	"github.com/onsi/gomega"
- 	batchv1 "k8s.io/api/batch/v1"
-@@ -28,7 +26,6 @@ import (
- 	"k8s.io/utils/ptr"
- 	"sigs.k8s.io/controller-runtime/pkg/client"
- 
--	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
- 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
- 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
- 	jobtesting "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
-@@ -42,12 +39,12 @@ var _ = ginkgo.Describe("Admission Fair Sharing", ginkgo.Label("feature:admissio
- 	)
- 
- 	ginkgo.BeforeAll(func() {
--		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
--			cfg.AdmissionFairSharing = &configapi.AdmissionFairSharing{
--				UsageHalfLifeTime:     metav1.Duration{Duration: 1 * time.Second},
--				UsageSamplingInterval: metav1.Duration{Duration: 1 * time.Second},
--			}
--		})
-+		// util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
-+		// 	cfg.AdmissionFairSharing = &configapi.AdmissionFairSharing{
-+		// 		UsageHalfLifeTime:     metav1.Duration{Duration: 1 * time.Second},
-+		// 		UsageSamplingInterval: metav1.Duration{Duration: 1 * time.Second},
-+		// 	}
-+		// })
- 
- 		rf = utiltestingapi.MakeResourceFlavor("afs-rf").Obj()
- 		util.MustCreate(ctx, k8sClient, rf)
- 

--- a/upstream/kueue/patch/test_util_e2e.patch
+++ b/upstream/kueue/patch/test_util_e2e.patch
@@ -1,15 +1,14 @@
 diff --git a/test/util/e2e.go b/test/util/e2e.go
-index 95c6d509f..92a01fcdd 100644
+index 77572d8fe..85503da67 100644
 --- a/test/util/e2e.go
 +++ b/test/util/e2e.go
-@@ -584,8 +584,14 @@ func CreateNamespaceFromPrefixWithLog(ctx context.Context, k8sClient client.Clie
+@@ -631,8 +631,13 @@ func CreateNamespaceFromPrefixWithLog(ctx context.Context, k8sClient client.Clie
  }
  
  func CreateNamespaceFromObjectWithLog(ctx context.Context, k8sClient client.Client, ns *corev1.Namespace) *corev1.Namespace {
 -	MustCreate(ctx, k8sClient, ns)
 -	ginkgo.GinkgoLogr.Info("Created namespace", "namespace", ns.Name)
 +	ginkgo.GinkgoLogr.Info("Created namespace", "namespace", ns)
-+	// Add label to the namespace to mark it as managed by Kueue.
 +	if ns.Labels == nil {
 +		ns.Labels = make(map[string]string)
 +	}
@@ -19,7 +18,7 @@ index 95c6d509f..92a01fcdd 100644
  	return ns
  }
  
-@@ -607,7 +613,7 @@ func ExpectMetricsToBeAvailable(ctx context.Context, cfg *rest.Config, restClien
+@@ -654,7 +659,7 @@ func ExpectMetricsToBeAvailable(ctx context.Context, cfg *rest.Config, restClien
  		metricsOutput, err := GetKueueMetrics(ctx, cfg, restClient, curlPodName, curlContainerName)
  		g.Expect(err).NotTo(gomega.HaveOccurred())
  		g.Expect(metricsOutput).Should(utiltesting.ContainMetrics(metrics))
@@ -28,7 +27,7 @@ index 95c6d509f..92a01fcdd 100644
  }
  
  func ExpectMetricsNotToBeAvailable(ctx context.Context, cfg *rest.Config, restClient *rest.RESTClient, curlPodName, curlContainerName string, metrics [][]string) {
-@@ -616,7 +622,7 @@ func ExpectMetricsNotToBeAvailable(ctx context.Context, cfg *rest.Config, restCl
+@@ -663,7 +668,7 @@ func ExpectMetricsNotToBeAvailable(ctx context.Context, cfg *rest.Config, restCl
  		metricsOutput, err := GetKueueMetrics(ctx, cfg, restClient, curlPodName, curlContainerName)
  		g.Expect(err).NotTo(gomega.HaveOccurred())
  		g.Expect(metricsOutput).Should(utiltesting.ExcludeMetrics(metrics))


### PR DESCRIPTION
## Summary
- Updates `upstream/kueue/src` submodule from `df4b1c04` to `851a097d`
- Syncs generated manifests in `bindata/` via `make submodule-workflow`

## Key upstream changes

### Feature Graduations
- **Concurrent Admission** (MVP): allows workloads to pursue multiple flavors simultaneously with migration support
- **KueueDRAIntegration** graduated to beta
- **ElasticJobsViaWorkloadSlices** graduated to beta
- **SchedulingEquivalenceHashing** graduated to beta
- **MultiKueueWaitForWorkloadAdmitted** promoted to stable
- **MultiKueueRedoAdmissionOnEvictionInWorker** promoted to stable
- **SkipFinalizersForPodsSuspendedByParent** promoted to stable

### New Features
- Partitionable devices support in DRA (KEP-2941)
- WorkloadPriorityClass defaulting support
- MultiKueue Manager Quota Automation (KEP-9988, Alpha1)
- MultiKueue global quotas support
- Add `quotaCheckStrategy` to ClusterQueue
- Add `concurrentAdmissionPolicy` to ClusterQueue CRD
- Increase Workload PodSet limit to 10
- Add shortNames to Kueue CRDs

### RBAC / Manifest Changes
- Add unique label per clusterrole (`rbac.kueue.x-k8s.io/role`)
- Migrate events API from `core/v1` to `events.k8s.io`
- Add `resourceslices` RBAC to manager role
- Webhook configuration updates for new resources

### Bug Fixes & Improvements
- MultiKueue: detect hung remotes faster, prevent stalling
- TAS improvements (balanced placement, node hotswap fixes, eviction for unhealthy nodes)
- Fix nil pointer panic in concurrent admission cache
- Prevent integer overflow in ResourceValue and TotalRequests
- Various test stability improvements

## Test plan
- [ ] Verify manifests are correctly synced
- [ ] CI passes with updated submodule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workload migration policy configuration for ClusterQueues to control flavor migration behavior
  * Added resource short names for convenient kubectl commands (e.g., `ac` for admissionchecks, `topo` for topologies)

* **Improvements**
  * Webhook filtering now excludes system namespaces from Kueue operations
  * Enhanced RBAC role identification and aggregation capabilities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->