### PR TITLE
[wip]OCPKUEUE-655: Reduce DRA e2e test boilerplate with SetupTestEnvironment

### DIFF
--- a/test/e2e/e2e_admission_fair_sharing_test.go
+++ b/test/e2e/e2e_admission_fair_sharing_test.go
@@ -430,7 +430,7 @@ func enableAdmissionFairSharing(ctx context.Context, halfLifeSeconds, samplingSe
 
 	DeferCleanup(func(ctx context.Context) {
 		By("Restoring initial Kueue configuration")
-		applyKueueConfig(ctx, savedConfig, kubeClient)
+		testutils.ApplyKueueConfig(ctx, savedConfig, clients)
 	})
 
 	By("Configuring Kueue with AdmissionFairSharing enabled")
@@ -439,7 +439,7 @@ func enableAdmissionFairSharing(ctx context.Context, halfLifeSeconds, samplingSe
 		UsageHalfLifeTimeSeconds:     halfLifeSeconds,
 		UsageSamplingIntervalSeconds: samplingSeconds,
 	}
-	applyKueueConfig(ctx, desiredConfig, kubeClient)
+	testutils.ApplyKueueConfig(ctx, desiredConfig, clients)
 
 	expectedHalfLife := (time.Duration(halfLifeSeconds) * time.Second).String()
 	expectedSampling := (time.Duration(samplingSeconds) * time.Second).String()

--- a/test/e2e/e2e_dra_extended_resources_test.go
+++ b/test/e2e/e2e_dra_extended_resources_test.go
@@ -71,7 +71,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 		Expect(err).NotTo(HaveOccurred())
 		hasDriverSlices := false
 		for _, s := range slices.Items {
-			if s.Spec.Driver == draDeviceClassName {
+			if s.Spec.Driver == testutils.DRADeviceClassName {
 				hasDriverSlices = true
 				break
 			}
@@ -82,7 +82,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 		gpusPerNode := map[string]int{}
 		for _, s := range slices.Items {
-			if s.Spec.Driver == draDeviceClassName {
+			if s.Spec.Driver == testutils.DRADeviceClassName {
 				if s.Spec.NodeName != nil {
 					for _, d := range s.Spec.Devices {
 						// The NVIDIA DRA driver uses the bare "type" attribute key (not fully qualified)
@@ -107,7 +107,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 		}
 
 		// Check if DeviceClass has extendedResourceName set (K8s DRAExtendedResource gate enabled)
-		dc, err := kubeClient.ResourceV1().DeviceClasses().Get(ctx, draDeviceClassName, metav1.GetOptions{})
+		dc, err := kubeClient.ResourceV1().DeviceClasses().Get(ctx, testutils.DRADeviceClassName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		if dc.Spec.ExtendedResourceName == nil || *dc.Spec.ExtendedResourceName == "" {
 			Skip("DeviceClass gpu.nvidia.com does not have extendedResourceName set - DRAExtendedResource feature gate not enabled")
@@ -119,7 +119,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 		// Clear deviceClassMappings if set by a previous test suite
 		kueueInstance.Spec.Config.Resources.DeviceClassMappings = nil
-		applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+		testutils.ApplyKueueConfig(ctx, kueueInstance.Spec.Config, clients)
 
 		// Wait for DRA feature gates to be enabled and deviceClassMappings to be cleared
 		Eventually(func() error {
@@ -134,8 +134,8 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 			if !strings.Contains(configData, "DRAExtendedResources: true") {
 				return fmt.Errorf("DRAExtendedResources not enabled yet")
 			}
-			if strings.Contains(configData, draLogicalResource) {
-				return fmt.Errorf("deviceClassMappings still contains %s, waiting for config reconciliation", draLogicalResource)
+			if strings.Contains(configData, testutils.DRALogicalResource) {
+				return fmt.Errorf("deviceClassMappings still contains %s, waiting for config reconciliation", testutils.DRALogicalResource)
 			}
 			return nil
 		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
@@ -143,7 +143,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 	AfterAll(func(ctx context.Context) {
 		if initialKueueInstance != nil {
-			applyKueueConfig(ctx, initialKueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		}
 	})
 
@@ -189,7 +189,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 		By("Creating Job with extended resource request nvidia.com/gpu")
 		builder := testutils.NewTestResourceBuilder(ns.Name, erLocalQueueName)
 		job := builder.NewJob()
-		setDRAJobCPU(job)
+		testutils.SetDRAJobCPU(job)
 		job.Name = "er-basic-job"
 		job.Labels[testutils.QueueLabel] = erLocalQueueName
 		job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
@@ -298,7 +298,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 		By(fmt.Sprintf("Creating Job requesting %d GPUs via extended resources (quota is %d)", maxGPUsPerNode+1, maxGPUsPerNode))
 		builder := testutils.NewTestResourceBuilder(ns.Name, erLocalQueueName)
 		job := builder.NewJob()
-		setDRAJobCPU(job)
+		testutils.SetDRAJobCPU(job)
 		job.Name = "er-exceed-job"
 		job.Labels[testutils.QueueLabel] = erLocalQueueName
 		exceededCount := *resource.NewQuantity(int64(maxGPUsPerNode+1), resource.DecimalSI)
@@ -358,7 +358,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 		By(fmt.Sprintf("Creating first job requesting all %d GPUs via extended resources (fills quota)", maxGPUsPerNode))
 		builder := testutils.NewTestResourceBuilder(ns.Name, erLocalQueueName)
 		job1 := builder.NewJob()
-		setDRAJobCPU(job1)
+		testutils.SetDRAJobCPU(job1)
 		job1.Name = "er-fill-job-1"
 		job1.Labels[testutils.QueueLabel] = erLocalQueueName
 		fillCount := *resource.NewQuantity(int64(maxGPUsPerNode), resource.DecimalSI)
@@ -382,7 +382,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 		By("Creating second job requesting 1 GPU via extended resources (quota full, should be suspended)")
 		job2 := builder.NewJob()
-		setDRAJobCPU(job2)
+		testutils.SetDRAJobCPU(job2)
 		job2.Name = "er-fill-job-2"
 		job2.Labels[testutils.QueueLabel] = erLocalQueueName
 		job2.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
@@ -454,7 +454,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 		By("Creating Job with 1 GPU via extended resource request")
 		builder := testutils.NewTestResourceBuilder(ns.Name, erLocalQueueName)
 		job := builder.NewJob()
-		setDRAJobCPU(job)
+		testutils.SetDRAJobCPU(job)
 		job.Name = "er-usage-job"
 		job.Labels[testutils.QueueLabel] = erLocalQueueName
 		job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
@@ -509,11 +509,11 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 			kueueInstance.Spec.Config.Resources.DeviceClassMappings = []ssv1.DeviceClassMapping{
 				{
-					Name:             draLogicalResource,
-					DeviceClassNames: []ssv1.DeviceClassName{draDeviceClassName},
+					Name:             testutils.DRALogicalResource,
+					DeviceClassNames: []ssv1.DeviceClassName{testutils.DRADeviceClassName},
 				},
 			}
-			applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, kueueInstance.Spec.Config, clients)
 
 			Eventually(func() error {
 				configMap, err := kubeClient.CoreV1().ConfigMaps(testutils.OperatorNamespace).Get(ctx, "kueue-manager-config", metav1.GetOptions{})
@@ -536,13 +536,13 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 			cqWrapper := testutils.NewClusterQueue().WithGenerateName().WithFlavorName(resourceFlavor.Name)
 			cqWrapper.Spec.ResourceGroups = []kueuev1beta2.ResourceGroup{{
-				CoveredResources: []corev1.ResourceName{"cpu", "memory", corev1.ResourceName(draLogicalResource), corev1.ResourceName(extendedResourceName)},
+				CoveredResources: []corev1.ResourceName{"cpu", "memory", corev1.ResourceName(testutils.DRALogicalResource), corev1.ResourceName(extendedResourceName)},
 				Flavors: []kueuev1beta2.FlavorQuotas{{
 					Name: kueuev1beta2.ResourceFlavorReference(resourceFlavor.Name),
 					Resources: []kueuev1beta2.ResourceQuota{
 						{Name: "cpu", NominalQuota: resource.MustParse("100")},
 						{Name: "memory", NominalQuota: resource.MustParse("100Gi")},
-						{Name: corev1.ResourceName(draLogicalResource), NominalQuota: *resource.NewQuantity(int64(maxGPUsPerNode), resource.DecimalSI)},
+						{Name: corev1.ResourceName(testutils.DRALogicalResource), NominalQuota: *resource.NewQuantity(int64(maxGPUsPerNode), resource.DecimalSI)},
 						{Name: corev1.ResourceName(extendedResourceName), NominalQuota: *resource.NewQuantity(int64(maxGPUsPerNode), resource.DecimalSI)},
 					},
 				}},
@@ -579,7 +579,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 								{
 									Name: "gpu-req",
 									Exactly: &resourcev1.ExactDeviceRequest{
-										DeviceClassName: draDeviceClassName,
+										DeviceClassName: testutils.DRADeviceClassName,
 										Count:           1,
 									},
 								},
@@ -595,7 +595,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 			By("Creating Job with both extended resource request and ResourceClaimTemplate")
 			builder := testutils.NewTestResourceBuilder(ns.Name, "er-mixed-queue")
 			job := builder.NewJob()
-			setDRAJobCPU(job)
+			testutils.SetDRAJobCPU(job)
 			job.Name = "er-mixed-job"
 			job.Labels[testutils.QueueLabel] = "er-mixed-queue"
 			job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
@@ -625,22 +625,22 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 				g.Expect(wl.Status.Admission.PodSetAssignments).To(HaveLen(1))
 
 				assignment := wl.Status.Admission.PodSetAssignments[0]
-				g.Expect(assignment.ResourceUsage).To(HaveKey(corev1.ResourceName(draLogicalResource)))
-				g.Expect(assignment.ResourceUsage[corev1.ResourceName(draLogicalResource)]).To(Equal(resource.MustParse("2")),
-					"both ER and RCT should be counted under %s", draLogicalResource)
+				g.Expect(assignment.ResourceUsage).To(HaveKey(corev1.ResourceName(testutils.DRALogicalResource)))
+				g.Expect(assignment.ResourceUsage[corev1.ResourceName(testutils.DRALogicalResource)]).To(Equal(resource.MustParse("2")),
+					"both ER and RCT should be counted under %s", testutils.DRALogicalResource)
 
 				// Verify ClusterQueue shows mapping name used, extended resource name stays at 0
 				cqObj, err := kueueClient.KueueV1beta2().ClusterQueues().Get(ctx, cq.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 				for _, flavor := range cqObj.Status.FlavorsReservation {
 					for _, res := range flavor.Resources {
-						if res.Name == corev1.ResourceName(draLogicalResource) {
+						if res.Name == corev1.ResourceName(testutils.DRALogicalResource) {
 							g.Expect(res.Total.Cmp(resource.MustParse("2"))).To(Equal(0),
-								"%s should show 2 reserved (ER + RCT converged), got %s", draLogicalResource, res.Total.String())
+								"%s should show 2 reserved (ER + RCT converged), got %s", testutils.DRALogicalResource, res.Total.String())
 						}
 						if res.Name == corev1.ResourceName(extendedResourceName) {
 							g.Expect(res.Total.Cmp(resource.MustParse("0"))).To(Equal(0),
-								"%s should show 0 (mapped to %s), got %s", extendedResourceName, draLogicalResource, res.Total.String())
+								"%s should show 0 (mapped to %s), got %s", extendedResourceName, testutils.DRALogicalResource, res.Total.String())
 						}
 					}
 				}

--- a/test/e2e/e2e_dra_extended_resources_test.go
+++ b/test/e2e/e2e_dra_extended_resources_test.go
@@ -198,7 +198,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 		}
 		createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
+		DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
 
 		By("Verifying workload is admitted with correct quota under extendedResourceName")
 		Eventually(func(g Gomega) {
@@ -308,7 +308,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 		}
 		createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
+		DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
 
 		By("Verifying job remains suspended")
 		Consistently(func() bool {
@@ -368,7 +368,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 		}
 		createdJob1, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job1, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		defer testutils.CleanUpJob(ctx, kubeClient, createdJob1.Namespace, createdJob1.Name)
+		DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob1.Namespace, createdJob1.Name)
 
 		By("Waiting for first job to be admitted")
 		Eventually(func() bool {
@@ -391,7 +391,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 		}
 		createdJob2, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job2, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		defer testutils.CleanUpJob(ctx, kubeClient, createdJob2.Namespace, createdJob2.Name)
+		DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob2.Namespace, createdJob2.Name)
 
 		By("Verifying second job is suspended (quota full)")
 		Consistently(func() bool {
@@ -463,7 +463,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 		}
 		createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
+		DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
 
 		By("Verifying ClusterQueue shows extended resource reservation")
 		Eventually(func(g Gomega) {
@@ -610,7 +610,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 			}
 			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
+			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
 
 			By("Verifying workload is admitted and deviceClassMappings name takes precedence")
 			Eventually(func(g Gomega) {

--- a/test/e2e/e2e_dra_test.go
+++ b/test/e2e/e2e_dra_test.go
@@ -685,7 +685,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			testutils.AddDRAClaims(&ss.Spec.Template.Spec, "gpu-template-workload-types")
 			createdSS, err := kubeClient.AppsV1().StatefulSets(ns.Name).Create(ctx, ss, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpObject(ctx, genericClient, createdSS)
+			DeferCleanup(testutils.CleanUpObject, genericClient, createdSS)
 
 			By("Waiting for StatefulSet pod to be created and workload to be admitted")
 			testutils.WaitForPodWorkloadAdmitted(ctx, kubeClient, kueueClient, ns.Name, "app=test-statefulset")

--- a/test/e2e/e2e_dra_test.go
+++ b/test/e2e/e2e_dra_test.go
@@ -151,51 +151,26 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 	When("basic DRA quota is configured", func() {
 		It("should admit job with ResourceClaimTemplate and account DRA quota correctly", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
+			env := testutils.SetupTestEnvironment(ctx, testutils.DRATestNamespacePrefix, testutils.DRALocalQueueName,
+				testutils.NewClusterQueue().WithDRAResource(testutils.DRALogicalResource, "1"),
+			)
 			kueueClient := clients.UpstreamKueueClient
 
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(testutils.DRALogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: testutils.DRATestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
-
 			By("Creating ResourceClaimTemplate for gpu.nvidia.com")
-			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-basic", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-basic", env.Namespace.Name, 1)
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(env.Namespace.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating Job referencing ResourceClaimTemplate")
-			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
+			builder := testutils.NewTestResourceBuilder(env.Namespace.Name, testutils.DRALocalQueueName)
 			job := testutils.NewDRAJob(builder, "dra-basic-job", "gpu-template-basic", testutils.DRALocalQueueName)
-			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
+			createdJob, err := kubeClient.BatchV1().Jobs(env.Namespace.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
 
 			By("Verifying workload is admitted with correct DRA quota")
 			Eventually(func(g Gomega) {
-				wlList, err := kueueClient.KueueV1beta2().Workloads(ns.Name).List(ctx, metav1.ListOptions{
+				wlList, err := kueueClient.KueueV1beta2().Workloads(env.Namespace.Name).List(ctx, metav1.ListOptions{
 					LabelSelector: fmt.Sprintf("kueue.x-k8s.io/job-uid=%s", string(createdJob.UID)),
 				})
 				g.Expect(err).NotTo(HaveOccurred())
@@ -212,120 +187,69 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 			By("Verifying job is unsuspended")
 			Eventually(func() bool {
-				return !testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJob.Name)
+				return !testutils.IsJobSuspended(ctx, kubeClient, env.Namespace.Name, createdJob.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Verifying job pod is running")
 			Eventually(func() bool {
-				return testutils.IsJobPodRunning(ctx, kubeClient, ns.Name, createdJob.Name)
+				return testutils.IsJobPodRunning(ctx, kubeClient, env.Namespace.Name, createdJob.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 		})
 
 		It("should suspend job when DRA quota is exceeded", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
-			kueueClient := clients.UpstreamKueueClient
-
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(testutils.DRALogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: testutils.DRATestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
+			env := testutils.SetupTestEnvironment(ctx, testutils.DRATestNamespacePrefix, testutils.DRALocalQueueName,
+				testutils.NewClusterQueue().WithDRAResource(testutils.DRALogicalResource, "1"),
+			)
 
 			By("Creating ResourceClaimTemplate requesting more GPUs than quota allows")
-			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-exceed", ns.Name, 5) // quota is 1
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-exceed", env.Namespace.Name, 5) // quota is 1
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(env.Namespace.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating Job that exceeds DRA quota")
-			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
+			builder := testutils.NewTestResourceBuilder(env.Namespace.Name, testutils.DRALocalQueueName)
 			job := testutils.NewDRAJob(builder, "dra-exceed-job", "gpu-template-exceed", testutils.DRALocalQueueName)
-			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
+			createdJob, err := kubeClient.BatchV1().Jobs(env.Namespace.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
 
 			By("Verifying job is suspended due to exceeding DRA quota")
 			Eventually(func() bool {
-				return testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJob.Name)
+				return testutils.IsJobSuspended(ctx, kubeClient, env.Namespace.Name, createdJob.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 		})
 
 		It("should admit waiting job after DRA quota is freed", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
+			env := testutils.SetupTestEnvironment(ctx, testutils.DRATestNamespacePrefix, testutils.DRALocalQueueName,
+				testutils.NewClusterQueue().WithDRAResource(testutils.DRALogicalResource, "1"),
+			)
 			kueueClient := clients.UpstreamKueueClient
 
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(testutils.DRALogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: testutils.DRATestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
-
 			By("Creating shared ResourceClaimTemplate requesting 1 GPU")
-			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-shared", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-shared", env.Namespace.Name, 1)
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(env.Namespace.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating first job referencing shared template (fills 1/1 quota)")
-			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
+			builder := testutils.NewTestResourceBuilder(env.Namespace.Name, testutils.DRALocalQueueName)
 			job1 := testutils.NewDRAJob(builder, "dra-fill-job-1", "gpu-template-shared", testutils.DRALocalQueueName)
-			createdJob1, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job1, metav1.CreateOptions{})
+			createdJob1, err := kubeClient.BatchV1().Jobs(env.Namespace.Name).Create(ctx, job1, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob1.Namespace, createdJob1.Name)
 
 			By("Waiting for first job to be admitted")
 			Eventually(func() bool {
-				return !testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJob1.Name)
+				return !testutils.IsJobSuspended(ctx, kubeClient, env.Namespace.Name, createdJob1.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Verifying first job pod is running")
 			Eventually(func() bool {
-				return testutils.IsJobPodRunning(ctx, kubeClient, ns.Name, createdJob1.Name)
+				return testutils.IsJobPodRunning(ctx, kubeClient, env.Namespace.Name, createdJob1.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Verifying ClusterQueue shows reservation before creating second job")
 			Eventually(func(g Gomega) {
-				cqObj, err := kueueClient.KueueV1beta2().ClusterQueues().Get(ctx, cq.Name, metav1.GetOptions{})
+				cqObj, err := kueueClient.KueueV1beta2().ClusterQueues().Get(ctx, env.ClusterQueue.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(cqObj.Status.FlavorsReservation).NotTo(BeEmpty())
 				found := false
@@ -341,13 +265,13 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 			By("Creating second job referencing same shared template (quota full, should be suspended)")
 			job2 := testutils.NewDRAJob(builder, "dra-fill-job-2", "gpu-template-shared", testutils.DRALocalQueueName)
-			createdJob2, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job2, metav1.CreateOptions{})
+			createdJob2, err := kubeClient.BatchV1().Jobs(env.Namespace.Name).Create(ctx, job2, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob2.Namespace, createdJob2.Name)
 
 			By("Waiting for second job to be suspended (quota full)")
 			Eventually(func() bool {
-				return testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJob2.Name)
+				return testutils.IsJobSuspended(ctx, kubeClient, env.Namespace.Name, createdJob2.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Deleting first job to free quota")
@@ -355,61 +279,36 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 			By("Verifying second job is admitted after quota freed")
 			Eventually(func() bool {
-				return !testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJob2.Name)
+				return !testutils.IsJobSuspended(ctx, kubeClient, env.Namespace.Name, createdJob2.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Verifying second job pod is running")
 			Eventually(func() bool {
-				return testutils.IsJobPodRunning(ctx, kubeClient, ns.Name, createdJob2.Name)
+				return testutils.IsJobPodRunning(ctx, kubeClient, env.Namespace.Name, createdJob2.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 		})
 
 		It("should verify ClusterQueue shows correct DRA resource usage", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
+			env := testutils.SetupTestEnvironment(ctx, testutils.DRATestNamespacePrefix, testutils.DRALocalQueueName,
+				testutils.NewClusterQueue().WithDRAResource(testutils.DRALogicalResource, "1"),
+			)
 			kueueClient := clients.UpstreamKueueClient
 
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(testutils.DRALogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: testutils.DRATestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
-
 			By("Creating ResourceClaimTemplate for 1 GPU")
-			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-usage", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-usage", env.Namespace.Name, 1)
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(env.Namespace.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating Job")
-			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
+			builder := testutils.NewTestResourceBuilder(env.Namespace.Name, testutils.DRALocalQueueName)
 			job := testutils.NewDRAJob(builder, "dra-usage-job", "gpu-template-usage", testutils.DRALocalQueueName)
-			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
+			createdJob, err := kubeClient.BatchV1().Jobs(env.Namespace.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
 
 			By("Verifying ClusterQueue shows DRA resource reservation")
 			Eventually(func(g Gomega) {
-				cqObj, err := kueueClient.KueueV1beta2().ClusterQueues().Get(ctx, cq.Name, metav1.GetOptions{})
+				cqObj, err := kueueClient.KueueV1beta2().ClusterQueues().Get(ctx, env.ClusterQueue.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(cqObj.Status.FlavorsReservation).NotTo(BeEmpty())
 
@@ -428,50 +327,25 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 			By("Verifying job pod is running")
 			Eventually(func() bool {
-				return testutils.IsJobPodRunning(ctx, kubeClient, ns.Name, createdJob.Name)
+				return testutils.IsJobPodRunning(ctx, kubeClient, env.Namespace.Name, createdJob.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 		})
 	})
 
 	When("two containers share a single GPU", func() {
 		It("should admit job with two containers sharing a single GPU", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
+			env := testutils.SetupTestEnvironment(ctx, testutils.DRATestNamespacePrefix, testutils.DRALocalQueueName,
+				testutils.NewClusterQueue().WithDRAResource(testutils.DRALogicalResource, "1"),
+			)
 			kueueClient := clients.UpstreamKueueClient
 
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(testutils.DRALogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: testutils.DRATestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
-
 			By("Creating ResourceClaimTemplate for a single GPU")
-			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-shared-ctr", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-shared-ctr", env.Namespace.Name, 1)
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(env.Namespace.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating Job with two containers sharing the same GPU claim")
-			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
+			builder := testutils.NewTestResourceBuilder(env.Namespace.Name, testutils.DRALocalQueueName)
 			job := testutils.NewDRAJob(builder, "dra-shared-gpu-job", "gpu-template-shared-ctr", testutils.DRALocalQueueName)
 			job.Spec.Template.Spec.Containers = append(job.Spec.Template.Spec.Containers, corev1.Container{
 				Name:    "ctr1",
@@ -484,13 +358,13 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 					Claims: []corev1.ResourceClaim{{Name: "gpu"}},
 				},
 			})
-			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
+			createdJob, err := kubeClient.BatchV1().Jobs(env.Namespace.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
 
 			By("Verifying workload is admitted with correct DRA quota (1 GPU shared between 2 containers)")
 			Eventually(func(g Gomega) {
-				wlList, err := kueueClient.KueueV1beta2().Workloads(ns.Name).List(ctx, metav1.ListOptions{
+				wlList, err := kueueClient.KueueV1beta2().Workloads(env.Namespace.Name).List(ctx, metav1.ListOptions{
 					LabelSelector: fmt.Sprintf("kueue.x-k8s.io/job-uid=%s", string(createdJob.UID)),
 				})
 				g.Expect(err).NotTo(HaveOccurred())
@@ -507,17 +381,17 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 			By("Verifying job is unsuspended")
 			Eventually(func() bool {
-				return !testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJob.Name)
+				return !testutils.IsJobSuspended(ctx, kubeClient, env.Namespace.Name, createdJob.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Verifying job pod is running")
 			Eventually(func() bool {
-				return testutils.IsJobPodRunning(ctx, kubeClient, ns.Name, createdJob.Name)
+				return testutils.IsJobPodRunning(ctx, kubeClient, env.Namespace.Name, createdJob.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Verifying exactly one ResourceClaim is allocated and reserved")
 			Eventually(func(g Gomega) {
-				claims, err := kubeClient.ResourceV1().ResourceClaims(ns.Name).List(ctx, metav1.ListOptions{})
+				claims, err := kubeClient.ResourceV1().ResourceClaims(env.Namespace.Name).List(ctx, metav1.ListOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(claims.Items).To(HaveLen(1), "expected exactly 1 ResourceClaim, got %d", len(claims.Items))
 				g.Expect(claims.Items[0].Status.Allocation).NotTo(BeNil(), "ResourceClaim not allocated")
@@ -528,211 +402,110 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 	When("different workload types use DRA resources", func() {
 		It("should admit DRA workloads for Pod type", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
+			env := testutils.SetupTestEnvironment(ctx, testutils.DRATestNamespacePrefix, testutils.DRALocalQueueName,
+				testutils.NewClusterQueue().WithDRAResource(testutils.DRALogicalResource, "1"),
+			)
 			kueueClient := clients.UpstreamKueueClient
 
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(testutils.DRALogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: testutils.DRATestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
-
 			By("Creating ResourceClaimTemplate requesting 1 GPU")
-			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-workload-types", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-workload-types", env.Namespace.Name, 1)
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(env.Namespace.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
+			builder := testutils.NewTestResourceBuilder(env.Namespace.Name, testutils.DRALocalQueueName)
 
 			By("Creating a Kueue-managed Pod with DRA ResourceClaim")
 			pod := builder.NewPod()
 			testutils.AddDRAClaims(&pod.Spec, "gpu-template-workload-types")
-			createdPod, err := kubeClient.CoreV1().Pods(ns.Name).Create(ctx, pod, metav1.CreateOptions{})
+			createdPod, err := kubeClient.CoreV1().Pods(env.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			testutils.VerifyWorkloadCreated(ctx, kueueClient, ns.Name, string(createdPod.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient, env.Namespace.Name, string(createdPod.UID))
 
 			By("Verifying Pod is running")
 			Eventually(func(g Gomega) {
-				p, err := kubeClient.CoreV1().Pods(ns.Name).Get(ctx, createdPod.Name, metav1.GetOptions{})
+				p, err := kubeClient.CoreV1().Pods(env.Namespace.Name).Get(ctx, createdPod.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(p.Status.Phase).To(Equal(corev1.PodRunning), "Pod not running")
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Verifying ResourceClaim is allocated and reserved for Pod")
-			testutils.VerifyResourceClaimAllocated(ctx, kubeClient, ns.Name)
+			testutils.VerifyResourceClaimAllocated(ctx, kubeClient, env.Namespace.Name)
 		})
 
 		It("should admit DRA workloads for Deployment type", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
+			env := testutils.SetupTestEnvironment(ctx, testutils.DRATestNamespacePrefix, testutils.DRALocalQueueName,
+				testutils.NewClusterQueue().WithDRAResource(testutils.DRALogicalResource, "1"),
+			)
 			kueueClient := clients.UpstreamKueueClient
 
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(testutils.DRALogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: testutils.DRATestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
-
 			By("Creating ResourceClaimTemplate requesting 1 GPU")
-			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-workload-types", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-workload-types", env.Namespace.Name, 1)
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(env.Namespace.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
+			builder := testutils.NewTestResourceBuilder(env.Namespace.Name, testutils.DRALocalQueueName)
 
 			By("Creating a Kueue-managed Deployment with DRA ResourceClaim")
 			deploy := builder.NewDeployment()
 			testutils.AddDRAClaims(&deploy.Spec.Template.Spec, "gpu-template-workload-types")
-			createdDeploy, err := kubeClient.AppsV1().Deployments(ns.Name).Create(ctx, deploy, metav1.CreateOptions{})
+			createdDeploy, err := kubeClient.AppsV1().Deployments(env.Namespace.Name).Create(ctx, deploy, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for Deployment pod to be created and workload to be admitted")
-			testutils.WaitForPodWorkloadAdmitted(ctx, kubeClient, kueueClient, ns.Name, "app=test-deployment")
+			testutils.WaitForPodWorkloadAdmitted(ctx, kubeClient, kueueClient, env.Namespace.Name, "app=test-deployment")
 
 			By("Verifying Deployment is available")
 			Eventually(func(g Gomega) {
-				d, err := kubeClient.AppsV1().Deployments(ns.Name).Get(ctx, createdDeploy.Name, metav1.GetOptions{})
+				d, err := kubeClient.AppsV1().Deployments(env.Namespace.Name).Get(ctx, createdDeploy.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(d.Status.AvailableReplicas).To(Equal(int32(1)), "Deployment not available")
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Verifying ResourceClaim is allocated and reserved for Deployment")
-			testutils.VerifyResourceClaimAllocated(ctx, kubeClient, ns.Name)
+			testutils.VerifyResourceClaimAllocated(ctx, kubeClient, env.Namespace.Name)
 		})
 
 		It("should admit DRA workloads for StatefulSet type", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
+			env := testutils.SetupTestEnvironment(ctx, testutils.DRATestNamespacePrefix, testutils.DRALocalQueueName,
+				testutils.NewClusterQueue().WithDRAResource(testutils.DRALogicalResource, "1"),
+			)
 			kueueClient := clients.UpstreamKueueClient
 
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(testutils.DRALogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: testutils.DRATestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
-
 			By("Creating ResourceClaimTemplate requesting 1 GPU")
-			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-workload-types", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-workload-types", env.Namespace.Name, 1)
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(env.Namespace.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
+			builder := testutils.NewTestResourceBuilder(env.Namespace.Name, testutils.DRALocalQueueName)
 
 			By("Creating a Kueue-managed StatefulSet with DRA ResourceClaim")
 			ss := builder.NewStatefulSet()
 			testutils.AddDRAClaims(&ss.Spec.Template.Spec, "gpu-template-workload-types")
-			createdSS, err := kubeClient.AppsV1().StatefulSets(ns.Name).Create(ctx, ss, metav1.CreateOptions{})
+			createdSS, err := kubeClient.AppsV1().StatefulSets(env.Namespace.Name).Create(ctx, ss, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpObject, genericClient, createdSS)
 
 			By("Waiting for StatefulSet pod to be created and workload to be admitted")
-			testutils.WaitForPodWorkloadAdmitted(ctx, kubeClient, kueueClient, ns.Name, "app=test-statefulset")
+			testutils.WaitForPodWorkloadAdmitted(ctx, kubeClient, kueueClient, env.Namespace.Name, "app=test-statefulset")
 
 			By("Verifying StatefulSet is ready")
 			Eventually(func(g Gomega) {
-				s, err := kubeClient.AppsV1().StatefulSets(ns.Name).Get(ctx, createdSS.Name, metav1.GetOptions{})
+				s, err := kubeClient.AppsV1().StatefulSets(env.Namespace.Name).Get(ctx, createdSS.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(s.Status.ReadyReplicas).To(Equal(int32(1)), "StatefulSet not ready")
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Verifying ResourceClaim is allocated and reserved for StatefulSet")
-			testutils.VerifyResourceClaimAllocated(ctx, kubeClient, ns.Name)
+			testutils.VerifyResourceClaimAllocated(ctx, kubeClient, env.Namespace.Name)
 		})
 	})
 
 	When("deviceClassMappings are misconfigured", func() {
 		It("should not admit DRA workloads when deviceClassMappings point to wrong DeviceClass", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
-			kueueClient := clients.UpstreamKueueClient
-
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(testutils.DRALogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: testutils.DRATestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
+			env := testutils.SetupTestEnvironment(ctx, testutils.DRATestNamespacePrefix, testutils.DRALocalQueueName,
+				testutils.NewClusterQueue().WithDRAResource(testutils.DRALogicalResource, "1"),
+			)
 
 			By("Saving current Kueue config before modifying deviceClassMappings")
 			kueueInstance, err := clients.KueueClient.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
@@ -760,46 +533,35 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Creating ResourceClaimTemplate for DRA job")
-			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-wrong-class", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-wrong-class", env.Namespace.Name, 1)
+			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(env.Namespace.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating DRA job with wrong DeviceClass mapping")
 			wrongClassStart := metav1.Now()
-			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
+			builder := testutils.NewTestResourceBuilder(env.Namespace.Name, testutils.DRALocalQueueName)
 			job := testutils.NewDRAJob(builder, "dra-wrong-class", "gpu-template-wrong-class", testutils.DRALocalQueueName)
-			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
+			createdJob, err := kubeClient.BatchV1().Jobs(env.Namespace.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
 
 			By("Verifying job is suspended due to wrong DeviceClass mapping")
 			Eventually(func() bool {
-				return testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJob.Name)
+				return testutils.IsJobSuspended(ctx, kubeClient, env.Namespace.Name, createdJob.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Verifying No ResourceClaim is created since the job was never unsuspended")
-			testutils.VerifyNoResourceClaims(ctx, kubeClient, ns.Name, wrongClassStart)
+			testutils.VerifyNoResourceClaims(ctx, kubeClient, env.Namespace.Name, wrongClassStart)
 		})
 	})
 
 	When("preemption is enabled", func() {
 		It("should preempt low-priority DRA workload when high-priority DRA workload is submitted", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
-			kueueClient := clients.UpstreamKueueClient
-
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: testutils.DRATestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
+			env := testutils.SetupTestEnvironment(ctx, testutils.DRATestNamespacePrefix, testutils.DRALocalQueueName,
+				testutils.NewClusterQueue().
+					WithPreemption(kueuev1beta2.PreemptionPolicyLowerPriority).
+					WithDRAResource(testutils.DRALogicalResource, "1"),
+			)
 
 			By("Creating PriorityClasses")
 			lowPC, cleanupLowPC, err := createPriorityClass(ctx, 100, "Low priority for DRA preemption")
@@ -809,60 +571,45 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupHighPC)
 
-			By("Creating ClusterQueue with preemption enabled and DRA quota")
-			preemptCQ, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithPreemption(kueuev1beta2.PreemptionPolicyLowerPriority).
-				WithDRAResource(testutils.DRALogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			By("Creating LocalQueue for preemption test")
-			preemptLQ, cleanupLQ, err := testutils.NewLocalQueue(ns.Name, "").WithGenerateName().WithClusterQueue(preemptCQ.Name).CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
-
 			By("Creating ResourceClaimTemplate")
-			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-preempt", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-preempt", env.Namespace.Name, 1)
+			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(env.Namespace.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Submitting low-priority DRA job that fills the 1-GPU quota")
-			builder := testutils.NewTestResourceBuilder(ns.Name, preemptLQ.Name)
-			lowJob := testutils.NewDRAJob(builder, "dra-low-prio", "gpu-template-preempt", preemptLQ.Name)
+			builder := testutils.NewTestResourceBuilder(env.Namespace.Name, testutils.DRALocalQueueName)
+			lowJob := testutils.NewDRAJob(builder, "dra-low-prio", "gpu-template-preempt", testutils.DRALocalQueueName)
 			lowJob.Spec.Template.Spec.PriorityClassName = lowPC.Name
-			createdLowJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, lowJob, metav1.CreateOptions{})
+			createdLowJob, err := kubeClient.BatchV1().Jobs(env.Namespace.Name).Create(ctx, lowJob, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdLowJob.Namespace, createdLowJob.Name)
 
 			By("Verifying low-priority job is admitted")
-			checkWorkloadCondition(ctx, ns.Name, string(createdLowJob.UID), kueuev1beta2.WorkloadAdmitted, "low-priority")
+			checkWorkloadCondition(ctx, env.Namespace.Name, string(createdLowJob.UID), kueuev1beta2.WorkloadAdmitted, "low-priority")
 
 			By("Verifying low-priority job pod is running")
 			Eventually(func() bool {
-				return testutils.IsJobPodRunning(ctx, kubeClient, ns.Name, createdLowJob.Name)
+				return testutils.IsJobPodRunning(ctx, kubeClient, env.Namespace.Name, createdLowJob.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Submitting high-priority DRA job that triggers preemption")
-			highJob := testutils.NewDRAJob(builder, "dra-high-prio", "gpu-template-preempt", preemptLQ.Name)
+			highJob := testutils.NewDRAJob(builder, "dra-high-prio", "gpu-template-preempt", testutils.DRALocalQueueName)
 			highJob.Spec.Template.Spec.PriorityClassName = highPC.Name
-			createdHighJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, highJob, metav1.CreateOptions{})
+			createdHighJob, err := kubeClient.BatchV1().Jobs(env.Namespace.Name).Create(ctx, highJob, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdHighJob.Namespace, createdHighJob.Name)
 
 			By("Verifying low-priority job is evicted")
-			checkWorkloadCondition(ctx, ns.Name, string(createdLowJob.UID), kueuev1beta2.WorkloadEvicted, "low-priority")
+			checkWorkloadCondition(ctx, env.Namespace.Name, string(createdLowJob.UID), kueuev1beta2.WorkloadEvicted, "low-priority")
 
 			By("Verifying high-priority job is admitted")
-			checkWorkloadCondition(ctx, ns.Name, string(createdHighJob.UID), kueuev1beta2.WorkloadAdmitted, "high-priority")
+			checkWorkloadCondition(ctx, env.Namespace.Name, string(createdHighJob.UID), kueuev1beta2.WorkloadAdmitted, "high-priority")
 
 			By("Waiting for high-priority job to complete")
-			checkWorkloadCondition(ctx, ns.Name, string(createdHighJob.UID), kueuev1beta2.WorkloadFinished, "high-priority")
+			checkWorkloadCondition(ctx, env.Namespace.Name, string(createdHighJob.UID), kueuev1beta2.WorkloadFinished, "high-priority")
 
 			By("Verifying low-priority job is re-admitted after high-priority completes")
-			checkWorkloadCondition(ctx, ns.Name, string(createdLowJob.UID), kueuev1beta2.WorkloadAdmitted, "low-priority")
+			checkWorkloadCondition(ctx, env.Namespace.Name, string(createdLowJob.UID), kueuev1beta2.WorkloadAdmitted, "low-priority")
 		})
 	})
 
@@ -872,22 +619,9 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 				Skip(fmt.Sprintf("gang scheduling test requires at least 2 GPUs, found %d", gpuCount))
 			}
 
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
-			kueueClient := clients.UpstreamKueueClient
-
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: testutils.DRATestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
+			env := testutils.SetupTestEnvironment(ctx, testutils.DRATestNamespacePrefix, testutils.DRALocalQueueName,
+				testutils.NewClusterQueue().WithDRAResource(testutils.DRALogicalResource, "2"),
+			)
 
 			By("Saving current Kueue config and enabling gang scheduling")
 			kueueInstance, err := clients.KueueClient.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
@@ -905,64 +639,50 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			}
 			testutils.ApplyKueueConfig(ctx, kueueInstance.Spec.Config, clients)
 
-			By("Creating ClusterQueue with 2 GPU DRA quota")
-			gangCQ, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(testutils.DRALogicalResource, "2").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			By("Creating LocalQueue for gang scheduling test")
-			gangLQ, cleanupLQ, err := testutils.NewLocalQueue(ns.Name, "").WithGenerateName().WithClusterQueue(gangCQ.Name).CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
-
 			By("Creating ResourceClaimTemplate")
-			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-gang", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-gang", env.Namespace.Name, 1)
+			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(env.Namespace.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Submitting single-pod DRA job that fills 1 of 2 GPUs")
-			builder := testutils.NewTestResourceBuilder(ns.Name, gangLQ.Name)
-			singleJob := testutils.NewDRAJob(builder, "dra-single-gpu", "gpu-template-gang", gangLQ.Name)
-			createdSingleJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, singleJob, metav1.CreateOptions{})
+			builder := testutils.NewTestResourceBuilder(env.Namespace.Name, testutils.DRALocalQueueName)
+			singleJob := testutils.NewDRAJob(builder, "dra-single-gpu", "gpu-template-gang", testutils.DRALocalQueueName)
+			createdSingleJob, err := kubeClient.BatchV1().Jobs(env.Namespace.Name).Create(ctx, singleJob, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdSingleJob.Namespace, createdSingleJob.Name)
 
 			By("Verifying single-pod job is admitted and running")
-			checkWorkloadCondition(ctx, ns.Name, string(createdSingleJob.UID), kueuev1beta2.WorkloadAdmitted, "single-gpu")
+			checkWorkloadCondition(ctx, env.Namespace.Name, string(createdSingleJob.UID), kueuev1beta2.WorkloadAdmitted, "single-gpu")
 			Eventually(func() bool {
-				return testutils.IsJobPodRunning(ctx, kubeClient, ns.Name, createdSingleJob.Name)
+				return testutils.IsJobPodRunning(ctx, kubeClient, env.Namespace.Name, createdSingleJob.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Submitting gang DRA job (parallelism=2, needs 2 GPUs, only 1 free)")
-			gangJob := testutils.NewDRAJob(builder, "dra-gang-job", "gpu-template-gang", gangLQ.Name)
+			gangJob := testutils.NewDRAJob(builder, "dra-gang-job", "gpu-template-gang", testutils.DRALocalQueueName)
 			gangJob.Spec.Parallelism = ptr.To(int32(2))
 			gangJob.Spec.Completions = ptr.To(int32(2))
-			createdGangJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, gangJob, metav1.CreateOptions{})
+			createdGangJob, err := kubeClient.BatchV1().Jobs(env.Namespace.Name).Create(ctx, gangJob, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdGangJob.Namespace, createdGangJob.Name)
 
 			By("Verifying gang job is suspended (not enough DRA quota for all pods)")
 			Eventually(func() bool {
-				return testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdGangJob.Name)
+				return testutils.IsJobSuspended(ctx, kubeClient, env.Namespace.Name, createdGangJob.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Deleting single-pod job to free its GPU")
 			testutils.CleanUpJob(ctx, kubeClient, createdSingleJob.Namespace, createdSingleJob.Name)
 
 			By("Verifying gang job is admitted after quota is freed")
-			checkWorkloadCondition(ctx, ns.Name, string(createdGangJob.UID), kueuev1beta2.WorkloadAdmitted, "gang")
+			checkWorkloadCondition(ctx, env.Namespace.Name, string(createdGangJob.UID), kueuev1beta2.WorkloadAdmitted, "gang")
 
 			By("Verifying gang job is unsuspended")
 			Eventually(func() bool {
-				return !testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdGangJob.Name)
+				return !testutils.IsJobSuspended(ctx, kubeClient, env.Namespace.Name, createdGangJob.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Waiting for gang job to complete")
-			checkWorkloadCondition(ctx, ns.Name, string(createdGangJob.UID), kueuev1beta2.WorkloadFinished, "gang")
+			checkWorkloadCondition(ctx, env.Namespace.Name, string(createdGangJob.UID), kueuev1beta2.WorkloadFinished, "gang")
 		})
 	})
 
@@ -996,44 +716,24 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			kueueClient := clients.UpstreamKueueClient
 
 			By("Creating ResourceFlavor, ClusterQueue with AFS, Namespace and two LocalQueues")
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
+			rf := testutils.MustCreateResourceFlavor(ctx)
 
-			cqWrapper := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithCPU("1").
-				WithMemory("4Gi").
-				WithDRAResource(testutils.DRALogicalResource, "2")
-			cqWrapper.Spec.AdmissionScope = &kueuev1beta2.AdmissionScope{
-				AdmissionMode: kueuev1beta2.UsageBasedAdmissionFairSharing,
-			}
-			cq, cleanupCQ, err := cqWrapper.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
+			cq := testutils.MustCreateClusterQueue(ctx, rf.Name,
+				testutils.NewClusterQueue().
+					WithCPU("1").
+					WithMemory("4Gi").
+					WithDRAResource(testutils.DRALogicalResource, "2").
+					WithAdmissionScope(kueuev1beta2.UsageBasedAdmissionFairSharing),
+			)
 
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: testutils.DRATestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
+			ns := testutils.MustCreateManagedNamespace(ctx, testutils.DRATestNamespacePrefix)
 
-			lqGPU, cleanupLQGPU, err := testutils.NewLocalQueue(ns.Name, "lq-gpu").WithClusterQueue(cq.Name).CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQGPU)
-
-			lqCPU, cleanupLQCPU, err := testutils.NewLocalQueue(ns.Name, "lq-cpu").WithClusterQueue(cq.Name).CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQCPU)
+			lqGPU := testutils.MustCreateLocalQueue(ctx, ns.Name, "lq-gpu", cq.Name, nil)
+			lqCPU := testutils.MustCreateLocalQueue(ctx, ns.Name, "lq-cpu", cq.Name, nil)
 
 			By("Creating ResourceClaimTemplate for 1 GPU")
 			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-afs", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Submitting GPU+CPU DRA jobs to lq-gpu")
@@ -1114,44 +814,24 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			kueueClient := clients.UpstreamKueueClient
 
 			By("Creating ResourceFlavor, ClusterQueue with AFS, Namespace and two LocalQueues")
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
+			rf := testutils.MustCreateResourceFlavor(ctx)
 
-			cqWrapper := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithCPU("1").
-				WithMemory("4Gi").
-				WithDRAResource(testutils.DRALogicalResource, "2")
-			cqWrapper.Spec.AdmissionScope = &kueuev1beta2.AdmissionScope{
-				AdmissionMode: kueuev1beta2.UsageBasedAdmissionFairSharing,
-			}
-			cq, cleanupCQ, err := cqWrapper.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
+			cq := testutils.MustCreateClusterQueue(ctx, rf.Name,
+				testutils.NewClusterQueue().
+					WithCPU("1").
+					WithMemory("4Gi").
+					WithDRAResource(testutils.DRALogicalResource, "2").
+					WithAdmissionScope(kueuev1beta2.UsageBasedAdmissionFairSharing),
+			)
 
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: testutils.DRATestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
+			ns := testutils.MustCreateManagedNamespace(ctx, testutils.DRATestNamespacePrefix)
 
-			lqGPU, cleanupLQGPU, err := testutils.NewLocalQueue(ns.Name, "lq-gpu").WithClusterQueue(cq.Name).CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQGPU)
-
-			lqCPU, cleanupLQCPU, err := testutils.NewLocalQueue(ns.Name, "lq-cpu").WithClusterQueue(cq.Name).CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQCPU)
+			lqGPU := testutils.MustCreateLocalQueue(ctx, ns.Name, "lq-gpu", cq.Name, nil)
+			lqCPU := testutils.MustCreateLocalQueue(ctx, ns.Name, "lq-cpu", cq.Name, nil)
 
 			By("Creating ResourceClaimTemplate for 1 GPU")
 			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-afs-order", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Submitting GPU+CPU DRA jobs to lq-gpu to build usage history")
@@ -1303,4 +983,3 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 	})
 
 })
-

--- a/test/e2e/e2e_dra_test.go
+++ b/test/e2e/e2e_dra_test.go
@@ -26,30 +26,13 @@ import (
 	. "github.com/onsi/gomega"
 	ssv1 "github.com/openshift/kueue-operator/pkg/apis/kueueoperator/v1"
 	"github.com/openshift/kueue-operator/test/e2e/testutils"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
 	kueuev1beta2 "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	upstreamkueueclient "sigs.k8s.io/kueue/client-go/clientset/versioned"
 )
-
-const (
-	draDeviceClassName     = "gpu.nvidia.com"
-	draLogicalResource     = "nvidia-gpu"
-	draTestNamespacePrefix = "kueue-dra-test-"
-	draLocalQueueName      = "dra-test-queue"
-)
-
-// setDRAJobCPU reduces CPU request for DRA test jobs to fit on GPU nodes
-// where NVIDIA operator daemonsets consume most of the CPU budget.
-func setDRAJobCPU(job *batchv1.Job) {
-	job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("100m")
-}
 
 var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered, func() {
 	var (
@@ -87,7 +70,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			slices, err = kubeClient.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			for _, s := range slices.Items {
-				if s.Spec.Driver == draDeviceClassName {
+				if s.Spec.Driver == testutils.DRADeviceClassName {
 					hasDriverSlices = true
 					break
 				}
@@ -98,7 +81,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 		}
 
 		for _, s := range slices.Items {
-			if s.Spec.Driver == draDeviceClassName {
+			if s.Spec.Driver == testutils.DRADeviceClassName {
 				for _, d := range s.Spec.Devices {
 					if typeAttr, ok := d.Attributes["type"]; ok {
 						if typeAttr.StringValue != nil && *typeAttr.StringValue == gpuDeviceType {
@@ -122,8 +105,8 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 		// otherwise append a new one.
 		found := false
 		for i, m := range kueueInstance.Spec.Config.Resources.DeviceClassMappings {
-			if m.Name == draLogicalResource {
-				kueueInstance.Spec.Config.Resources.DeviceClassMappings[i].DeviceClassNames = []ssv1.DeviceClassName{draDeviceClassName}
+			if m.Name == testutils.DRALogicalResource {
+				kueueInstance.Spec.Config.Resources.DeviceClassMappings[i].DeviceClassNames = []ssv1.DeviceClassName{testutils.DRADeviceClassName}
 				found = true
 				break
 			}
@@ -132,12 +115,12 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			kueueInstance.Spec.Config.Resources.DeviceClassMappings = append(
 				kueueInstance.Spec.Config.Resources.DeviceClassMappings,
 				ssv1.DeviceClassMapping{
-					Name:             draLogicalResource,
-					DeviceClassNames: []ssv1.DeviceClassName{draDeviceClassName},
+					Name:             testutils.DRALogicalResource,
+					DeviceClassNames: []ssv1.DeviceClassName{testutils.DRADeviceClassName},
 				},
 			)
 		}
-		applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+		testutils.ApplyKueueConfig(ctx, kueueInstance.Spec.Config, clients)
 
 		// Wait for the operator to reconcile the config into the kueue-manager-config ConfigMap
 		Eventually(func() error {
@@ -149,7 +132,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			if !strings.Contains(configData, "DynamicResourceAllocation: true") {
 				return fmt.Errorf("DynamicResourceAllocation not enabled yet")
 			}
-			if !strings.Contains(configData, draLogicalResource) {
+			if !strings.Contains(configData, testutils.DRALogicalResource) {
 				return fmt.Errorf("deviceClassMappings not configured yet")
 			}
 			return nil
@@ -162,7 +145,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			// Clear deviceClassMappings rather than restoring originals to avoid
 			// contaminating the extended-resources suite which manages its own mappings.
 			initialKueueInstance.Spec.Config.Resources.DeviceClassMappings = nil
-			restoreKueueConfig(ctx, initialKueueInstance.Spec.Config, kubeClient)
+			testutils.RestoreKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		}
 	})
 
@@ -178,14 +161,14 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			cq, cleanupCQ, err := testutils.NewClusterQueue().
 				WithGenerateName().
 				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
+				WithDRAResource(testutils.DRALogicalResource, "1").
 				CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupCQ)
 
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
+					GenerateName: testutils.DRATestNamespacePrefix,
 					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
 				},
 			}
@@ -193,19 +176,19 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupNs)
 
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
+			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
 			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupLQ)
 
 			By("Creating ResourceClaimTemplate for gpu.nvidia.com")
-			rct := newDRAResourceClaimTemplate("gpu-template-basic", ns.Name, 1)
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-basic", ns.Name, 1)
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating Job referencing ResourceClaimTemplate")
-			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
-			job := newDRAJob(builder, "dra-basic-job", "gpu-template-basic", draLocalQueueName)
+			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
+			job := testutils.NewDRAJob(builder, "dra-basic-job", "gpu-template-basic", testutils.DRALocalQueueName)
 			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
@@ -223,8 +206,8 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 				g.Expect(wl.Status.Admission.PodSetAssignments).To(HaveLen(1))
 
 				assignment := wl.Status.Admission.PodSetAssignments[0]
-				g.Expect(assignment.ResourceUsage).To(HaveKey(corev1.ResourceName(draLogicalResource)))
-				g.Expect(assignment.ResourceUsage[corev1.ResourceName(draLogicalResource)]).To(Equal(resource.MustParse("1")))
+				g.Expect(assignment.ResourceUsage).To(HaveKey(corev1.ResourceName(testutils.DRALogicalResource)))
+				g.Expect(assignment.ResourceUsage[corev1.ResourceName(testutils.DRALogicalResource)]).To(Equal(resource.MustParse("1")))
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Verifying job is unsuspended")
@@ -249,14 +232,14 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			cq, cleanupCQ, err := testutils.NewClusterQueue().
 				WithGenerateName().
 				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
+				WithDRAResource(testutils.DRALogicalResource, "1").
 				CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupCQ)
 
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
+					GenerateName: testutils.DRATestNamespacePrefix,
 					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
 				},
 			}
@@ -264,19 +247,19 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupNs)
 
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
+			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
 			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupLQ)
 
 			By("Creating ResourceClaimTemplate requesting more GPUs than quota allows")
-			rct := newDRAResourceClaimTemplate("gpu-template-exceed", ns.Name, 5) // quota is 1
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-exceed", ns.Name, 5) // quota is 1
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating Job that exceeds DRA quota")
-			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
-			job := newDRAJob(builder, "dra-exceed-job", "gpu-template-exceed", draLocalQueueName)
+			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
+			job := testutils.NewDRAJob(builder, "dra-exceed-job", "gpu-template-exceed", testutils.DRALocalQueueName)
 			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
@@ -298,14 +281,14 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			cq, cleanupCQ, err := testutils.NewClusterQueue().
 				WithGenerateName().
 				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
+				WithDRAResource(testutils.DRALogicalResource, "1").
 				CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupCQ)
 
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
+					GenerateName: testutils.DRATestNamespacePrefix,
 					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
 				},
 			}
@@ -313,19 +296,19 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupNs)
 
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
+			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
 			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupLQ)
 
 			By("Creating shared ResourceClaimTemplate requesting 1 GPU")
-			rct := newDRAResourceClaimTemplate("gpu-template-shared", ns.Name, 1)
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-shared", ns.Name, 1)
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating first job referencing shared template (fills 1/1 quota)")
-			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
-			job1 := newDRAJob(builder, "dra-fill-job-1", "gpu-template-shared", draLocalQueueName)
+			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
+			job1 := testutils.NewDRAJob(builder, "dra-fill-job-1", "gpu-template-shared", testutils.DRALocalQueueName)
 			createdJob1, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job1, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob1.Namespace, createdJob1.Name)
@@ -348,16 +331,16 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 				found := false
 				for _, flavor := range cqObj.Status.FlavorsReservation {
 					for _, res := range flavor.Resources {
-						if res.Name == corev1.ResourceName(draLogicalResource) && res.Total.Cmp(resource.MustParse("1")) == 0 {
+						if res.Name == corev1.ResourceName(testutils.DRALogicalResource) && res.Total.Cmp(resource.MustParse("1")) == 0 {
 							found = true
 						}
 					}
 				}
-				g.Expect(found).To(BeTrue(), "ClusterQueue should show 1 %s reserved before creating second job", draLogicalResource)
+				g.Expect(found).To(BeTrue(), "ClusterQueue should show 1 %s reserved before creating second job", testutils.DRALogicalResource)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Creating second job referencing same shared template (quota full, should be suspended)")
-			job2 := newDRAJob(builder, "dra-fill-job-2", "gpu-template-shared", draLocalQueueName)
+			job2 := testutils.NewDRAJob(builder, "dra-fill-job-2", "gpu-template-shared", testutils.DRALocalQueueName)
 			createdJob2, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job2, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob2.Namespace, createdJob2.Name)
@@ -392,14 +375,14 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			cq, cleanupCQ, err := testutils.NewClusterQueue().
 				WithGenerateName().
 				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
+				WithDRAResource(testutils.DRALogicalResource, "1").
 				CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupCQ)
 
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
+					GenerateName: testutils.DRATestNamespacePrefix,
 					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
 				},
 			}
@@ -407,19 +390,19 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupNs)
 
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
+			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
 			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupLQ)
 
 			By("Creating ResourceClaimTemplate for 1 GPU")
-			rct := newDRAResourceClaimTemplate("gpu-template-usage", ns.Name, 1)
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-usage", ns.Name, 1)
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating Job")
-			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
-			job := newDRAJob(builder, "dra-usage-job", "gpu-template-usage", draLocalQueueName)
+			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
+			job := testutils.NewDRAJob(builder, "dra-usage-job", "gpu-template-usage", testutils.DRALocalQueueName)
 			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
@@ -433,14 +416,14 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 				found := false
 				for _, flavor := range cqObj.Status.FlavorsReservation {
 					for _, res := range flavor.Resources {
-						if res.Name == corev1.ResourceName(draLogicalResource) {
+						if res.Name == corev1.ResourceName(testutils.DRALogicalResource) {
 							g.Expect(res.Total.Cmp(resource.MustParse("1"))).To(Equal(0),
-								"ClusterQueue should show 1 %s reserved", draLogicalResource)
+								"ClusterQueue should show 1 %s reserved", testutils.DRALogicalResource)
 							found = true
 						}
 					}
 				}
-				g.Expect(found).To(BeTrue(), "DRA resource %s not found in ClusterQueue reservation", draLogicalResource)
+				g.Expect(found).To(BeTrue(), "DRA resource %s not found in ClusterQueue reservation", testutils.DRALogicalResource)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Verifying job pod is running")
@@ -462,14 +445,14 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			cq, cleanupCQ, err := testutils.NewClusterQueue().
 				WithGenerateName().
 				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
+				WithDRAResource(testutils.DRALogicalResource, "1").
 				CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupCQ)
 
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
+					GenerateName: testutils.DRATestNamespacePrefix,
 					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
 				},
 			}
@@ -477,19 +460,19 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupNs)
 
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
+			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
 			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupLQ)
 
 			By("Creating ResourceClaimTemplate for a single GPU")
-			rct := newDRAResourceClaimTemplate("gpu-template-shared-ctr", ns.Name, 1)
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-shared-ctr", ns.Name, 1)
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating Job with two containers sharing the same GPU claim")
-			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
-			job := newDRAJob(builder, "dra-shared-gpu-job", "gpu-template-shared-ctr", draLocalQueueName)
+			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
+			job := testutils.NewDRAJob(builder, "dra-shared-gpu-job", "gpu-template-shared-ctr", testutils.DRALocalQueueName)
 			job.Spec.Template.Spec.Containers = append(job.Spec.Template.Spec.Containers, corev1.Container{
 				Name:    "ctr1",
 				Image:   testutils.GetContainerImageForWorkloads(),
@@ -518,8 +501,8 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 				g.Expect(wl.Status.Admission.PodSetAssignments).To(HaveLen(1))
 
 				assignment := wl.Status.Admission.PodSetAssignments[0]
-				g.Expect(assignment.ResourceUsage).To(HaveKey(corev1.ResourceName(draLogicalResource)))
-				g.Expect(assignment.ResourceUsage[corev1.ResourceName(draLogicalResource)]).To(Equal(resource.MustParse("1")))
+				g.Expect(assignment.ResourceUsage).To(HaveKey(corev1.ResourceName(testutils.DRALogicalResource)))
+				g.Expect(assignment.ResourceUsage[corev1.ResourceName(testutils.DRALogicalResource)]).To(Equal(resource.MustParse("1")))
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Verifying job is unsuspended")
@@ -555,14 +538,14 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			cq, cleanupCQ, err := testutils.NewClusterQueue().
 				WithGenerateName().
 				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
+				WithDRAResource(testutils.DRALogicalResource, "1").
 				CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupCQ)
 
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
+					GenerateName: testutils.DRATestNamespacePrefix,
 					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
 				},
 			}
@@ -570,25 +553,25 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupNs)
 
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
+			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
 			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupLQ)
 
 			By("Creating ResourceClaimTemplate requesting 1 GPU")
-			rct := newDRAResourceClaimTemplate("gpu-template-workload-types", ns.Name, 1)
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-workload-types", ns.Name, 1)
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
+			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
 
 			By("Creating a Kueue-managed Pod with DRA ResourceClaim")
 			pod := builder.NewPod()
-			addDRAClaims(&pod.Spec, "gpu-template-workload-types")
+			testutils.AddDRAClaims(&pod.Spec, "gpu-template-workload-types")
 			createdPod, err := kubeClient.CoreV1().Pods(ns.Name).Create(ctx, pod, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			verifyWorkloadCreated(kueueClient, ns.Name, string(createdPod.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient, ns.Name, string(createdPod.UID))
 
 			By("Verifying Pod is running")
 			Eventually(func(g Gomega) {
@@ -598,7 +581,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Verifying ResourceClaim is allocated and reserved for Pod")
-			verifyResourceClaimAllocated(ctx, kubeClient, ns.Name)
+			testutils.VerifyResourceClaimAllocated(ctx, kubeClient, ns.Name)
 		})
 
 		It("should admit DRA workloads for Deployment type", func(ctx context.Context) {
@@ -612,14 +595,14 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			cq, cleanupCQ, err := testutils.NewClusterQueue().
 				WithGenerateName().
 				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
+				WithDRAResource(testutils.DRALogicalResource, "1").
 				CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupCQ)
 
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
+					GenerateName: testutils.DRATestNamespacePrefix,
 					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
 				},
 			}
@@ -627,26 +610,26 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupNs)
 
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
+			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
 			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupLQ)
 
 			By("Creating ResourceClaimTemplate requesting 1 GPU")
-			rct := newDRAResourceClaimTemplate("gpu-template-workload-types", ns.Name, 1)
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-workload-types", ns.Name, 1)
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
+			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
 
 			By("Creating a Kueue-managed Deployment with DRA ResourceClaim")
 			deploy := builder.NewDeployment()
-			addDRAClaims(&deploy.Spec.Template.Spec, "gpu-template-workload-types")
+			testutils.AddDRAClaims(&deploy.Spec.Template.Spec, "gpu-template-workload-types")
 			createdDeploy, err := kubeClient.AppsV1().Deployments(ns.Name).Create(ctx, deploy, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for Deployment pod to be created and workload to be admitted")
-			waitForPodWorkloadAdmitted(ctx, kubeClient, kueueClient, ns.Name, "app=test-deployment")
+			testutils.WaitForPodWorkloadAdmitted(ctx, kubeClient, kueueClient, ns.Name, "app=test-deployment")
 
 			By("Verifying Deployment is available")
 			Eventually(func(g Gomega) {
@@ -656,7 +639,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Verifying ResourceClaim is allocated and reserved for Deployment")
-			verifyResourceClaimAllocated(ctx, kubeClient, ns.Name)
+			testutils.VerifyResourceClaimAllocated(ctx, kubeClient, ns.Name)
 		})
 
 		It("should admit DRA workloads for StatefulSet type", func(ctx context.Context) {
@@ -670,14 +653,14 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			cq, cleanupCQ, err := testutils.NewClusterQueue().
 				WithGenerateName().
 				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
+				WithDRAResource(testutils.DRALogicalResource, "1").
 				CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupCQ)
 
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
+					GenerateName: testutils.DRATestNamespacePrefix,
 					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
 				},
 			}
@@ -685,27 +668,27 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupNs)
 
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
+			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
 			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupLQ)
 
 			By("Creating ResourceClaimTemplate requesting 1 GPU")
-			rct := newDRAResourceClaimTemplate("gpu-template-workload-types", ns.Name, 1)
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-workload-types", ns.Name, 1)
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
+			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
 
 			By("Creating a Kueue-managed StatefulSet with DRA ResourceClaim")
 			ss := builder.NewStatefulSet()
-			addDRAClaims(&ss.Spec.Template.Spec, "gpu-template-workload-types")
+			testutils.AddDRAClaims(&ss.Spec.Template.Spec, "gpu-template-workload-types")
 			createdSS, err := kubeClient.AppsV1().StatefulSets(ns.Name).Create(ctx, ss, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			defer testutils.CleanUpObject(ctx, genericClient, createdSS)
 
 			By("Waiting for StatefulSet pod to be created and workload to be admitted")
-			waitForPodWorkloadAdmitted(ctx, kubeClient, kueueClient, ns.Name, "app=test-statefulset")
+			testutils.WaitForPodWorkloadAdmitted(ctx, kubeClient, kueueClient, ns.Name, "app=test-statefulset")
 
 			By("Verifying StatefulSet is ready")
 			Eventually(func(g Gomega) {
@@ -715,7 +698,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Verifying ResourceClaim is allocated and reserved for StatefulSet")
-			verifyResourceClaimAllocated(ctx, kubeClient, ns.Name)
+			testutils.VerifyResourceClaimAllocated(ctx, kubeClient, ns.Name)
 		})
 	})
 
@@ -731,14 +714,14 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			cq, cleanupCQ, err := testutils.NewClusterQueue().
 				WithGenerateName().
 				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
+				WithDRAResource(testutils.DRALogicalResource, "1").
 				CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupCQ)
 
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
+					GenerateName: testutils.DRATestNamespacePrefix,
 					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
 				},
 			}
@@ -746,7 +729,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupNs)
 
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
+			lq := testutils.NewLocalQueue(ns.Name, testutils.DRALocalQueueName).WithClusterQueue(cq.Name)
 			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupLQ)
@@ -756,17 +739,17 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			Expect(err).NotTo(HaveOccurred())
 			savedConfig := kueueInstance.Spec.Config.DeepCopy()
 			DeferCleanup(func(cleanupCtx context.Context) {
-				restoreKueueConfig(cleanupCtx, *savedConfig, kubeClient)
+				testutils.RestoreKueueConfig(cleanupCtx, *savedConfig, clients)
 			})
 
 			By("Setting wrong DeviceClass name in deviceClassMappings")
 			kueueInstance.Spec.Config.Resources.DeviceClassMappings = []ssv1.DeviceClassMapping{
 				{
-					Name:             draLogicalResource,
+					Name:             testutils.DRALogicalResource,
 					DeviceClassNames: []ssv1.DeviceClassName{"nonexistent.nvidia.com"},
 				},
 			}
-			applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, kueueInstance.Spec.Config, clients)
 
 			By("Verifying ConfigMap has wrong DeviceClass name")
 			Eventually(func(g Gomega) {
@@ -777,14 +760,14 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Creating ResourceClaimTemplate for DRA job")
-			rct := newDRAResourceClaimTemplate("gpu-template-wrong-class", ns.Name, 1)
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-wrong-class", ns.Name, 1)
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating DRA job with wrong DeviceClass mapping")
 			wrongClassStart := metav1.Now()
-			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
-			job := newDRAJob(builder, "dra-wrong-class", "gpu-template-wrong-class", draLocalQueueName)
+			builder := testutils.NewTestResourceBuilder(ns.Name, testutils.DRALocalQueueName)
+			job := testutils.NewDRAJob(builder, "dra-wrong-class", "gpu-template-wrong-class", testutils.DRALocalQueueName)
 			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
@@ -795,7 +778,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Verifying No ResourceClaim is created since the job was never unsuspended")
-			verifyNoResourceClaims(ctx, kubeClient, ns.Name, wrongClassStart)
+			testutils.VerifyNoResourceClaims(ctx, kubeClient, ns.Name, wrongClassStart)
 		})
 	})
 
@@ -810,7 +793,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
+					GenerateName: testutils.DRATestNamespacePrefix,
 					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
 				},
 			}
@@ -831,7 +814,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 				WithGenerateName().
 				WithFlavorName(resourceFlavor.Name).
 				WithPreemption(kueuev1beta2.PreemptionPolicyLowerPriority).
-				WithDRAResource(draLogicalResource, "1").
+				WithDRAResource(testutils.DRALogicalResource, "1").
 				CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupCQ)
@@ -842,13 +825,13 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			DeferCleanup(cleanupLQ)
 
 			By("Creating ResourceClaimTemplate")
-			rct := newDRAResourceClaimTemplate("gpu-template-preempt", ns.Name, 1)
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-preempt", ns.Name, 1)
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Submitting low-priority DRA job that fills the 1-GPU quota")
 			builder := testutils.NewTestResourceBuilder(ns.Name, preemptLQ.Name)
-			lowJob := newDRAJob(builder, "dra-low-prio", "gpu-template-preempt", preemptLQ.Name)
+			lowJob := testutils.NewDRAJob(builder, "dra-low-prio", "gpu-template-preempt", preemptLQ.Name)
 			lowJob.Spec.Template.Spec.PriorityClassName = lowPC.Name
 			createdLowJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, lowJob, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
@@ -863,7 +846,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Submitting high-priority DRA job that triggers preemption")
-			highJob := newDRAJob(builder, "dra-high-prio", "gpu-template-preempt", preemptLQ.Name)
+			highJob := testutils.NewDRAJob(builder, "dra-high-prio", "gpu-template-preempt", preemptLQ.Name)
 			highJob.Spec.Template.Spec.PriorityClassName = highPC.Name
 			createdHighJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, highJob, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
@@ -898,7 +881,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
+					GenerateName: testutils.DRATestNamespacePrefix,
 					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
 				},
 			}
@@ -911,7 +894,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			Expect(err).NotTo(HaveOccurred())
 			savedConfig := kueueInstance.Spec.Config.DeepCopy()
 			DeferCleanup(func(cleanupCtx context.Context) {
-				restoreKueueConfig(cleanupCtx, *savedConfig, kubeClient)
+				testutils.RestoreKueueConfig(cleanupCtx, *savedConfig, clients)
 			})
 
 			kueueInstance.Spec.Config.GangScheduling = ssv1.GangScheduling{
@@ -920,13 +903,13 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 					Admission: ssv1.GangSchedulingWorkloadAdmissionSequential,
 				},
 			}
-			applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, kueueInstance.Spec.Config, clients)
 
 			By("Creating ClusterQueue with 2 GPU DRA quota")
 			gangCQ, cleanupCQ, err := testutils.NewClusterQueue().
 				WithGenerateName().
 				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "2").
+				WithDRAResource(testutils.DRALogicalResource, "2").
 				CreateWithObject(ctx, kueueClient)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupCQ)
@@ -937,13 +920,13 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			DeferCleanup(cleanupLQ)
 
 			By("Creating ResourceClaimTemplate")
-			rct := newDRAResourceClaimTemplate("gpu-template-gang", ns.Name, 1)
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-gang", ns.Name, 1)
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Submitting single-pod DRA job that fills 1 of 2 GPUs")
 			builder := testutils.NewTestResourceBuilder(ns.Name, gangLQ.Name)
-			singleJob := newDRAJob(builder, "dra-single-gpu", "gpu-template-gang", gangLQ.Name)
+			singleJob := testutils.NewDRAJob(builder, "dra-single-gpu", "gpu-template-gang", gangLQ.Name)
 			createdSingleJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, singleJob, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdSingleJob.Namespace, createdSingleJob.Name)
@@ -955,7 +938,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Submitting gang DRA job (parallelism=2, needs 2 GPUs, only 1 free)")
-			gangJob := newDRAJob(builder, "dra-gang-job", "gpu-template-gang", gangLQ.Name)
+			gangJob := testutils.NewDRAJob(builder, "dra-gang-job", "gpu-template-gang", gangLQ.Name)
 			gangJob.Spec.Parallelism = ptr.To(int32(2))
 			gangJob.Spec.Completions = ptr.To(int32(2))
 			createdGangJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, gangJob, metav1.CreateOptions{})
@@ -996,13 +979,13 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 				UsageHalfLifeTimeSeconds:     120,
 				UsageSamplingIntervalSeconds: 1,
 			}
-			applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, kueueInstance.Spec.Config, clients)
 		})
 
 		AfterAll(func(ctx context.Context) {
 			By("Restoring Kueue config after AFS tests")
 			if savedAFSConfig != nil {
-				restoreKueueConfig(ctx, *savedAFSConfig, kubeClient)
+				testutils.RestoreKueueConfig(ctx, *savedAFSConfig, clients)
 			}
 		})
 
@@ -1022,7 +1005,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 				WithFlavorName(resourceFlavor.Name).
 				WithCPU("1").
 				WithMemory("4Gi").
-				WithDRAResource(draLogicalResource, "2")
+				WithDRAResource(testutils.DRALogicalResource, "2")
 			cqWrapper.Spec.AdmissionScope = &kueuev1beta2.AdmissionScope{
 				AdmissionMode: kueuev1beta2.UsageBasedAdmissionFairSharing,
 			}
@@ -1032,7 +1015,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
+					GenerateName: testutils.DRATestNamespacePrefix,
 					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
 				},
 			}
@@ -1049,18 +1032,18 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			DeferCleanup(cleanupLQCPU)
 
 			By("Creating ResourceClaimTemplate for 1 GPU")
-			rct := newDRAResourceClaimTemplate("gpu-template-afs", ns.Name, 1)
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-afs", ns.Name, 1)
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Submitting GPU+CPU DRA jobs to lq-gpu")
 			builder := testutils.NewTestResourceBuilder(ns.Name, lqGPU.Name)
-			jobGPU1 := newDRAJob(builder, "job-gpu-afs-1", "gpu-template-afs", lqGPU.Name)
+			jobGPU1 := testutils.NewDRAJob(builder, "job-gpu-afs-1", "gpu-template-afs", lqGPU.Name)
 			createdJobGPU1, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, jobGPU1, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJobGPU1.Namespace, createdJobGPU1.Name)
 
-			jobGPU2 := newDRAJob(builder, "job-gpu-afs-2", "gpu-template-afs", lqGPU.Name)
+			jobGPU2 := testutils.NewDRAJob(builder, "job-gpu-afs-2", "gpu-template-afs", lqGPU.Name)
 			createdJobGPU2, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, jobGPU2, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJobGPU2.Namespace, createdJobGPU2.Name)
@@ -1068,7 +1051,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			By("Submitting CPU-only job to lq-cpu")
 			cpuBuilder := testutils.NewTestResourceBuilder(ns.Name, lqCPU.Name)
 			jobCPU := cpuBuilder.NewJob()
-			setDRAJobCPU(jobCPU)
+			testutils.SetDRAJobCPU(jobCPU)
 			jobCPU.Name = "job-cpu-afs"
 			jobCPU.Labels[testutils.QueueLabel] = lqCPU.Name
 			jobCPU.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "echo Hello Kueue; sleep 10"}
@@ -1105,10 +1088,10 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 				g.Expect(lq.Status.FairSharing.AdmissionFairSharingStatus).NotTo(BeNil(),
 					"lq-gpu admissionFairSharingStatus should be populated")
 				consumed := lq.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources
-				gpuUsage := consumed[corev1.ResourceName(draLogicalResource)]
+				gpuUsage := consumed[corev1.ResourceName(testutils.DRALogicalResource)]
 				g.Expect(gpuUsage.IsZero()).To(BeFalse(),
-					"lq-gpu consumedResources should include non-zero %s, got %s", draLogicalResource, gpuUsage.String())
-			}, 60*time.Second, 2*time.Second).Should(Succeed())
+					"lq-gpu consumedResources should include non-zero %s, got %s", testutils.DRALogicalResource, gpuUsage.String())
+			}, testutils.DRAResourceSliceTimeout, testutils.DRAResourceSlicePoll).Should(Succeed())
 
 			By("Verifying lq-cpu consumedResources has zero nvidia-gpu usage")
 			Eventually(func(g Gomega) {
@@ -1118,10 +1101,10 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 				g.Expect(lq.Status.FairSharing.AdmissionFairSharingStatus).NotTo(BeNil(),
 					"lq-cpu admissionFairSharingStatus should be populated")
 				consumed := lq.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources
-				gpuUsage := consumed[corev1.ResourceName(draLogicalResource)]
+				gpuUsage := consumed[corev1.ResourceName(testutils.DRALogicalResource)]
 				g.Expect(gpuUsage.IsZero()).To(BeTrue(),
-					"lq-cpu consumedResources should have zero %s usage, got %s", draLogicalResource, gpuUsage.String())
-			}, 60*time.Second, 2*time.Second).Should(Succeed())
+					"lq-cpu consumedResources should have zero %s usage, got %s", testutils.DRALogicalResource, gpuUsage.String())
+			}, testutils.DRAResourceSliceTimeout, testutils.DRAResourceSlicePoll).Should(Succeed())
 		})
 
 		It("should deprioritize GPU-heavy queue in admission ordering", func(ctx context.Context) {
@@ -1140,7 +1123,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 				WithFlavorName(resourceFlavor.Name).
 				WithCPU("1").
 				WithMemory("4Gi").
-				WithDRAResource(draLogicalResource, "2")
+				WithDRAResource(testutils.DRALogicalResource, "2")
 			cqWrapper.Spec.AdmissionScope = &kueuev1beta2.AdmissionScope{
 				AdmissionMode: kueuev1beta2.UsageBasedAdmissionFairSharing,
 			}
@@ -1150,7 +1133,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
+					GenerateName: testutils.DRATestNamespacePrefix,
 					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
 				},
 			}
@@ -1167,18 +1150,18 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			DeferCleanup(cleanupLQCPU)
 
 			By("Creating ResourceClaimTemplate for 1 GPU")
-			rct := newDRAResourceClaimTemplate("gpu-template-afs-order", ns.Name, 1)
+			rct := testutils.NewDRAResourceClaimTemplate("gpu-template-afs-order", ns.Name, 1)
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Submitting GPU+CPU DRA jobs to lq-gpu to build usage history")
 			builder := testutils.NewTestResourceBuilder(ns.Name, lqGPU.Name)
-			jobGPU1 := newDRAJob(builder, "job-gpu-order-1", "gpu-template-afs-order", lqGPU.Name)
+			jobGPU1 := testutils.NewDRAJob(builder, "job-gpu-order-1", "gpu-template-afs-order", lqGPU.Name)
 			createdJobGPU1, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, jobGPU1, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJobGPU1.Namespace, createdJobGPU1.Name)
 
-			jobGPU2 := newDRAJob(builder, "job-gpu-order-2", "gpu-template-afs-order", lqGPU.Name)
+			jobGPU2 := testutils.NewDRAJob(builder, "job-gpu-order-2", "gpu-template-afs-order", lqGPU.Name)
 			createdJobGPU2, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, jobGPU2, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJobGPU2.Namespace, createdJobGPU2.Name)
@@ -1186,7 +1169,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			By("Submitting CPU-only job to lq-cpu to build usage history")
 			cpuBuilder := testutils.NewTestResourceBuilder(ns.Name, lqCPU.Name)
 			jobCPU := cpuBuilder.NewJob()
-			setDRAJobCPU(jobCPU)
+			testutils.SetDRAJobCPU(jobCPU)
 			jobCPU.Name = "job-cpu-order"
 			jobCPU.Labels[testutils.QueueLabel] = lqCPU.Name
 			jobCPU.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "echo Hello Kueue; sleep 10"}
@@ -1228,11 +1211,11 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 				g.Expect(lq.Status.FairSharing.AdmissionFairSharingStatus).NotTo(BeNil(),
 					"lq-gpu admissionFairSharingStatus should be populated")
 				consumed := lq.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources
-				gpuUsage := consumed[corev1.ResourceName(draLogicalResource)]
+				gpuUsage := consumed[corev1.ResourceName(testutils.DRALogicalResource)]
 				g.Expect(gpuUsage.IsZero()).To(BeFalse(),
 					"lq-gpu consumedResources should still include non-zero %s after completion, got %s",
-					draLogicalResource, gpuUsage.String())
-			}, 30*time.Second, 2*time.Second).Should(Succeed())
+					testutils.DRALogicalResource, gpuUsage.String())
+			}, testutils.DRASettleTimeout, testutils.DRAResourceSlicePoll).Should(Succeed())
 
 			By("Creating placeholder job on lq-gpu to fill CPU quota")
 			placeholderBuilder := testutils.NewTestResourceBuilder(ns.Name, lqGPU.Name)
@@ -1314,170 +1297,10 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			By("Verifying lq-gpu job remains suspended (higher AFS usage due to GPU history)")
 			Consistently(func() bool {
 				return testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJobGPUCompete.Name)
-			}, 15*time.Second, 2*time.Second).Should(BeTrue(),
+			}, testutils.DRAQuotaCheckTimeout, testutils.DRAResourceSlicePoll).Should(BeTrue(),
 				"job-gpu-compete (lq-gpu, higher total usage including GPUs) should remain suspended")
 		})
 	})
 
 })
 
-// newDRAResourceClaimTemplate creates a ResourceClaimTemplate that requests the given number of GPUs
-// from the gpu.nvidia.com DeviceClass.
-func newDRAResourceClaimTemplate(name, namespace string, gpuCount int64) *resourcev1.ResourceClaimTemplate {
-	return &resourcev1.ResourceClaimTemplate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: resourcev1.ResourceClaimTemplateSpec{
-			Spec: resourcev1.ResourceClaimSpec{
-				Devices: resourcev1.DeviceClaim{
-					Requests: []resourcev1.DeviceRequest{
-						{
-							Name: "gpu-req",
-							Exactly: &resourcev1.ExactDeviceRequest{
-								DeviceClassName: draDeviceClassName,
-								Count:           gpuCount,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-// waitForPodWorkloadAdmitted waits until a pod matching the label selector has
-// a corresponding admitted Kueue workload, correlating via OwnerReferences.
-func waitForPodWorkloadAdmitted(ctx context.Context, kubeClient *kubernetes.Clientset, kueueClient *upstreamkueueclient.Clientset, namespace, labelSelector string) {
-	Eventually(func() error {
-		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
-			LabelSelector: labelSelector,
-		})
-		if err != nil {
-			return err
-		}
-		if len(pods.Items) == 0 {
-			return fmt.Errorf("no pods found with label %s", labelSelector)
-		}
-		ownerUIDs := make(map[types.UID]bool)
-		for _, pod := range pods.Items {
-			for _, ref := range pod.OwnerReferences {
-				ownerUIDs[ref.UID] = true
-			}
-			ownerUIDs[pod.UID] = true
-		}
-		workloads, err := kueueClient.KueueV1beta2().Workloads(namespace).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return err
-		}
-		for _, wl := range workloads.Items {
-			if wl.Status.Admission == nil {
-				continue
-			}
-			for _, ref := range wl.OwnerReferences {
-				if ownerUIDs[ref.UID] {
-					return nil
-				}
-			}
-		}
-		return fmt.Errorf("no admitted workload correlated to pods with label %s", labelSelector)
-	}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
-}
-
-// verifyResourceClaimAllocated verifies that at least one ResourceClaim
-// in the namespace is in the "allocated,reserved" state.
-func verifyResourceClaimAllocated(ctx context.Context, kubeClient *kubernetes.Clientset, namespace string) {
-	Eventually(func(g Gomega) {
-		claims, err := kubeClient.ResourceV1().ResourceClaims(namespace).List(ctx, metav1.ListOptions{})
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(claims.Items).NotTo(BeEmpty(), "no ResourceClaims found in namespace %s", namespace)
-		claim := claims.Items[0]
-		g.Expect(claim.Status.Allocation).NotTo(BeNil(), "ResourceClaim not allocated in namespace %s", namespace)
-		g.Expect(claim.Status.ReservedFor).NotTo(BeEmpty(), "ResourceClaim not reserved in namespace %s", namespace)
-	}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
-}
-
-// verifyNoResourceClaims verifies that no ResourceClaims created after the given
-// timestamp exist in the namespace.
-func verifyNoResourceClaims(ctx context.Context, kubeClient *kubernetes.Clientset, namespace string, createdAfter metav1.Time) {
-	Consistently(func(g Gomega) {
-		claims, err := kubeClient.ResourceV1().ResourceClaims(namespace).List(ctx, metav1.ListOptions{})
-		g.Expect(err).NotTo(HaveOccurred())
-		var filtered []resourcev1.ResourceClaim
-		for _, c := range claims.Items {
-			if c.CreationTimestamp.After(createdAfter.Time) {
-				filtered = append(filtered, c)
-			}
-		}
-		g.Expect(filtered).To(BeEmpty(), "expected no ResourceClaims after %v in namespace %s", createdAfter.Time, namespace)
-	}, testutils.ConsistentlyTimeout, testutils.ConsistentlyPoll).Should(Succeed())
-}
-
-// newDRAJob creates a Job with DRA ResourceClaim configuration for the given template.
-func newDRAJob(builder *testutils.TestResourceBuilder, name, templateName, queueName string) *batchv1.Job {
-	job := builder.NewJob()
-	setDRAJobCPU(job)
-	job.Name = name
-	job.Labels[testutils.QueueLabel] = queueName
-	job.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "echo Hello Kueue; sleep 10"}
-	job.Spec.Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
-		{Name: "gpu", ResourceClaimTemplateName: ptr.To(templateName)},
-	}
-	job.Spec.Template.Spec.Containers[0].Resources.Claims = []corev1.ResourceClaim{{Name: "gpu"}}
-	return job
-}
-
-// restoreKueueConfig restores a Kueue CR config with retry on resourceVersion conflicts.
-// This function re-fetches the CR on each attempt to get a fresh resourceVersion.
-func restoreKueueConfig(ctx context.Context, config ssv1.KueueConfiguration, kClient *kubernetes.Clientset) {
-	kueueClientset := clients.KueueClient
-
-	initialDeployment, err := kClient.AppsV1().Deployments(testutils.OperatorNamespace).Get(ctx, "kueue-controller-manager", metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred(), "Failed to fetch kueue-controller-manager deployment before restore")
-	initialResourceVersion := initialDeployment.ResourceVersion
-
-	By("Restoring Kueue config (with conflict retry)")
-	Eventually(func() error {
-		instance, err := kueueClientset.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to fetch Kueue instance: %w", err)
-		}
-		instance.Spec.Config = config
-		_, err = kueueClientset.KueueV1().Kueues().Update(ctx, instance, metav1.UpdateOptions{})
-		return err
-	}, 30*time.Second, 2*time.Second).Should(Succeed(), "Failed to restore Kueue config")
-
-	By("Waiting for kueue-controller-manager deployment to be updated after config restore")
-	Eventually(func() error {
-		dep, err := kClient.AppsV1().Deployments(testutils.OperatorNamespace).Get(ctx, "kueue-controller-manager", metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("unable to fetch manager deployment: %w", err)
-		}
-		if dep.ResourceVersion == initialResourceVersion {
-			return fmt.Errorf("deployment resource version has not changed yet (still %s)", initialResourceVersion)
-		}
-		return nil
-	}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "kueue-controller-manager deployment resource version did not change after restore")
-
-	By("Waiting for kueue-controller-manager to be ready after config restore")
-	Eventually(func() error {
-		dep, err := kClient.AppsV1().Deployments(testutils.OperatorNamespace).Get(ctx, "kueue-controller-manager", metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("unable to fetch manager deployment: %w", err)
-		}
-		if dep.Status.ReadyReplicas != dep.Status.Replicas {
-			return fmt.Errorf("deployment not ready: %d/%d replicas ready", dep.Status.ReadyReplicas, dep.Status.Replicas)
-		}
-		return nil
-	}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "kueue-controller-manager not ready after config restore")
-}
-
-// adds DRA ResourceClaim references and reduces CPU request on a PodSpec.
-func addDRAClaims(spec *corev1.PodSpec, templateName string) {
-	spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("100m")
-	spec.Containers[0].Resources.Claims = []corev1.ResourceClaim{{Name: "gpu-claim"}}
-	spec.ResourceClaims = []corev1.PodResourceClaim{
-		{Name: "gpu-claim", ResourceClaimTemplateName: ptr.To(templateName)},
-	}
-}

--- a/test/e2e/e2e_gangscheduling_test.go
+++ b/test/e2e/e2e_gangscheduling_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 					},
 				},
 			}
-			applyKueueConfig(ctx, newConfig, kubeClient)
+			testutils.ApplyKueueConfig(ctx, newConfig, clients)
 
 			By("Waiting for Kueue configuration to be applied")
 			Eventually(func(g Gomega) {
@@ -75,7 +75,7 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 
 		AfterAll(func(ctx context.Context) {
 			By("Restoring initial Kueue configuration")
-			applyKueueConfig(ctx, initialKueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		})
 
 		It("should apply all-or-nothing admission for workloads", func(ctx context.Context) {
@@ -101,7 +101,7 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 			}, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespace)
+				testutils.DeleteNamespace(ctx, kubeClient, namespace)
 			})
 			localQueue, cleanupLocalQueue, err := testutils.NewLocalQueue(namespace.Name, "local-queue").WithClusterQueue(clusterQueue.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create local queue")
@@ -113,7 +113,7 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 			DeferCleanup(cleanupJob1)
 
 			By("Verifying first job workload is created and admitted")
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespace.Name, string(job1.UID))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespace.Name, string(job1.UID))
 
 			By("Creating a gang job (parallelism=2) that exceeds remaining quota")
 			cleanupJob2, job2, err := createJobGang(ctx, "job-gang", namespace.Name, localQueue.Name, "150m", "128Mi", 2)
@@ -150,7 +150,7 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "First job should complete")
 
 			By("Verifying the second gang job is now admitted after quota is freed (all pods admitted together)")
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespace.Name, string(job2.UID))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespace.Name, string(job2.UID))
 
 		})
 
@@ -179,7 +179,7 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 			}, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespace)
+				testutils.DeleteNamespace(ctx, kubeClient, namespace)
 			})
 
 			localQueue, cleanupLocalQueue, err := testutils.NewLocalQueue(namespace.Name, "local-queue").WithClusterQueue(clusterQueue.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
@@ -192,7 +192,7 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 			DeferCleanup(cleanupJob1)
 
 			By("Verifying first gang job workload is admitted")
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespace.Name, string(createdJob1.UID))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespace.Name, string(createdJob1.UID))
 
 			By("Creating the second gang job (parallelism=2) while first gang job pods are not yet ready")
 			cleanupJob2, createdJob2, err := createJobGang(ctx, "job-sequential-2", namespace.Name, localQueue.Name, "100m", "100Mi", 2)
@@ -228,7 +228,7 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue(), "First gang job pods should complete")
 
 			By("Verifying second gang job is now admitted after first gang job pods became ready")
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespace.Name, string(createdJob2.UID))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespace.Name, string(createdJob2.UID))
 		})
 	})
 
@@ -253,7 +253,7 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 					},
 				},
 			}
-			applyKueueConfig(ctx, newConfig, kubeClient)
+			testutils.ApplyKueueConfig(ctx, newConfig, clients)
 
 			By("Waiting for Kueue configuration to be applied")
 			Eventually(func(g Gomega) {
@@ -267,7 +267,7 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 
 		AfterAll(func(ctx context.Context) {
 			By("Restoring initial Kueue configuration")
-			applyKueueConfig(ctx, initialKueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		})
 
 		It("should admit workloads in parallel without waiting for pods to be ready", func(ctx context.Context) {
@@ -294,7 +294,7 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 			}, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespace)
+				testutils.DeleteNamespace(ctx, kubeClient, namespace)
 			})
 
 			localQueue, cleanupLocalQueue, err := testutils.NewLocalQueue(namespace.Name, "local-queue").WithClusterQueue(clusterQueue.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
@@ -307,7 +307,7 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 			DeferCleanup(cleanupJob1)
 
 			By("Verifying first gang job workload is admitted")
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespace.Name, string(createdJob1.UID))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespace.Name, string(createdJob1.UID))
 
 			By("Creating the second gang job (parallelism=2) while first gang job pods are not yet ready")
 			cleanupJob2, createdJob2, err := createJobGang(ctx, "job-parallel-2", namespace.Name, localQueue.Name, "100m", "100Mi", 2)
@@ -315,7 +315,7 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 			DeferCleanup(cleanupJob2)
 
 			By("Verifying second gang job is admitted immediately despite first gang job pods not being ready (parallel admission)")
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespace.Name, string(createdJob2.UID))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespace.Name, string(createdJob2.UID))
 
 			By("Verifying both gang jobs are admitted together without waiting for pod readiness")
 			workloads, err := clients.UpstreamKueueClient.KueueV1beta2().Workloads(namespace.Name).List(ctx, metav1.ListOptions{})

--- a/test/e2e/e2e_local_queue_defaulting_test.go
+++ b/test/e2e/e2e_local_queue_defaulting_test.go
@@ -104,7 +104,7 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 				Size:              0,
 			})
 			Expect(genericClient.Create(ctx, lwsWithoutQueue)).To(Succeed(), "Failed to create LeaderWorkerSet")
-			defer testutils.CleanUpObject(ctx, genericClient, lwsWithoutQueue)
+			DeferCleanup(testutils.CleanUpObject, genericClient, lwsWithoutQueue)
 
 			By("verifying LeaderWorkerSet has queue label added")
 			Eventually(func() map[string]string {
@@ -269,7 +269,7 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 			By("Creating JobSet without queue name")
 			jobSetWithoutQueue := builder.NewJobSetWithoutQueue()
 			Expect(genericClient.Create(ctx, jobSetWithoutQueue)).Should(Succeed())
-			defer testutils.CleanUpObject(ctx, genericClient, jobSetWithoutQueue)
+			DeferCleanup(testutils.CleanUpObject, genericClient, jobSetWithoutQueue)
 			Expect(jobSetWithoutQueue.Labels).To(HaveKeyWithValue(testutils.QueueLabel, testutils.DefaultLocalQueueName))
 			By("verifying jobset did start in labeled namespace")
 			Eventually(func() error {

--- a/test/e2e/e2e_local_queue_defaulting_test.go
+++ b/test/e2e/e2e_local_queue_defaulting_test.go
@@ -150,7 +150,7 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(createdJob.Labels).To(HaveKeyWithValue(testutils.QueueLabel, secondQueueName))
 
-			testutils.VerifyWorkloadCreated(ctx, kueueClient,ns.Name, string(createdPod.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient, ns.Name, string(createdJob.UID))
 
 			By("creating pod in other local queue")
 			pod = builder.NewPodWithoutQueue()

--- a/test/e2e/e2e_local_queue_defaulting_test.go
+++ b/test/e2e/e2e_local_queue_defaulting_test.go
@@ -51,13 +51,13 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 			Expect(err).ToNot(HaveOccurred(), "Failed to fetch Kueue instance")
 			initialKueueInstance = kueueInstance.DeepCopy()
 			kueueInstance.Spec.Config.WorkloadManagement.LabelPolicy = kueueoperatorv1.LabelPolicyNone
-			applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, kueueInstance.Spec.Config, clients)
 			createClusterQueueAndResourceFlavor(ctx)
 		})
 
 		AfterAll(func(ctx context.Context) {
 			deleteClusterQueueAndResourceFlavor(ctx, kueueClient)
-			applyKueueConfig(ctx, initialKueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		})
 
 		BeforeEach(func(ctx context.Context) {
@@ -68,7 +68,11 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 		})
 
 		AfterEach(func(ctx context.Context) {
-			deleteNamespace(ctx, ns)
+			if defaultLocalQueueClean != nil {
+				defaultLocalQueueClean()
+				defaultLocalQueueClean = nil
+			}
+			testutils.DeleteNamespace(ctx, kubeClient, ns)
 		})
 
 		JustAfterEach(func(ctx context.Context) {
@@ -82,14 +86,14 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(createdJob.Labels).To(HaveKeyWithValue(testutils.QueueLabel, testutils.DefaultLocalQueueName))
-			verifyWorkloadCreated(kueueClient, ns.Name, string(createdJob.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient,ns.Name, string(createdJob.UID))
 
 			By("creating pod without queue name")
 			podWithLabel := builder.NewPodWithoutQueue()
 			createdPod, err := kubeClient.CoreV1().Pods(ns.Name).Create(ctx, podWithLabel, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(createdPod.Labels).To(HaveKeyWithValue(testutils.QueueLabel, testutils.DefaultLocalQueueName))
-			verifyWorkloadCreated(kueueClient, ns.Name, string(createdPod.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient,ns.Name, string(createdPod.UID))
 		})
 
 		It("should label and admit LeaderWorkerSet", func(ctx context.Context) {
@@ -113,7 +117,7 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(HaveKeyWithValue(testutils.QueueLabel, testutils.DefaultLocalQueueName), "LeaderWorkerSet should have default queue label")
 
 			By("verifying workload is created for LeaderWorkerSet")
-			verifyWorkloadCreated(kueueClient, ns.Name, string(lwsWithoutQueue.GetUID()))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient,ns.Name, string(lwsWithoutQueue.GetUID()))
 		})
 
 		It("should allow other local queues in same namespace without interfering", func(ctx context.Context) {
@@ -125,7 +129,7 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(createdJob.Labels).To(HaveKeyWithValue(testutils.QueueLabel, testutils.DefaultLocalQueueName))
 
-			verifyWorkloadCreated(kueueClient, ns.Name, string(createdJob.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient,ns.Name, string(createdJob.UID))
 
 			By("creating pod without queue name")
 			pod := builder.NewPodWithoutQueue()
@@ -133,7 +137,7 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(createdPod.Labels).To(HaveKeyWithValue(testutils.QueueLabel, testutils.DefaultLocalQueueName))
 
-			verifyWorkloadCreated(kueueClient, ns.Name, string(createdPod.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient,ns.Name, string(createdPod.UID))
 
 			cleanupSecondQueue, err := testutils.CreateLocalQueue(ctx, kueueClient, ns.Name, secondQueueName)
 			Expect(err).NotTo(HaveOccurred())
@@ -146,7 +150,7 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(createdJob.Labels).To(HaveKeyWithValue(testutils.QueueLabel, secondQueueName))
 
-			verifyWorkloadCreated(kueueClient, ns.Name, string(createdPod.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient,ns.Name, string(createdPod.UID))
 
 			By("creating pod in other local queue")
 			pod = builder.NewPodWithoutQueue()
@@ -155,7 +159,7 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(createdPod.Labels).To(HaveKeyWithValue(testutils.QueueLabel, secondQueueName))
 
-			verifyWorkloadCreated(kueueClient, ns.Name, string(createdPod.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient,ns.Name, string(createdPod.UID))
 		})
 
 		It("should allow to label pod and job with default localqueue after they're created", func(ctx context.Context) {
@@ -196,7 +200,7 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 				_, ok := job.Labels[testutils.QueueLabel]
 				return ok && job.Labels[testutils.QueueLabel] == testutils.DefaultLocalQueueName
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue(), "Job did not get labeled with queue name")
-			verifyWorkloadCreated(kueueClient, ns.Name, string(createdJob.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient,ns.Name, string(createdJob.UID))
 
 			// Checking that pod and job did not get labeled
 			By("Checking that Job and Pod were not automatically labeled")
@@ -216,7 +220,7 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 			Eventually(func() bool {
 				return testutils.IsPodScheduled(ctx, kubeClient, ns.Name, createdPodWithoutQueue.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue(), "Pod not in 'Scheduling' condition")
-			verifyWorkloadCreated(kueueClient, ns.Name, string(podPatched.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient,ns.Name, string(podPatched.UID))
 
 			// Adding LocalQueue Default label to Job
 			By(fmt.Sprintf("Adding localQueue Default label to Job suspended: %s", updatedJobWithoutQueue.Name))
@@ -227,7 +231,7 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 			Eventually(func() bool {
 				return testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJobWithoutQueue.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeFalse(), "Job in 'Suspended' condition")
-			verifyWorkloadCreated(kueueClient, ns.Name, string(jobPatched.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient,ns.Name, string(jobPatched.UID))
 		})
 	})
 
@@ -242,7 +246,11 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 		})
 		AfterEach(func(ctx context.Context) {
 			// Clean Up - resources deprovision
-			deleteNamespace(ctx, ns)
+			if defaultLocalQueueClean != nil {
+				defaultLocalQueueClean()
+				defaultLocalQueueClean = nil
+			}
+			testutils.DeleteNamespace(ctx, kubeClient, ns)
 			deleteClusterQueueAndResourceFlavor(ctx, kueueClient)
 		})
 		It("should label and admit Job", func(ctx context.Context) {
@@ -255,7 +263,7 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 				return testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJobWithoutQueue.Name)
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeFalse(), "Job in 'Suspended' condition")
 			Expect(createdJobWithoutQueue.Labels).To(HaveKeyWithValue(testutils.QueueLabel, testutils.DefaultLocalQueueName))
-			verifyWorkloadCreated(kueueClient, ns.Name, string(createdJobWithoutQueue.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient,ns.Name, string(createdJobWithoutQueue.UID))
 		})
 		It("should label and admit JobSet", func(ctx context.Context) {
 			By("Creating JobSet without queue name")
@@ -274,7 +282,7 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 				}
 				return nil
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "Incorrect jobset status in labeled namespace")
-			verifyWorkloadCreated(kueueClient, ns.Name, string(jobSetWithoutQueue.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient,ns.Name, string(jobSetWithoutQueue.UID))
 		})
 	})
 
@@ -286,7 +294,11 @@ var _ = Describe("LocalQueueDefaulting", Label("local-queue-default"), Ordered, 
 		})
 		AfterEach(func(ctx context.Context) {
 			// Clean Up - resources deprovision
-			deleteNamespace(ctx, ns)
+			if defaultLocalQueueClean != nil {
+				defaultLocalQueueClean()
+				defaultLocalQueueClean = nil
+			}
+			testutils.DeleteNamespace(ctx, kubeClient, ns)
 			deleteClusterQueueAndResourceFlavor(ctx, kueueClient)
 		})
 		It("should label and admit Pod", func(ctx context.Context) {
@@ -338,17 +350,6 @@ func deleteClusterQueueAndResourceFlavor(ctx context.Context, kueueClient *upstr
 			return fmt.Errorf("ResourceFlavor default still exists")
 		}, testutils.DeletionTime, testutils.DeletionPoll).Should(Succeed(), "ResourceFlavor was not cleaned up properly")
 	}
-}
-
-func deleteNamespace(ctx context.Context, namespace *corev1.Namespace) {
-	if defaultLocalQueueClean != nil {
-		defaultLocalQueueClean()
-		defaultLocalQueueClean = nil
-	}
-	By(fmt.Sprintf("Deleting namespace %s", namespace.Name))
-	err := kubeClient.CoreV1().Namespaces().Delete(ctx, namespace.Name, metav1.DeleteOptions{})
-	Expect(err).NotTo(HaveOccurred())
-	testutils.WaitForAllPodsInNamespaceDeleted(ctx, clients.GenericClient, namespace)
 }
 
 func createClusterQueueAndResourceFlavor(ctx context.Context) {

--- a/test/e2e/e2e_managed_jobs_namespace_selector_test.go
+++ b/test/e2e/e2e_managed_jobs_namespace_selector_test.go
@@ -103,7 +103,7 @@ var _ = Describe("ManagedJobsNamespaceSelectorAlwaysRespected", Label("managed-j
 			job := unmanagedBuilder.NewJobWithoutQueue()
 			createdJob, err := kubeClient.BatchV1().Jobs(unmanagedNs.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
+			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
 
 			By("verifying no workload is created for the job in unmanaged namespace")
 			Consistently(func() error {
@@ -127,7 +127,7 @@ var _ = Describe("ManagedJobsNamespaceSelectorAlwaysRespected", Label("managed-j
 			job := managedBuilder.NewJobWithoutQueue()
 			createdJob, err := kubeClient.BatchV1().Jobs(managedNs.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
+			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
 
 			By("verifying workload is created for the job in managed namespace")
 			testutils.VerifyWorkloadCreated(ctx, nsKueueClient, managedNs.Name, string(createdJob.UID))
@@ -139,7 +139,7 @@ var _ = Describe("ManagedJobsNamespaceSelectorAlwaysRespected", Label("managed-j
 			job.Labels = map[string]string{testutils.QueueLabel: testutils.DefaultLocalQueueName}
 			createdJob, err := kubeClient.BatchV1().Jobs(unmanagedNs.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
+			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
 
 			By("verifying job is not suspended and runs normally")
 			Eventually(func(g Gomega) {
@@ -210,7 +210,7 @@ var _ = Describe("ManagedJobsNamespaceSelectorAlwaysRespected", Label("managed-j
 			job.Labels = map[string]string{testutils.QueueLabel: "test-queue"}
 			createdJob, err := kubeClient.BatchV1().Jobs(unmanagedNs.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
+			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
 
 			By("verifying no workload is created for the job in unmanaged namespace")
 			Consistently(func() error {

--- a/test/e2e/e2e_managed_jobs_namespace_selector_test.go
+++ b/test/e2e/e2e_managed_jobs_namespace_selector_test.go
@@ -49,7 +49,7 @@ var _ = Describe("ManagedJobsNamespaceSelectorAlwaysRespected", Label("managed-j
 			Expect(err).ToNot(HaveOccurred(), "Failed to fetch Kueue instance")
 			initialKueueInstance = kueueInstance.DeepCopy()
 			kueueInstance.Spec.Config.WorkloadManagement.LabelPolicy = kueueoperatorv1.LabelPolicyNone
-			applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, kueueInstance.Spec.Config, clients)
 			createClusterQueueAndResourceFlavor(ctx)
 
 			managedNs, err = kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
@@ -91,7 +91,7 @@ var _ = Describe("ManagedJobsNamespaceSelectorAlwaysRespected", Label("managed-j
 				testutils.WaitForAllPodsInNamespaceDeleted(ctx, clients.GenericClient, unmanagedNs)
 			}
 			deleteClusterQueueAndResourceFlavor(ctx, nsKueueClient)
-			applyKueueConfig(ctx, initialKueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		})
 
 		JustAfterEach(func(ctx context.Context) {
@@ -130,7 +130,7 @@ var _ = Describe("ManagedJobsNamespaceSelectorAlwaysRespected", Label("managed-j
 			defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
 
 			By("verifying workload is created for the job in managed namespace")
-			verifyWorkloadCreated(nsKueueClient, managedNs.Name, string(createdJob.UID))
+			testutils.VerifyWorkloadCreated(ctx, nsKueueClient, managedNs.Name, string(createdJob.UID))
 		})
 
 		It("should not reconcile a job with queue-name in unlabeled namespace", func(ctx context.Context) {

--- a/test/e2e/e2e_operator_test.go
+++ b/test/e2e/e2e_operator_test.go
@@ -21,10 +21,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"slices"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,7 +32,6 @@ import (
 	"github.com/openshift/kueue-operator/test/e2e/testutils"
 	batchv1 "k8s.io/api/batch/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -42,7 +39,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	kueuev1beta2 "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	upstreamkueueclient "sigs.k8s.io/kueue/client-go/clientset/versioned"
 
 	networkingv1 "k8s.io/api/networking/v1"
@@ -404,7 +400,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 					},
 				},
 			}
-			applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, kueueInstance.Spec.Config, clients)
 
 			apiResourceLists, err := kubeClient.Discovery().ServerResourcesForGroupVersion("resource.k8s.io/v1")
 			if err == nil {
@@ -418,7 +414,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 		})
 
 		AfterAll(func(ctx context.Context) {
-			applyKueueConfig(ctx, initialKueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		})
 
 		It("verify DRA feature gate is enabled when DRA APIs are available", func() {
@@ -560,12 +556,12 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 
 		AfterAll(func(ctx context.Context) {
 			cleanupLocalQueue()
-			deleteNamespace(ctx, &corev1.Namespace{
+			testutils.DeleteNamespace(ctx, kubeClient, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testNamespaceWithLabel,
 				},
 			})
-			deleteNamespace(ctx, &corev1.Namespace{
+			testutils.DeleteNamespace(ctx, kubeClient, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testNamespaceWithoutLabel,
 				},
@@ -589,7 +585,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			Expect(err).ToNot(HaveOccurred(), "Failed to fetch Kueue instance")
 			initialKueueInstance := kueueInstance.DeepCopy()
 			kueueInstance.Spec.Config.WorkloadManagement.LabelPolicy = ssv1.LabelPolicyNone
-			applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, kueueInstance.Spec.Config, clients)
 
 			// Test labeled namespace
 			By("creating job in labeled namespace")
@@ -599,7 +595,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
 
-			fetchWorkload(kueueClient, testNamespaceWithLabel, string(createdJob.UID))
+			testutils.FetchWorkload(ctx, kueueClient,testNamespaceWithLabel, string(createdJob.UID))
 
 			// Verify job did not start (Kueue interference)
 			Eventually(func() *batchv1.JobStatus {
@@ -619,7 +615,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 				return &job.Status
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(HaveField("Active", BeNumerically(">=", 1)), "Job not started in unlabeled namespace")
 
-			applyKueueConfig(ctx, initialKueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		})
 
 		It("should manage jobs only in labeled namespaces", func() {
@@ -637,7 +633,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
 
-			verifyWorkloadCreated(kueueClient, testNamespaceWithLabel, string(createdJob.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient,testNamespaceWithLabel, string(createdJob.UID))
 
 			By("creating job in labeled namespace not managed by Kueue")
 			jobWithoutQueue := builderWithLabel.NewJobWithoutQueue()
@@ -677,7 +673,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer testutils.CleanUpObject(ctx, genericClient, createdPod)
 
-			verifyWorkloadCreated(kueueClient, testNamespaceWithLabel, string(createdPod.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient,testNamespaceWithLabel, string(createdPod.UID))
 
 			By("creating pod in labeled namespace not managed by Kueue")
 			podWithoutQueue := builderWithLabel.NewPodWithoutQueue()
@@ -728,7 +724,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 				return nil
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
-			verifyWorkloadCreated(kueueClient, testNamespaceWithLabel, string(deploymentPod.UID))
+			testutils.VerifyWorkloadCreated(ctx, kueueClient,testNamespaceWithLabel, string(deploymentPod.UID))
 
 			By("verifying deployment pods are available")
 			Eventually(func() int32 {
@@ -785,7 +781,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 				return nil
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
-			workload := verifyWorkloadCreated(kueueClient, testNamespaceWithLabel, string(ssPod.UID))
+			workload := testutils.VerifyWorkloadCreated(ctx, kueueClient,testNamespaceWithLabel, string(ssPod.UID))
 			defer testutils.CleanUpWorkload(ctx, kueueClient, testNamespaceWithLabel, workload)
 
 			By("verifying statefulset pods are running")
@@ -825,7 +821,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			Expect(err).ToNot(HaveOccurred(), "Failed to fetch Kueue instance")
 			initialKueueInstance := kueueInstance.DeepCopy()
 			kueueInstance.Spec.Config.WorkloadManagement.LabelPolicy = "None"
-			applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, kueueInstance.Spec.Config, clients)
 
 			jobsetInUnlabeledNamespace := builderWithoutLabel.NewJobSetWithoutQueue()
 			jobsetInLabeledNamespace := builderWithLabel.NewJobSetWithoutQueue()
@@ -852,7 +848,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			defer testutils.CleanUpObject(ctx, genericClient, jobsetInLabeledNamespace)
 
 			By("verifying workload is created")
-			fetchWorkload(kueueClient, testNamespaceWithLabel, string(jobsetInLabeledNamespace.UID))
+			testutils.FetchWorkload(ctx, kueueClient,testNamespaceWithLabel, string(jobsetInLabeledNamespace.UID))
 
 			By("verifying jobset did not start in labeled namespace")
 			Eventually(func() error {
@@ -870,7 +866,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 				return nil
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "Incorrect jobset status in labeled namespace")
 
-			applyKueueConfig(ctx, initialKueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		})
 
 		It("should manage LeaderWorkerSet without queue name in labeled namespace when labelPolicy=None", func() {
@@ -881,7 +877,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			Expect(err).ToNot(HaveOccurred(), "Failed to fetch Kueue instance")
 			initialKueueInstance := kueueInstance.DeepCopy()
 			kueueInstance.Spec.Config.WorkloadManagement.LabelPolicy = ssv1.LabelPolicyNone
-			applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, kueueInstance.Spec.Config, clients)
 
 			By("creating LeaderWorkerSet without queue name in labeled namespace")
 			lwsWithoutQueue := builderWithLabel.NewLeaderWorkerSet(testutils.LeaderWorkerSetOptions{
@@ -942,7 +938,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 				}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "Pod %s should be in SchedulingGated state", pod.Name)
 			}
 
-			applyKueueConfig(ctx, initialKueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		})
 
 		It("should not manage LeaderWorkerSet without queue name in unlabeled namespace when labelPolicy=None", func() {
@@ -953,7 +949,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			Expect(err).ToNot(HaveOccurred(), "Failed to fetch Kueue instance")
 			initialKueueInstance := kueueInstance.DeepCopy()
 			kueueInstance.Spec.Config.WorkloadManagement.LabelPolicy = ssv1.LabelPolicyNone
-			applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, kueueInstance.Spec.Config, clients)
 
 			By("creating LeaderWorkerSet without queue name in unlabeled namespace")
 			lwsWithoutQueue := builderWithoutLabel.NewLeaderWorkerSet(testutils.LeaderWorkerSetOptions{
@@ -1001,7 +997,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 				return nil
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "LeaderWorkerSet pods should be running in unlabeled namespace")
 
-			applyKueueConfig(ctx, initialKueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		})
 		It("should expose metrics endpoint with TLS", func() {
 			ctx := context.TODO()
@@ -1444,182 +1440,6 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 	})
 })
 
-func applyKueueConfig(ctx context.Context, config ssv1.KueueConfiguration, kClient *kubernetes.Clientset) {
-	kueueClientset := clients.KueueClient
-	By("Feching Kueue Instance")
-	kueueInstance, err := kueueClientset.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
-	Expect(err).ToNot(HaveOccurred(), "Failed to fetch Kueue instance")
-
-	// Check if the config is actually changing
-	configChanged := !reflect.DeepEqual(kueueInstance.Spec.Config, config)
-
-	// Get the current resource version of kueue-controller-manager before updating config
-	initialDeployment, err := kClient.AppsV1().Deployments(testutils.OperatorNamespace).Get(ctx, "kueue-controller-manager", metav1.GetOptions{})
-	Expect(err).ToNot(HaveOccurred(), "Failed to fetch kueue-controller-manager deployment")
-	initialResourceVersion := initialDeployment.ResourceVersion
-
-	kueueInstance.Spec.Config = config
-	By("Updating Kueue config")
-	_, err = kueueClientset.KueueV1().Kueues().Update(ctx, kueueInstance, metav1.UpdateOptions{})
-	Expect(err).ToNot(HaveOccurred(), "Failed to update Kueue config")
-
-	// Only wait for deployment update if the config actually changed
-	if configChanged {
-		// Wait for the deployment resource version to change
-		By(fmt.Sprintf("Waiting for kueue-controller-manager resource version to change from %s", initialResourceVersion))
-		Eventually(func() error {
-			managerDeployment, err := kClient.AppsV1().Deployments(testutils.OperatorNamespace).Get(ctx, "kueue-controller-manager", metav1.GetOptions{})
-			if err != nil {
-				return fmt.Errorf("Unable to fetch manager deployment: %v", err)
-			}
-			if managerDeployment.ResourceVersion == initialResourceVersion {
-				return fmt.Errorf("deployment resource version has not changed yet (still %s)", initialResourceVersion)
-			}
-			return nil
-		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "kueue-controller-manager deployment resource version did not change")
-	} else {
-		By("Skipping deployment update wait - config unchanged")
-	}
-
-	Eventually(func() error {
-		managerDeployment, err := kClient.AppsV1().Deployments(testutils.OperatorNamespace).Get(ctx, "kueue-controller-manager", metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("Unable to fetch manager deployment: %v", err)
-		}
-		By(fmt.Sprintf("Checking if deployment replicas: %v matches amount of ready replicas: %v", managerDeployment.Status.Replicas, managerDeployment.Status.ReadyReplicas))
-		if managerDeployment.Status.ReadyReplicas == managerDeployment.Status.Replicas {
-			return nil
-		}
-		return fmt.Errorf("deployment is not ready")
-	}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "kueue-controller-manager deployment failed to be ready")
-
-	// Wait for webhook configurations to be created/updated
-	By("Waiting for webhook configurations to exist")
-	Eventually(func() error {
-		_, err := kClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, "kueue-mutating-webhook-configuration", metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("mutating webhook configuration not found: %w", err)
-		}
-		_, err = kClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, "kueue-validating-webhook-configuration", metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("validating webhook configuration not found: %w", err)
-		}
-		return nil
-	}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "webhook configurations not found")
-
-	waitForWebhookReady(ctx, kClient)
-
-	// After redeployment, CRD conversion webhooks may be temporarily unreachable
-	// causing the API server to return 404 for kueue resource types. Wait until
-	// the CRDs are actually servable before returning.
-	By("Verifying kueue CRDs are servable")
-	Eventually(func() error {
-		_, err := clients.UpstreamKueueClient.KueueV1beta2().ClusterQueues().List(ctx, metav1.ListOptions{Limit: 1})
-		return err
-	}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "kueue CRDs not servable after reconfiguration")
-}
-
-// waitForWebhookReady waits for the webhook to be ready by attempting to create a test job
-func waitForWebhookReady(ctx context.Context, kubeClient *kubernetes.Clientset) {
-	By("Waiting for webhook to handle requests successfully")
-
-	// Track consecutive successes to ensure webhook is stable
-	consecutiveSuccesses := 0
-	requiredSuccesses := 3
-
-	Eventually(func() error {
-		// First, verify webhook service endpoints exist and are not empty
-		endpointSlices, err := kubeClient.DiscoveryV1().EndpointSlices(testutils.OperatorNamespace).List(
-			ctx,
-			metav1.ListOptions{
-				LabelSelector: "kubernetes.io/service-name=kueue-webhook-service",
-			},
-		)
-		if err != nil {
-			consecutiveSuccesses = 0
-			return fmt.Errorf("webhook service endpointslices not found: %w", err)
-		}
-
-		// Check if there are at least 2 ready endpoints
-		readyEndpointCount := 0
-		for _, slice := range endpointSlices.Items {
-			for _, endpoint := range slice.Endpoints {
-				if endpoint.Conditions.Ready != nil && *endpoint.Conditions.Ready {
-					readyEndpointCount++
-				}
-			}
-		}
-		if readyEndpointCount < 2 {
-			consecutiveSuccesses = 0
-			return fmt.Errorf("webhook service has %d ready endpoints, need 2", readyEndpointCount)
-		}
-
-		// Create a test job to verify webhook responds
-		testJob := &batchv1.Job{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "webhook-test-",
-				Namespace:    testutils.OperatorNamespace,
-			},
-			Spec: batchv1.JobSpec{
-				Template: corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						RestartPolicy: corev1.RestartPolicyNever,
-						Containers: []corev1.Container{
-							{
-								Name:    "test",
-								Image:   "busybox",
-								Command: []string{"true"},
-							},
-						},
-					},
-				},
-			},
-		}
-
-		// Try to create the job - if webhook responds (success or rejection), it's ready
-		job, err := kubeClient.BatchV1().Jobs(testutils.OperatorNamespace).Create(ctx, testJob, metav1.CreateOptions{})
-		if err == nil {
-			// Webhook responded successfully - clean up the test job
-			klog.Infof("Webhook test successful, cleaning up test job: %s", job.Name)
-			_ = kubeClient.BatchV1().Jobs(testutils.OperatorNamespace).Delete(ctx, job.Name, metav1.DeleteOptions{
-				PropagationPolicy: func() *metav1.DeletionPropagation {
-					p := metav1.DeletePropagationBackground
-					return &p
-				}(),
-			})
-			consecutiveSuccesses++
-			if consecutiveSuccesses >= requiredSuccesses {
-				klog.Infof("Webhook stable after %d consecutive successes", consecutiveSuccesses)
-				return nil
-			}
-			klog.Infof("Webhook success %d/%d", consecutiveSuccesses, requiredSuccesses)
-			return fmt.Errorf("waiting for webhook stability (%d/%d successes)", consecutiveSuccesses, requiredSuccesses)
-		}
-
-		// Reset counter on any error
-		consecutiveSuccesses = 0
-
-		// If error is a webhook timeout/connection error, webhook is not ready
-		if strings.Contains(err.Error(), "failed calling webhook") ||
-			strings.Contains(err.Error(), "failed to call webhook") ||
-			strings.Contains(err.Error(), "context deadline exceeded") ||
-			strings.Contains(err.Error(), "connection refused") {
-			klog.Infof("Webhook not ready yet: %v", err)
-			return fmt.Errorf("webhook not responding: %w", err)
-		}
-
-		// Any other error (validation, etc.) means webhook is responding
-		klog.Infof("Webhook is responding (returned error: %v)", err)
-		consecutiveSuccesses++
-		if consecutiveSuccesses >= requiredSuccesses {
-			klog.Infof("Webhook stable after %d consecutive successes", consecutiveSuccesses)
-			return nil
-		}
-		klog.Infof("Webhook success %d/%d", consecutiveSuccesses, requiredSuccesses)
-		return fmt.Errorf("waiting for webhook stability (%d/%d successes)", consecutiveSuccesses, requiredSuccesses)
-	}, testutils.OperatorReadyTime, 3*time.Second).Should(Succeed(), "webhook failed to respond to requests")
-}
-
 func validateWebhookConfig(kubeClient *kubernetes.Clientset, labelKey, labelValue, framework string) {
 	ctx := context.TODO()
 	// avoid matching on two of same names like job and jobset.
@@ -1670,180 +1490,6 @@ func validateWebhookConfig(kubeClient *kubernetes.Clientset, labelKey, labelValu
 	mwh, err := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, "kueue-mutating-webhook-configuration", metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	mutatingWebhook(mwh)
-}
-
-func fetchWorkload(kueueClient *upstreamkueueclient.Clientset, namespace, uid string) {
-	ctx := context.TODO()
-	Eventually(func() error {
-		workloads, err := kueueClient.KueueV1beta2().Workloads(namespace).List(ctx, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("kueue.x-k8s.io/job-uid=%s", uid),
-		})
-		if err != nil {
-			return err
-		}
-		if len(workloads.Items) == 0 {
-			return fmt.Errorf("no workload found")
-		}
-		return nil
-	}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
-}
-
-func verifyWorkloadCreated(kueueClient *upstreamkueueclient.Clientset, namespace, uid string) string {
-	ctx := context.TODO()
-	By(fmt.Sprintf("verifying workload created in namespace %s and uid %s", namespace, uid))
-	// Verify that a Workload with the expected label is created and admitted
-	var workload *kueuev1beta2.Workload
-	Eventually(func() error {
-		workloads, err := kueueClient.KueueV1beta2().Workloads(namespace).List(ctx, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("kueue.x-k8s.io/job-uid=%s", uid),
-		})
-		if err != nil {
-			return err
-		}
-		if len(workloads.Items) > 0 {
-			workload = &workloads.Items[0]
-			return nil
-		}
-
-		// If not found by job-uid label, look for workloads by ownerReference (for StatefulSets)
-		allWorkloads, err := kueueClient.KueueV1beta2().Workloads(namespace).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return err
-		}
-
-		for _, wl := range allWorkloads.Items {
-			for _, ownerRef := range wl.OwnerReferences {
-				if ownerRef.UID == types.UID(uid) {
-					workload = &wl
-
-					return nil
-				}
-			}
-		}
-
-		return fmt.Errorf("no workload found in namespace %s with uid %s", namespace, uid)
-	}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
-
-	Eventually(func() error {
-		updatedWorkload, err := kueueClient.KueueV1beta2().Workloads(namespace).Get(ctx, workload.Name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		// Accept workloads that are either admitted or finished (which means they were admitted and completed)
-		if apimeta.IsStatusConditionTrue(updatedWorkload.Status.Conditions, kueuev1beta2.WorkloadAdmitted) ||
-			apimeta.IsStatusConditionTrue(updatedWorkload.Status.Conditions, kueuev1beta2.WorkloadFinished) {
-			return nil
-		}
-		return fmt.Errorf("workload %s/%s not admitted or finished", namespace, workload.Name)
-	}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
-	return workload.Name
-}
-
-func deployOperand() error {
-	ssClient := clients.KueueClient
-
-	ctx, cancelFnc := context.WithCancel(context.TODO())
-	defer cancelFnc()
-
-	Eventually(func() error {
-		klog.Infof("Creating Kueue instance")
-		requiredSS := testutils.NewKueueDefault()
-		_, err := ssClient.KueueV1().Kueues().Create(ctx, requiredSS.GetKueue(), metav1.CreateOptions{})
-		if err != nil {
-			if apierrors.IsAlreadyExists(err) {
-				return nil
-			}
-			return err
-		}
-		return nil
-	}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "Kueue instance should be deployed")
-
-	Eventually(func() error {
-		ctx := context.TODO()
-		podItems, err := kubeClient.CoreV1().Pods(testutils.OperatorNamespace).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			klog.Errorf("Unable to list pods: %v", err)
-			return nil
-		}
-		for _, pod := range podItems.Items {
-			if !strings.HasPrefix(pod.Name, "kueue-controller-manager") {
-				continue
-			}
-			klog.Infof("Checking pod: %v, phase: %v, deletionTS: %v\n", pod.Name, pod.Status.Phase, pod.GetDeletionTimestamp())
-			if pod.Status.Phase == corev1.PodRunning && pod.GetDeletionTimestamp() == nil && pod.Status.ContainerStatuses[0].Ready {
-				return nil
-			}
-		}
-		return fmt.Errorf("pod is not ready")
-	}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "kueue pod failed to be ready")
-
-	// Wait for all Kueue CRDs to be registered
-	By("Waiting for all Kueue CRDs to be registered")
-	requiredCRDs := []string{
-		"clusterqueues.kueue.x-k8s.io",
-		"cohorts.kueue.x-k8s.io",
-		"localqueues.kueue.x-k8s.io",
-		"multikueueconfigs.kueue.x-k8s.io",
-		"provisioningrequestconfigs.kueue.x-k8s.io",
-		"resourceflavors.kueue.x-k8s.io",
-		"topologies.kueue.x-k8s.io",
-		"workloadpriorityclasses.kueue.x-k8s.io",
-		"workloads.kueue.x-k8s.io",
-	}
-
-	Eventually(func() error {
-		ctx := context.TODO()
-		crdList, err := clients.APIExtClient.CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to list CRDs: %w", err)
-		}
-
-		// Create a map of found CRDs
-		foundCRDs := make(map[string]bool)
-		for _, crd := range crdList.Items {
-			foundCRDs[crd.Name] = true
-		}
-
-		// Check all required CRDs are present
-		var missingCRDs []string
-		for _, requiredCRD := range requiredCRDs {
-			if !foundCRDs[requiredCRD] {
-				missingCRDs = append(missingCRDs, requiredCRD)
-			}
-		}
-
-		if len(missingCRDs) > 0 {
-			return fmt.Errorf("missing Kueue CRDs: %v", missingCRDs)
-		}
-
-		// Verify all CRDs are established (ready to accept requests)
-		for _, requiredCRD := range requiredCRDs {
-			crd, err := clients.APIExtClient.CustomResourceDefinitions().Get(ctx, requiredCRD, metav1.GetOptions{})
-			if err != nil {
-				return fmt.Errorf("failed to get CRD %s: %w", requiredCRD, err)
-			}
-
-			// Check if CRD is established
-			established := false
-			for _, condition := range crd.Status.Conditions {
-				if condition.Type == apiextensionsv1.Established && condition.Status == apiextensionsv1.ConditionTrue {
-					established = true
-					break
-				}
-			}
-
-			if !established {
-				return fmt.Errorf("CRD %s is not established yet", requiredCRD)
-			}
-		}
-
-		klog.Infof("All %d Kueue CRDs are registered and established", len(requiredCRDs))
-		return nil
-	}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "Kueue CRDs failed to be registered")
-
-	waitForWebhookReady(ctx, kubeClient)
-
-	return nil
 }
 
 func Kexecute(ctx context.Context, restConfig *rest.Config, kubeClient kubernetes.Interface, namespace, podName, containerName string, command []string) ([]byte, []byte, error) {

--- a/test/e2e/e2e_operator_test.go
+++ b/test/e2e/e2e_operator_test.go
@@ -84,9 +84,8 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			testutils.DumpKueueControllerManagerLogs(ctx, kubeClient, 500)
 		})
 
-		It("operator pods should be ready", func() {
+		It("operator pods should be ready", func(ctx context.Context) {
 			Eventually(func() error {
-				ctx := context.TODO()
 				podItems, err := kubeClient.CoreV1().Pods(testutils.OperatorNamespace).List(ctx, metav1.ListOptions{})
 				if err != nil {
 					klog.Errorf("Unable to list pods: %v", err)
@@ -104,8 +103,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 				return fmt.Errorf("pod is not ready")
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "operator pod failed to be ready")
 		})
-		It("kueue pods should be ready", func() {
-			ctx := context.TODO()
+		It("kueue pods should be ready", func(ctx context.Context) {
 			Eventually(func() error {
 				podItems, err := kubeClient.CoreV1().Pods(testutils.OperatorNamespace).List(ctx, metav1.ListOptions{})
 				if err != nil {
@@ -131,8 +129,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			testutils.DumpKueueControllerManagerLogs(ctx, kubeClient, 500)
 		})
 
-		It("should set ReadyReplicas in operator status and handle degraded condition", func() {
-			ctx := context.TODO()
+		It("should set ReadyReplicas in operator status and handle degraded condition", func(ctx context.Context) {
 			Eventually(func() error {
 				kueueInstance, err := clients.KueueClient.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
 				if err != nil {
@@ -167,8 +164,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "ReadyReplicas not properly set or degraded condition not handled")
 		})
 
-		It("kueue operator deployment should contain priority class", func() {
-			ctx := context.TODO()
+		It("kueue operator deployment should contain priority class", func(ctx context.Context) {
 			Eventually(func() error {
 				operatorDeployment, err := kubeClient.AppsV1().Deployments(testutils.OperatorNamespace).Get(ctx, "openshift-kueue-operator", metav1.GetOptions{})
 				if err != nil {
@@ -181,8 +177,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "Unexpected priority class")
 		})
 
-		It("kueue deployment should contain priority class and have no resource limits set", func() {
-			ctx := context.TODO()
+		It("kueue deployment should contain priority class and have no resource limits set", func(ctx context.Context) {
 
 			Eventually(func() error {
 				managerDeployment, err := kubeClient.AppsV1().Deployments(testutils.OperatorNamespace).Get(ctx, "kueue-controller-manager", metav1.GetOptions{})
@@ -199,9 +194,8 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "Unexpected kueue-controller-manager spec")
 		})
 
-		It("Verifying that no v1alpha Kueue CRDs are installed", func() {
+		It("Verifying that no v1alpha Kueue CRDs are installed", func(ctx context.Context) {
 			Eventually(func() error {
-				ctx := context.TODO()
 				crdList, err := clients.APIExtClient.CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
 				if err != nil {
 					klog.Errorf("Failed to list CRDs: %v", err)
@@ -233,8 +227,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "Unexpected v1alpha CRD is installed")
 		})
 
-		It("verify webhook readiness", func() {
-			ctx := context.TODO()
+		It("verify webhook readiness", func(ctx context.Context) {
 			Eventually(func() error {
 				endpointSlices, err := kubeClient.DiscoveryV1().EndpointSlices(testutils.OperatorNamespace).List(
 					ctx,
@@ -355,8 +348,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "network policy has not been setup")
 		})
 
-		It("verify kueue-config-map is updated with operators configuration", func() {
-			ctx := context.TODO()
+		It("verify kueue-config-map is updated with operators configuration", func(ctx context.Context) {
 			By("check if JobSet is present")
 			Eventually(func() error {
 				configMap, err := kubeClient.CoreV1().ConfigMaps(testutils.OperatorNamespace).Get(ctx, "kueue-manager-config", metav1.GetOptions{})
@@ -417,11 +409,10 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			testutils.ApplyKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		})
 
-		It("verify DRA feature gate is enabled when DRA APIs are available", func() {
+		It("verify DRA feature gate is enabled when DRA APIs are available", func(ctx context.Context) {
 			if !draSupported {
 				Skip("DRA APIs (resource.k8s.io/v1) not available on this cluster")
 			}
-			ctx := context.TODO()
 			Eventually(func() error {
 				configMap, err := kubeClient.CoreV1().ConfigMaps(testutils.OperatorNamespace).Get(ctx, "kueue-manager-config", metav1.GetOptions{})
 				if err != nil {
@@ -438,11 +429,10 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "DRA feature gate should be enabled on supported cluster")
 		})
 
-		It("verify DRA feature gate is not enabled when DRA APIs are unavailable", func() {
+		It("verify DRA feature gate is not enabled when DRA APIs are unavailable", func(ctx context.Context) {
 			if draSupported {
 				Skip("DRA APIs (resource.k8s.io/v1) available on this cluster")
 			}
-			ctx := context.TODO()
 			Eventually(func() error {
 				configMap, err := kubeClient.CoreV1().ConfigMaps(testutils.OperatorNamespace).Get(ctx, "kueue-manager-config", metav1.GetOptions{})
 				if err != nil {
@@ -571,9 +561,8 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			cleanupResourceFlavor()
 		})
 
-		It("should suspend jobs only in labeled namespaces when labelPolicy=None", func() {
+		It("should suspend jobs only in labeled namespaces when labelPolicy=None", func(ctx context.Context) {
 			kueueClientset := clients.KueueClient
-			ctx := context.TODO()
 
 			// Verify webhook configuration
 			Eventually(func() error {
@@ -593,7 +582,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			job.Labels = map[string]string{}
 			createdJob, err := kubeClient.BatchV1().Jobs(testNamespaceWithLabel).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
+			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
 
 			testutils.FetchWorkload(ctx, kueueClient,testNamespaceWithLabel, string(createdJob.UID))
 
@@ -607,7 +596,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			jobWithoutLabel := builderWithoutLabel.NewJob()
 			createdUnlabeledJob, err := kubeClient.BatchV1().Jobs(testNamespaceWithoutLabel).Create(ctx, jobWithoutLabel, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpJob(ctx, kubeClient, createdUnlabeledJob.Namespace, createdUnlabeledJob.Name)
+			DeferCleanup(testutils.CleanUpJob, kubeClient, createdUnlabeledJob.Namespace, createdUnlabeledJob.Name)
 
 			// Verify job starts normally (no Kueue interference)
 			Eventually(func() *batchv1.JobStatus {
@@ -618,20 +607,18 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			testutils.ApplyKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		})
 
-		It("should manage jobs only in labeled namespaces", func() {
+		It("should manage jobs only in labeled namespaces", func(ctx context.Context) {
 			// Verify webhook configuration
 			Eventually(func() error {
 				validateWebhookConfig(kubeClient, labelKey, labelValue, "job")
 				return nil
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
-
-			ctx := context.TODO()
 			// Test labeled namespace
 			By("creating job in labeled namespace")
 			jobWithLabel := builderWithLabel.NewJob()
 			createdJob, err := kubeClient.BatchV1().Jobs(testNamespaceWithLabel).Create(ctx, jobWithLabel, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
+			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
 
 			testutils.VerifyWorkloadCreated(ctx, kueueClient,testNamespaceWithLabel, string(createdJob.UID))
 
@@ -639,7 +626,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			jobWithoutQueue := builderWithLabel.NewJobWithoutQueue()
 			createdUnmanagedJob, err := kubeClient.BatchV1().Jobs(testNamespaceWithLabel).Create(ctx, jobWithoutQueue, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpJob(ctx, kubeClient, createdUnmanagedJob.Namespace, createdUnmanagedJob.Name)
+			DeferCleanup(testutils.CleanUpJob, kubeClient, createdUnmanagedJob.Namespace, createdUnmanagedJob.Name)
 
 			Eventually(func() *batchv1.JobStatus {
 				job, _ := kubeClient.BatchV1().Jobs(testNamespaceWithLabel).Get(ctx, createdUnmanagedJob.Name, metav1.GetOptions{})
@@ -650,7 +637,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			jobWithoutLabel := builderWithoutLabel.NewJob()
 			createdUnlabeledJob, err := kubeClient.BatchV1().Jobs(testNamespaceWithoutLabel).Create(ctx, jobWithoutLabel, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpJob(ctx, kubeClient, createdUnlabeledJob.Namespace, createdUnlabeledJob.Name)
+			DeferCleanup(testutils.CleanUpJob, kubeClient, createdUnlabeledJob.Namespace, createdUnlabeledJob.Name)
 			// Verify job starts normally (no Kueue interference)
 			Eventually(func() *batchv1.JobStatus {
 				job, _ := kubeClient.BatchV1().Jobs(testNamespaceWithoutLabel).Get(ctx, createdUnlabeledJob.Name, metav1.GetOptions{})
@@ -658,7 +645,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(HaveField("Active", BeNumerically(">=", 1)), "Job not started in unlabeled namespace")
 		})
 
-		It("should manage pods only in labeled namespaces", func() {
+		It("should manage pods only in labeled namespaces", func(ctx context.Context) {
 			// Verify webhook configuration
 			Eventually(func() error {
 				validateWebhookConfig(kubeClient, labelKey, labelValue, "pod")
@@ -668,10 +655,9 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			// Test labeled namespace
 			By("creating pod in labeled namespace")
 			podWithLabel := builderWithLabel.NewPod()
-			ctx := context.TODO()
 			createdPod, err := kubeClient.CoreV1().Pods(testNamespaceWithLabel).Create(ctx, podWithLabel, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpObject(ctx, genericClient, createdPod)
+			DeferCleanup(testutils.CleanUpObject, genericClient, createdPod)
 
 			testutils.VerifyWorkloadCreated(ctx, kueueClient,testNamespaceWithLabel, string(createdPod.UID))
 
@@ -679,7 +665,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			podWithoutQueue := builderWithLabel.NewPodWithoutQueue()
 			createdUnmanagedPod, err := kubeClient.CoreV1().Pods(testNamespaceWithLabel).Create(ctx, podWithoutQueue, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpObject(ctx, genericClient, createdUnmanagedPod)
+			DeferCleanup(testutils.CleanUpObject, genericClient, createdUnmanagedPod)
 
 			Eventually(func() corev1.PodPhase {
 				pod, _ := kubeClient.CoreV1().Pods(testNamespaceWithLabel).Get(ctx, createdUnmanagedPod.Name, metav1.GetOptions{})
@@ -690,7 +676,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			podWithoutLabel := builderWithoutLabel.NewPod()
 			createdUnlabeledPod, err := kubeClient.CoreV1().Pods(testNamespaceWithoutLabel).Create(ctx, podWithoutLabel, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpObject(ctx, genericClient, createdUnlabeledPod)
+			DeferCleanup(testutils.CleanUpObject, genericClient, createdUnlabeledPod)
 
 			// Verify pod starts normally (no Kueue interference)
 			Eventually(func() corev1.PodPhase {
@@ -698,18 +684,17 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 				return pod.Status.Phase
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Equal(corev1.PodRunning), "Pod not running in unlabeled namespace")
 		})
-		It("should manage deployments only in labeled namespaces", func() {
+		It("should manage deployments only in labeled namespaces", func(ctx context.Context) {
 			// Verify webhook configuration
 			Eventually(func() error {
 				validateWebhookConfig(kubeClient, labelKey, labelValue, "deployment")
 				return nil
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
-			ctx := context.TODO()
 			By("creating deployment in labeled namespace")
 			deployWithLabel := builderWithLabel.NewDeployment()
 			createdDeploy, err := kubeClient.AppsV1().Deployments(testNamespaceWithLabel).Create(ctx, deployWithLabel, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpObject(ctx, genericClient, createdDeploy)
+			DeferCleanup(testutils.CleanUpObject, genericClient, createdDeploy)
 
 			// Get the deployment's pod
 			var deploymentPod *corev1.Pod
@@ -736,7 +721,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			deployWithoutQueue := builderWithLabel.NewDeploymentWithoutQueue()
 			createdUnmanagedDeploy, err := kubeClient.AppsV1().Deployments(testNamespaceWithLabel).Create(ctx, deployWithoutQueue, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpObject(ctx, genericClient, createdUnmanagedDeploy)
+			DeferCleanup(testutils.CleanUpObject, genericClient, createdUnmanagedDeploy)
 
 			Eventually(func() int32 {
 				deploy, _ := kubeClient.AppsV1().Deployments(testNamespaceWithLabel).Get(ctx, createdUnmanagedDeploy.Name, metav1.GetOptions{})
@@ -747,14 +732,14 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			deployWithoutLabel := builderWithoutLabel.NewDeployment()
 			createdUnlabeledDeploy, err := kubeClient.AppsV1().Deployments(testNamespaceWithoutLabel).Create(ctx, deployWithoutLabel, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpObject(ctx, genericClient, createdUnlabeledDeploy)
+			DeferCleanup(testutils.CleanUpObject, genericClient, createdUnlabeledDeploy)
 
 			Eventually(func() int32 {
 				deploy, _ := kubeClient.AppsV1().Deployments(testNamespaceWithoutLabel).Get(ctx, createdUnlabeledDeploy.Name, metav1.GetOptions{})
 				return deploy.Status.AvailableReplicas
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Equal(int32(1)), "Deployment in unlabeled namespace not available")
 		})
-		It("should manage statefulsets only in labeled namespaces", func() {
+		It("should manage statefulsets only in labeled namespaces", func(ctx context.Context) {
 			// Verify webhook configuration
 			Eventually(func() error {
 				validateWebhookConfig(kubeClient, labelKey, labelValue, "statefulset")
@@ -762,11 +747,10 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("creating statefulset in labeled namespace")
-			ctx := context.TODO()
 			ssWithLabel := builderWithLabel.NewStatefulSet()
 			createdSS, err := kubeClient.AppsV1().StatefulSets(testNamespaceWithLabel).Create(ctx, ssWithLabel, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpObject(ctx, genericClient, createdSS)
+			DeferCleanup(testutils.CleanUpObject, genericClient, createdSS)
 
 			// Wait for StatefulSet to create pod
 			var ssPod *corev1.Pod
@@ -782,7 +766,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			workload := testutils.VerifyWorkloadCreated(ctx, kueueClient,testNamespaceWithLabel, string(ssPod.UID))
-			defer testutils.CleanUpWorkload(ctx, kueueClient, testNamespaceWithLabel, workload)
+			DeferCleanup(testutils.CleanUpWorkload, kueueClient, testNamespaceWithLabel, workload)
 
 			By("verifying statefulset pods are running")
 			Eventually(func() int32 {
@@ -794,7 +778,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			ssWithoutQueue := builderWithLabel.NewStatefulSetWithoutQueue()
 			createdUnmanagedSS, err := kubeClient.AppsV1().StatefulSets(testNamespaceWithLabel).Create(ctx, ssWithoutQueue, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpObject(ctx, genericClient, createdUnmanagedSS)
+			DeferCleanup(testutils.CleanUpObject, genericClient, createdUnmanagedSS)
 
 			Eventually(func() int32 {
 				ss, _ := kubeClient.AppsV1().StatefulSets(testNamespaceWithLabel).Get(ctx, createdUnmanagedSS.Name, metav1.GetOptions{})
@@ -805,7 +789,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			ssWithoutLabel := builderWithoutLabel.NewStatefulSet()
 			createdUnlabeledSS, err := kubeClient.AppsV1().StatefulSets(testNamespaceWithoutLabel).Create(ctx, ssWithoutLabel, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpObject(ctx, genericClient, createdUnlabeledSS)
+			DeferCleanup(testutils.CleanUpObject, genericClient, createdUnlabeledSS)
 
 			Eventually(func() int32 {
 				ss, _ := kubeClient.AppsV1().StatefulSets(testNamespaceWithoutLabel).Get(ctx, createdUnlabeledSS.Name, metav1.GetOptions{})
@@ -828,7 +812,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 
 			By("creating jobset in unlabeled namespace")
 			Expect(genericClient.Create(ctx, jobsetInUnlabeledNamespace)).Should(Succeed())
-			defer testutils.CleanUpObject(ctx, genericClient, jobsetInUnlabeledNamespace)
+			DeferCleanup(testutils.CleanUpObject, genericClient, jobsetInUnlabeledNamespace)
 
 			By("verifying jobset did start in unlabeled namespace")
 			Eventually(func() error {
@@ -845,7 +829,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			By("creating jobset in labeled namespace")
 			err = genericClient.Create(ctx, jobsetInLabeledNamespace)
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpObject(ctx, genericClient, jobsetInLabeledNamespace)
+			DeferCleanup(testutils.CleanUpObject, genericClient, jobsetInLabeledNamespace)
 
 			By("verifying workload is created")
 			testutils.FetchWorkload(ctx, kueueClient,testNamespaceWithLabel, string(jobsetInLabeledNamespace.UID))
@@ -869,9 +853,8 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			testutils.ApplyKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		})
 
-		It("should manage LeaderWorkerSet without queue name in labeled namespace when labelPolicy=None", func() {
+		It("should manage LeaderWorkerSet without queue name in labeled namespace when labelPolicy=None", func(ctx context.Context) {
 			kueueClientset := clients.KueueClient
-			ctx := context.TODO()
 
 			kueueInstance, err := kueueClientset.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred(), "Failed to fetch Kueue instance")
@@ -886,7 +869,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 				Size:              0,
 			})
 			Expect(genericClient.Create(ctx, lwsWithoutQueue)).To(Succeed(), "Failed to create LeaderWorkerSet")
-			defer testutils.CleanUpObject(ctx, genericClient, lwsWithoutQueue)
+			DeferCleanup(testutils.CleanUpObject, genericClient, lwsWithoutQueue)
 
 			By("verifying workload is created for LeaderWorkerSet without queue name")
 			Eventually(func() error {
@@ -941,9 +924,8 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			testutils.ApplyKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		})
 
-		It("should not manage LeaderWorkerSet without queue name in unlabeled namespace when labelPolicy=None", func() {
+		It("should not manage LeaderWorkerSet without queue name in unlabeled namespace when labelPolicy=None", func(ctx context.Context) {
 			kueueClientset := clients.KueueClient
-			ctx := context.TODO()
 
 			kueueInstance, err := kueueClientset.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred(), "Failed to fetch Kueue instance")
@@ -958,7 +940,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 				Size:              0,
 			})
 			Expect(genericClient.Create(ctx, lwsWithoutQueue)).To(Succeed(), "Failed to create LeaderWorkerSet")
-			defer testutils.CleanUpObject(ctx, genericClient, lwsWithoutQueue)
+			DeferCleanup(testutils.CleanUpObject, genericClient, lwsWithoutQueue)
 
 			By("verifying no workload is created for LeaderWorkerSet in unlabeled namespace")
 			Consistently(func() error {
@@ -999,8 +981,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 
 			testutils.ApplyKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		})
-		It("should expose metrics endpoint with TLS", func() {
-			ctx := context.TODO()
+		It("should expose metrics endpoint with TLS", func(ctx context.Context) {
 			var (
 				err                error
 				podName            = "curl-metrics-test"
@@ -1077,8 +1058,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			dynamicClient = clients.DynamicClient
 		})
 
-		It("should delete Kueue instance and verify cleanup", func() {
-			ctx := context.TODO()
+		It("should delete Kueue instance and verify cleanup", func(ctx context.Context) {
 
 			// First, create some Kueue Custom Resources to test that they are NOT deleted
 			// This addresses OCPBUGS-62254: Kueue uninstall does not delete all Kueue CRs
@@ -1165,7 +1145,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 				Size:              1,
 			})
 			Expect(genericClient.Create(ctx, lws)).To(Succeed(), "Failed to create LeaderWorkerSet")
-			defer testutils.CleanUpObject(ctx, genericClient, lws)
+			DeferCleanup(testutils.CleanUpObject, genericClient, lws)
 
 			var lwsWorkloadName string
 			By("wait for workload to be created for LeaderWorkerSet")
@@ -1188,7 +1168,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			By("create a JobSet in the test namespace")
 			jobset := builder.NewJobSet()
 			Expect(genericClient.Create(ctx, jobset)).To(Succeed(), "Failed to create JobSet")
-			defer testutils.CleanUpObject(ctx, genericClient, jobset)
+			DeferCleanup(testutils.CleanUpObject, genericClient, jobset)
 
 			var jobsetWorkloadName string
 			By("wait for workload to be created for JobSet")
@@ -1405,8 +1385,7 @@ var _ = Describe("Kueue Operator", Label("operator"), Ordered, func() {
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "Resources were not cleaned up properly")
 		})
 
-		It("should redeploy Kueue instance and verify pod is ready", func() {
-			ctx := context.TODO()
+		It("should redeploy Kueue instance and verify pod is ready", func(ctx context.Context) {
 
 			klog.Infof("Redeploying Kueue instance")
 			requiredSS := testutils.NewKueueDefault()

--- a/test/e2e/e2e_preemption_test.go
+++ b/test/e2e/e2e_preemption_test.go
@@ -32,11 +32,6 @@ import (
 )
 
 var _ = Describe("Preemption", Label("preemption"), Ordered, func() {
-	var (
-		labelKey   = testutils.OpenShiftManagedLabel
-		labelValue = trueLabelValue
-	)
-
 	When("Preemption is Fair Sharing", func() {
 		var initialKueueInstance *ssv1.Kueue
 
@@ -58,69 +53,35 @@ var _ = Describe("Preemption", Label("preemption"), Ordered, func() {
 
 		It("should preempt workloads", func(ctx context.Context) {
 			By("Creating Resource Flavor")
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create resource flavor")
-			DeferCleanup(cleanupResourceFlavor)
+			rf := testutils.MustCreateResourceFlavor(ctx)
 
 			By("Creating ClusterQueue, Namespace and LocalQueue for A")
 			cohortName := "fair-sharing-cohort"
-			clusterQueueA, cleanupClusterQueueA, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithCPU("250m").
-				WithMemory("256Mi").
-				WithFlavorName(resourceFlavor.Name).
-				WithCohort(cohortName).
-				WithPreemption(kueuev1beta2.PreemptionPolicyLowerPriority).
-				WithReclaimWithinCohort(kueuev1beta2.PreemptionPolicyLowerPriority).
-				WithBorrowingLimit(corev1.ResourceCPU, "250m").
-				CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create cluster queue A")
-			DeferCleanup(cleanupClusterQueueA)
+			clusterQueueA := testutils.MustCreateClusterQueue(ctx, rf.Name,
+				testutils.NewClusterQueue().
+					WithCPU("250m").
+					WithMemory("256Mi").
+					WithCohort(cohortName).
+					WithPreemption(kueuev1beta2.PreemptionPolicyLowerPriority).
+					WithReclaimWithinCohort(kueuev1beta2.PreemptionPolicyLowerPriority).
+					WithBorrowingLimit(corev1.ResourceCPU, "250m"),
+			)
 
-			namespaceA, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preemption-a-",
-					Labels: map[string]string{
-						labelKey: labelValue,
-					},
-				},
-			}, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(func(ctx context.Context) {
-				testutils.DeleteNamespace(ctx, kubeClient, namespaceA)
-			})
-			localQueueA, cleanupLocalQueueA, err := testutils.NewLocalQueue(namespaceA.Name, "local-queue-a").WithClusterQueue(clusterQueueA.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create local queue A")
-			DeferCleanup(cleanupLocalQueueA)
+			namespaceA := testutils.MustCreateManagedNamespace(ctx, "preemption-a-")
+			localQueueA := testutils.MustCreateLocalQueue(ctx, namespaceA.Name, "local-queue-a", clusterQueueA.Name, nil)
 
 			By("Creating ClusterQueue, Namespace and LocalQueue for B")
-			clusterQueueB, cleanupClusterQueueB, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithCPU("250m").
-				WithMemory("256Mi").
-				WithFlavorName(resourceFlavor.Name).
-				WithCohort(cohortName).
-				WithPreemption(kueuev1beta2.PreemptionPolicyLowerPriority).
-				WithReclaimWithinCohort(kueuev1beta2.PreemptionPolicyAny).
-				CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create cluster queue B")
-			DeferCleanup(cleanupClusterQueueB)
+			clusterQueueB := testutils.MustCreateClusterQueue(ctx, rf.Name,
+				testutils.NewClusterQueue().
+					WithCPU("250m").
+					WithMemory("256Mi").
+					WithCohort(cohortName).
+					WithPreemption(kueuev1beta2.PreemptionPolicyLowerPriority).
+					WithReclaimWithinCohort(kueuev1beta2.PreemptionPolicyAny),
+			)
 
-			namespaceB, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preemption-b-",
-					Labels: map[string]string{
-						labelKey: labelValue,
-					},
-				},
-			}, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(func(ctx context.Context) {
-				testutils.DeleteNamespace(ctx, kubeClient, namespaceB)
-			})
-			localQueueB, cleanupLocalQueueB, err := testutils.NewLocalQueue(namespaceB.Name, "local-queue-b").WithClusterQueue(clusterQueueB.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create local queue B")
-			DeferCleanup(cleanupLocalQueueB)
+			namespaceB := testutils.MustCreateManagedNamespace(ctx, "preemption-b-")
+			localQueueB := testutils.MustCreateLocalQueue(ctx, namespaceB.Name, "local-queue-b", clusterQueueB.Name, nil)
 
 			By("Creating a job on A that borrows resources from the cohort")
 			cleanupBorrowingJob, borrowingJob, err := createCustomJob(ctx, "borrowing-job", namespaceA.Name, localQueueA.Name, "", "500m", "128Mi")

--- a/test/e2e/e2e_preemption_test.go
+++ b/test/e2e/e2e_preemption_test.go
@@ -48,12 +48,12 @@ var _ = Describe("Preemption", Label("preemption"), Ordered, func() {
 
 			By("Updating Kueue configuration to use FairSharing preemption")
 			kueueInstance.Spec.Config.Preemption.PreemptionPolicy = ssv1.PreemptionStrategyFairsharing
-			applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, kueueInstance.Spec.Config, clients)
 		})
 
 		AfterAll(func(ctx context.Context) {
 			By("Restoring initial Kueue configuration")
-			applyKueueConfig(ctx, initialKueueInstance.Spec.Config, kubeClient)
+			testutils.ApplyKueueConfig(ctx, initialKueueInstance.Spec.Config, clients)
 		})
 
 		It("should preempt workloads", func(ctx context.Context) {
@@ -87,7 +87,7 @@ var _ = Describe("Preemption", Label("preemption"), Ordered, func() {
 			}, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespaceA)
+				testutils.DeleteNamespace(ctx, kubeClient, namespaceA)
 			})
 			localQueueA, cleanupLocalQueueA, err := testutils.NewLocalQueue(namespaceA.Name, "local-queue-a").WithClusterQueue(clusterQueueA.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create local queue A")
@@ -116,7 +116,7 @@ var _ = Describe("Preemption", Label("preemption"), Ordered, func() {
 			}, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespaceB)
+				testutils.DeleteNamespace(ctx, kubeClient, namespaceB)
 			})
 			localQueueB, cleanupLocalQueueB, err := testutils.NewLocalQueue(namespaceB.Name, "local-queue-b").WithClusterQueue(clusterQueueB.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create local queue B")

--- a/test/e2e/e2e_scheduling_gate_test.go
+++ b/test/e2e/e2e_scheduling_gate_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Scheduling Gate", Label("scheduling-gate"), Ordered, func() {
 			deploy := builder.NewDeployment()
 			createdDeploy, err := kubeClient.AppsV1().Deployments(testNamespace).Create(ctx, deploy, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpObject(ctx, genericClient, createdDeploy)
+			DeferCleanup(testutils.CleanUpObject, genericClient, createdDeploy)
 
 			By("Waiting for deployment pods to be created")
 			var deploymentPods []corev1.Pod
@@ -219,7 +219,7 @@ var _ = Describe("Scheduling Gate", Label("scheduling-gate"), Ordered, func() {
 			ss := builder.NewStatefulSet()
 			createdSS, err := kubeClient.AppsV1().StatefulSets(testNamespace).Create(ctx, ss, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer testutils.CleanUpObject(ctx, genericClient, createdSS)
+			DeferCleanup(testutils.CleanUpObject, genericClient, createdSS)
 
 			By("Waiting for statefulset pods to be created")
 			var ssPods []corev1.Pod
@@ -289,7 +289,7 @@ var _ = Describe("Scheduling Gate", Label("scheduling-gate"), Ordered, func() {
 				Size:              2,
 			})
 			Expect(genericClient.Create(ctx, lws)).To(Succeed(), "Failed to create LeaderWorkerSet")
-			defer testutils.CleanUpObject(ctx, genericClient, lws)
+			DeferCleanup(testutils.CleanUpObject, genericClient, lws)
 
 			By("Waiting for LeaderWorkerSet pods to be created")
 			var lwsPods []corev1.Pod

--- a/test/e2e/e2e_scheduling_gate_test.go
+++ b/test/e2e/e2e_scheduling_gate_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Scheduling Gate", Label("scheduling-gate"), Ordered, func() {
 				LabelPolicy: ssv1.LabelPolicyQueueName,
 			},
 		}
-		applyKueueConfig(ctx, newConfig, kubeClient)
+		testutils.ApplyKueueConfig(ctx, newConfig, clients)
 
 		// Create namespace with managed label
 		By(fmt.Sprintf("Creating namespace %s with managed label", testNamespace))
@@ -96,7 +96,7 @@ var _ = Describe("Scheduling Gate", Label("scheduling-gate"), Ordered, func() {
 		By("Cleaning up test resources")
 
 		// Delete namespace
-		deleteNamespaceForSchedulingGateTest(ctx, &corev1.Namespace{
+		testutils.DeleteNamespace(ctx, kubeClient, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testNamespace,
 			},
@@ -123,7 +123,7 @@ var _ = Describe("Scheduling Gate", Label("scheduling-gate"), Ordered, func() {
 				},
 			},
 		}
-		applyKueueConfig(ctx, defaultConfig, kubeClient)
+		testutils.ApplyKueueConfig(ctx, defaultConfig, clients)
 	})
 
 	When("workloads are submitted to a non-existent LocalQueue", func() {
@@ -353,9 +353,3 @@ var _ = Describe("Scheduling Gate", Label("scheduling-gate"), Ordered, func() {
 	})
 })
 
-func deleteNamespaceForSchedulingGateTest(ctx context.Context, namespace *corev1.Namespace) {
-	By(fmt.Sprintf("Deleting namespace %s", namespace.Name))
-	err := kubeClient.CoreV1().Namespaces().Delete(ctx, namespace.Name, metav1.DeleteOptions{})
-	Expect(err).NotTo(HaveOccurred())
-	testutils.WaitForAllPodsInNamespaceDeleted(ctx, clients.GenericClient, namespace)
-}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -76,5 +76,5 @@ var _ = BeforeSuite(func() {
 
 	// Deploy the Kueue operand once for all tests
 	By("Deploying Kueue operand for all test suites")
-	Expect(deployOperand()).To(Succeed(), "operand deployment should not fail")
+	Expect(testutils.DeployOperand(clients)).To(Succeed(), "operand deployment should not fail")
 })

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -68,6 +68,7 @@ func TestE2E(t *testing.T) {
 var _ = BeforeSuite(func() {
 	log.SetLogger(zap.New(zap.UseDevMode(true)))
 	clients = testutils.NewTestClients()
+	testutils.InitClients(clients)
 	kubeClient = clients.KubeClient
 	genericClient = clients.GenericClient
 

--- a/test/e2e/e2e_tls_profile_test.go
+++ b/test/e2e/e2e_tls_profile_test.go
@@ -43,7 +43,7 @@ var _ = Describe("TLS Security Profile", Label("tls-profile"), Ordered, func() {
 		isHyperShift         bool
 	)
 
-	BeforeAll(func() {
+	BeforeAll(func(ctx context.Context) {
 		var err error
 		configClient, err = configclientv1.NewForConfig(clients.RestConfig)
 		Expect(err).NotTo(HaveOccurred(), "failed to create OpenShift config client")
@@ -52,22 +52,21 @@ var _ = Describe("TLS Security Profile", Label("tls-profile"), Ordered, func() {
 		Expect(err).NotTo(HaveOccurred(), "failed to detect HyperShift cluster")
 
 		// Save the original TLS profile so we can restore it after tests
-		apiServer, err := configClient.APIServers().Get(context.TODO(), "cluster", metav1.GetOptions{})
+		apiServer, err := configClient.APIServers().Get(ctx, "cluster", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred(), "failed to get APIServer CR")
 		originalTLSProfile = apiServer.Spec.TLSSecurityProfile
 
 		// Capture current ConfigMap state
 		configMap, err := kubeClient.CoreV1().ConfigMaps(testutils.OperatorNamespace).Get(
-			context.TODO(), "kueue-manager-config", metav1.GetOptions{})
+			ctx, "kueue-manager-config", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred(), "failed to get kueue-manager-config ConfigMap")
 		initialConfigMapData = configMap.Data["controller_manager_config.yaml"]
 	})
 
-	AfterAll(func() {
+	AfterAll(func(ctx context.Context) {
 		if isHyperShift {
 			return
 		}
-		ctx := context.TODO()
 		By("Restoring original TLS security profile")
 		err := updateAPIServerTLSProfile(ctx, configClient, originalTLSProfile)
 		Expect(err).NotTo(HaveOccurred(), "failed to restore original TLS profile")

--- a/test/e2e/e2e_visibility_on_demand_test.go
+++ b/test/e2e/e2e_visibility_on_demand_test.go
@@ -91,7 +91,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 		})
 		AfterAll(func(ctx context.Context) {
 			cleanupLocalQueue()
-			deleteNamespace(ctx, ns)
+			testutils.DeleteNamespace(ctx, kubeClient,ns)
 			cleanupClusterQueue()
 			cleanupResourceFlavor()
 		})
@@ -203,7 +203,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			}, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespaceA)
+				testutils.DeleteNamespace(ctx, kubeClient,namespaceA)
 			})
 
 			localQueueA, cleanupLocalQueueA, err := testutils.NewLocalQueue(namespaceA.Name, "local-queue-a").WithClusterQueue(clusterQueueA.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
@@ -220,7 +220,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			}, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespaceB)
+				testutils.DeleteNamespace(ctx, kubeClient,namespaceB)
 			})
 			localQueueB, cleanupLocalQueueB, err := testutils.NewLocalQueue(namespaceB.Name, "local-queue-b").WithClusterQueue(clusterQueueB.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create local queue")
@@ -260,7 +260,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			By("Creating testing data")
 			cleanupJobBlockerA, jobBlockerA, err := createCustomJob(ctx, "job-blocker", namespaceA.Name, localQueueA.Name, highPriorityClass.Name, "2", "1Gi")
 			Expect(err).NotTo(HaveOccurred(), "Failed to create blocker job")
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespaceA.Name, string(jobBlockerA.UID))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespaceA.Name, string(jobBlockerA.UID))
 			DeferCleanup(cleanupJobBlockerA)
 			cleanupJobHighA, jobHighA, err := createCustomJob(ctx, "job-high-a", namespaceA.Name, localQueueA.Name, highPriorityClass.Name, "1", "512Mi")
 			Expect(err).NotTo(HaveOccurred(), "Failed to create high priority job")
@@ -273,7 +273,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			DeferCleanup(cleanupJobLowA)
 			cleanupJobBlockerB, jobBlockerB, err := createCustomJob(ctx, "job-blocker-b", namespaceB.Name, localQueueB.Name, highPriorityClass.Name, "2", "1Gi")
 			Expect(err).NotTo(HaveOccurred(), "Failed to create blocker job")
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespaceB.Name, string(jobBlockerB.UID))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespaceB.Name, string(jobBlockerB.UID))
 			DeferCleanup(cleanupJobBlockerB)
 			cleanupJobHighB, jobHighB, err := createCustomJob(ctx, "job-high-b", namespaceB.Name, localQueueB.Name, highPriorityClass.Name, "1", "512Mi")
 			Expect(err).NotTo(HaveOccurred(), "Failed to create blocker job")
@@ -332,10 +332,10 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			Expect(clusterPendingWorkloadsB.Items[0].Priority).To(Equal(int32(100)), "First workload should have high priority (100)")
 
 			By("All workloads should have been created")
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespaceA.Name, string(jobHighA.UID))
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespaceA.Name, string(jobMediumA.UID))
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespaceA.Name, string(jobLowA.UID))
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespaceB.Name, string(jobHighB.UID))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespaceA.Name, string(jobHighA.UID))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespaceA.Name, string(jobMediumA.UID))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespaceA.Name, string(jobLowA.UID))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespaceB.Name, string(jobHighB.UID))
 
 			By("Verifying pending workloads lists are empty")
 			Eventually(func() error {
@@ -396,7 +396,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			}, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespaceA)
+				testutils.DeleteNamespace(ctx, kubeClient,namespaceA)
 			})
 
 			localQueueA, cleanupLocalQueueA, err := testutils.NewLocalQueue(namespaceA.Name, "local-queue-a").WithClusterQueue(clusterQueue.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
@@ -414,7 +414,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			}, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespaceB)
+				testutils.DeleteNamespace(ctx, kubeClient,namespaceB)
 			})
 
 			localQueueB, cleanupLocalQueueB, err := testutils.NewLocalQueue(namespaceB.Name, "local-queue-b").WithClusterQueue(clusterQueue.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
@@ -453,14 +453,14 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			By("Creating testing data")
 			cleanupJobBlockerA, jobBlockerA, err := createCustomJob(ctx, "job-blocker", namespaceA.Name, localQueueA.Name, highPriorityClass.Name, "2", "1Gi")
 			Expect(err).NotTo(HaveOccurred(), "Failed to create blocker job")
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespaceA.Name, string(jobBlockerA.UID))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespaceA.Name, string(jobBlockerA.UID))
 			DeferCleanup(cleanupJobBlockerA)
 			cleanupJobLowA, jobHighA, err := createCustomJob(ctx, "job-high-a", namespaceA.Name, localQueueA.Name, lowPriorityClass.Name, "1", "512Mi")
 			Expect(err).NotTo(HaveOccurred(), "Failed to create high priority job")
 			DeferCleanup(cleanupJobLowA)
 			cleanupJobBlockerB, jobBlockerB, err := createCustomJob(ctx, "job-blocker-b", namespaceB.Name, localQueueB.Name, highPriorityClass.Name, "2", "1Gi")
 			Expect(err).NotTo(HaveOccurred(), "Failed to create blocker job")
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespaceB.Name, string(jobBlockerB.UID))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespaceB.Name, string(jobBlockerB.UID))
 			DeferCleanup(cleanupJobBlockerB)
 			cleanupJobLowB, jobLowB, err := createCustomJob(ctx, "job-low-b", namespaceB.Name, localQueueB.Name, lowPriorityClass.Name, "1", "512Mi")
 			Expect(err).NotTo(HaveOccurred(), "Failed to create low priority job")
@@ -558,8 +558,8 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue(), "Expected a Forbidden error when user from namespaceA tries to access LocalQueue in namespaceB")
 
 			By("All workloads should have been created")
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespaceA.Name, string(jobHighA.UID))
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespaceB.Name, string(jobLowB.UID))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespaceA.Name, string(jobHighA.UID))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespaceB.Name, string(jobLowB.UID))
 
 			By("Verifying pending workloads lists are empty")
 			Eventually(func() error {
@@ -603,7 +603,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			}, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespace)
+				testutils.DeleteNamespace(ctx, kubeClient,namespace)
 			})
 
 			localQueue, cleanupLocalQueue, err := testutils.NewLocalQueue(namespace.Name, "local-queue").WithClusterQueue(clusterQueue.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
@@ -708,7 +708,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			}, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespaceA)
+				testutils.DeleteNamespace(ctx, kubeClient,namespaceA)
 			})
 
 			localQueueA, cleanupLocalQueueA, err := testutils.NewLocalQueue(namespaceA.Name, "local-queue-a").WithClusterQueue(clusterQueue.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
@@ -725,7 +725,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			}, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespaceB)
+				testutils.DeleteNamespace(ctx, kubeClient,namespaceB)
 			})
 
 			localQueueB, cleanupLocalQueueB, err := testutils.NewLocalQueue(namespaceB.Name, "local-queue-b").WithClusterQueue(clusterQueue.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
@@ -787,7 +787,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			})
 			blockerLWS.Name = "lws-blocker-a"
 			Expect(genericClient.Create(ctx, blockerLWS)).To(Succeed(), "Failed to create blocker LWS")
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespaceA.Name, string(blockerLWS.GetUID()))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespaceA.Name, string(blockerLWS.GetUID()))
 
 			By("Waiting for blocker LWS pods to be created")
 			Eventually(func() error {
@@ -902,7 +902,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			}, testutils.DeletionTime, testutils.DeletionPoll).Should(Succeed(), "Blocker LWS pods were not deleted")
 
 			By("Verifying high priority workload is admitted")
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespaceB.Name, string(highLWS.GetUID()))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespaceB.Name, string(highLWS.GetUID()))
 
 			By("Verifying high priority LWS pods are running after admission")
 			Eventually(func() error {
@@ -924,7 +924,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "High priority LWS pods should be running after admission")
 
 			By("Verifying medium priority workload is admitted")
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespaceA.Name, string(mediumLWS.GetUID()))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespaceA.Name, string(mediumLWS.GetUID()))
 
 			By("Verifying medium priority LWS pods are running after admission")
 			Eventually(func() error {
@@ -987,7 +987,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			}, testutils.DeletionTime, testutils.DeletionPoll).Should(Succeed(), "Medium priority LWS pods were not deleted")
 
 			By("Verifying low priority workload is admitted")
-			verifyWorkloadCreated(clients.UpstreamKueueClient, namespaceA.Name, string(lowLWS.GetUID()))
+			testutils.VerifyWorkloadCreated(ctx, clients.UpstreamKueueClient,namespaceA.Name, string(lowLWS.GetUID()))
 
 			By("Verifying low priority LWS pods are running after admission")
 			Eventually(func() error {
@@ -1039,7 +1039,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			}, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespace)
+				testutils.DeleteNamespace(ctx, kubeClient,namespace)
 			})
 
 			localQueue, cleanupLocalQueue, err := testutils.NewLocalQueue(namespace.Name, "local-queue").WithClusterQueue(clusterQueue.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)

--- a/test/e2e/e2e_visibility_on_demand_test.go
+++ b/test/e2e/e2e_visibility_on_demand_test.go
@@ -1074,7 +1074,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			builder := testutils.NewTestResourceBuilder(namespace.Name, localQueue.Name)
 			jobset := builder.NewJobSet()
 			Expect(genericClient.Create(ctx, jobset)).To(Succeed(), "Failed to create jobset")
-			defer testutils.CleanUpObject(ctx, genericClient, jobset)
+			DeferCleanup(testutils.CleanUpObject, genericClient, jobset)
 
 			By("Verifying all pending workloads are created")
 			verifyWorkloadCreatedNotAdmitted(clients.UpstreamKueueClient, namespace.Name, jobset.GetUID())

--- a/test/e2e/testutils/dra_helpers.go
+++ b/test/e2e/testutils/dra_helpers.go
@@ -49,7 +49,10 @@ const (
 // SetDRAJobCPU reduces CPU request for DRA test jobs to fit on GPU nodes
 // where NVIDIA operator daemonsets consume most of the CPU budget.
 func SetDRAJobCPU(job *batchv1.Job) {
-	job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("100m")
+	Expect(job.Spec.Template.Spec.Containers).NotTo(BeEmpty(), "job must have at least one container")
+	c := &job.Spec.Template.Spec.Containers[0]
+	Expect(c.Resources.Requests).NotTo(BeNil(), "container resource requests must be initialized by the builder")
+	c.Resources.Requests[corev1.ResourceCPU] = resource.MustParse("100m")
 }
 
 // NewDRAResourceClaimTemplate creates a ResourceClaimTemplate that requests
@@ -83,6 +86,7 @@ func NewDRAJob(builder *TestResourceBuilder, name, templateName, queueName strin
 	job := builder.NewJob()
 	SetDRAJobCPU(job)
 	job.Name = name
+	Expect(job.Labels).NotTo(BeNil(), "job labels must be initialized by the builder")
 	job.Labels[QueueLabel] = queueName
 	job.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "echo Hello Kueue; sleep 10"}
 	job.Spec.Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
@@ -94,8 +98,11 @@ func NewDRAJob(builder *TestResourceBuilder, name, templateName, queueName strin
 
 // AddDRAClaims adds DRA ResourceClaim references and reduces CPU request on a PodSpec.
 func AddDRAClaims(spec *corev1.PodSpec, templateName string) {
-	spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("100m")
-	spec.Containers[0].Resources.Claims = []corev1.ResourceClaim{{Name: "gpu-claim"}}
+	Expect(spec.Containers).NotTo(BeEmpty(), "pod spec must have at least one container")
+	c := &spec.Containers[0]
+	Expect(c.Resources.Requests).NotTo(BeNil(), "container resource requests must be initialized by the builder")
+	c.Resources.Requests[corev1.ResourceCPU] = resource.MustParse("100m")
+	c.Resources.Claims = []corev1.ResourceClaim{{Name: "gpu-claim"}}
 	spec.ResourceClaims = []corev1.PodResourceClaim{
 		{Name: "gpu-claim", ResourceClaimTemplateName: ptr.To(templateName)},
 	}

--- a/test/e2e/testutils/dra_helpers.go
+++ b/test/e2e/testutils/dra_helpers.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
+	upstreamkueueclient "sigs.k8s.io/kueue/client-go/clientset/versioned"
+)
+
+const (
+	DRADeviceClassName     = "gpu.nvidia.com"
+	DRALogicalResource     = "nvidia-gpu"
+	DRATestNamespacePrefix = "kueue-dra-test-"
+	DRALocalQueueName      = "dra-test-queue"
+	DRAGPUDeviceType       = "gpu"
+
+	DRAResourceSliceTimeout = 60 * time.Second
+	DRAResourceSlicePoll    = 2 * time.Second
+	DRASettleTimeout        = 30 * time.Second
+	DRAQuotaCheckTimeout    = 15 * time.Second
+)
+
+// SetDRAJobCPU reduces CPU request for DRA test jobs to fit on GPU nodes
+// where NVIDIA operator daemonsets consume most of the CPU budget.
+func SetDRAJobCPU(job *batchv1.Job) {
+	job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("100m")
+}
+
+// NewDRAResourceClaimTemplate creates a ResourceClaimTemplate that requests
+// the given number of GPUs from the gpu.nvidia.com DeviceClass.
+func NewDRAResourceClaimTemplate(name, namespace string, gpuCount int64) *resourcev1.ResourceClaimTemplate {
+	return &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: resourcev1.ResourceClaimTemplateSpec{
+			Spec: resourcev1.ResourceClaimSpec{
+				Devices: resourcev1.DeviceClaim{
+					Requests: []resourcev1.DeviceRequest{
+						{
+							Name: "gpu-req",
+							Exactly: &resourcev1.ExactDeviceRequest{
+								DeviceClassName: DRADeviceClassName,
+								Count:           gpuCount,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// NewDRAJob creates a Job with DRA ResourceClaim configuration for the given template.
+func NewDRAJob(builder *TestResourceBuilder, name, templateName, queueName string) *batchv1.Job {
+	job := builder.NewJob()
+	SetDRAJobCPU(job)
+	job.Name = name
+	job.Labels[QueueLabel] = queueName
+	job.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "echo Hello Kueue; sleep 10"}
+	job.Spec.Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
+		{Name: "gpu", ResourceClaimTemplateName: ptr.To(templateName)},
+	}
+	job.Spec.Template.Spec.Containers[0].Resources.Claims = []corev1.ResourceClaim{{Name: "gpu"}}
+	return job
+}
+
+// AddDRAClaims adds DRA ResourceClaim references and reduces CPU request on a PodSpec.
+func AddDRAClaims(spec *corev1.PodSpec, templateName string) {
+	spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("100m")
+	spec.Containers[0].Resources.Claims = []corev1.ResourceClaim{{Name: "gpu-claim"}}
+	spec.ResourceClaims = []corev1.PodResourceClaim{
+		{Name: "gpu-claim", ResourceClaimTemplateName: ptr.To(templateName)},
+	}
+}
+
+// WaitForPodWorkloadAdmitted waits until a pod matching the label selector has
+// a corresponding admitted Kueue workload, correlating via OwnerReferences.
+func WaitForPodWorkloadAdmitted(ctx context.Context, kubeClient *kubernetes.Clientset, kueueClient *upstreamkueueclient.Clientset, namespace, labelSelector string) {
+	Eventually(func() error {
+		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+		if err != nil {
+			return err
+		}
+		if len(pods.Items) == 0 {
+			return fmt.Errorf("no pods found with label %s", labelSelector)
+		}
+		ownerUIDs := make(map[types.UID]bool)
+		for _, pod := range pods.Items {
+			for _, ref := range pod.OwnerReferences {
+				ownerUIDs[ref.UID] = true
+			}
+			ownerUIDs[pod.UID] = true
+		}
+		workloads, err := kueueClient.KueueV1beta2().Workloads(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		for _, wl := range workloads.Items {
+			if wl.Status.Admission == nil {
+				continue
+			}
+			for _, ref := range wl.OwnerReferences {
+				if ownerUIDs[ref.UID] {
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("no admitted workload correlated to pods with label %s", labelSelector)
+	}, OperatorReadyTime, OperatorPoll).Should(Succeed())
+}
+
+// VerifyResourceClaimAllocated verifies that at least one ResourceClaim
+// in the namespace is in the "allocated,reserved" state.
+func VerifyResourceClaimAllocated(ctx context.Context, kubeClient *kubernetes.Clientset, namespace string) {
+	Eventually(func(g Gomega) {
+		claims, err := kubeClient.ResourceV1().ResourceClaims(namespace).List(ctx, metav1.ListOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(claims.Items).NotTo(BeEmpty(), "no ResourceClaims found in namespace %s", namespace)
+		claim := claims.Items[0]
+		g.Expect(claim.Status.Allocation).NotTo(BeNil(), "ResourceClaim not allocated in namespace %s", namespace)
+		g.Expect(claim.Status.ReservedFor).NotTo(BeEmpty(), "ResourceClaim not reserved in namespace %s", namespace)
+	}, OperatorReadyTime, OperatorPoll).Should(Succeed())
+}
+
+// VerifyNoResourceClaims verifies that no ResourceClaims created after the given
+// timestamp exist in the namespace.
+func VerifyNoResourceClaims(ctx context.Context, kubeClient *kubernetes.Clientset, namespace string, createdAfter metav1.Time) {
+	Consistently(func(g Gomega) {
+		claims, err := kubeClient.ResourceV1().ResourceClaims(namespace).List(ctx, metav1.ListOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		var filtered []resourcev1.ResourceClaim
+		for _, c := range claims.Items {
+			if c.CreationTimestamp.After(createdAfter.Time) {
+				filtered = append(filtered, c)
+			}
+		}
+		g.Expect(filtered).To(BeEmpty(), "expected no ResourceClaims after %v in namespace %s", createdAfter.Time, namespace)
+	}, ConsistentlyTimeout, ConsistentlyPoll).Should(Succeed())
+}
+
+// CountGPUsFromResourceSlices counts GPU devices (type="gpu") from the
+// gpu.nvidia.com driver across all ResourceSlices. Filters by the "type"
+// device attribute to exclude non-GPU devices like MIG partitions.
+func CountGPUsFromResourceSlices(ctx context.Context, kubeClient *kubernetes.Clientset) (int, error) {
+	slices, err := kubeClient.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, s := range slices.Items {
+		if s.Spec.Driver == DRADeviceClassName {
+			for _, d := range s.Spec.Devices {
+				if typeAttr, ok := d.Attributes["type"]; ok {
+					if typeAttr.StringValue != nil && *typeAttr.StringValue == DRAGPUDeviceType {
+						count++
+					}
+				}
+			}
+		}
+	}
+	return count, nil
+}

--- a/test/e2e/testutils/operator_helpers.go
+++ b/test/e2e/testutils/operator_helpers.go
@@ -184,12 +184,14 @@ func WaitForWebhookReady(ctx context.Context, kubeClient *kubernetes.Clientset) 
 		job, err := kubeClient.BatchV1().Jobs(OperatorNamespace).Create(ctx, testJob, metav1.CreateOptions{})
 		if err == nil {
 			klog.Infof("Webhook test successful, cleaning up test job: %s", job.Name)
-			_ = kubeClient.BatchV1().Jobs(OperatorNamespace).Delete(ctx, job.Name, metav1.DeleteOptions{
+			if delErr := kubeClient.BatchV1().Jobs(OperatorNamespace).Delete(ctx, job.Name, metav1.DeleteOptions{
 				PropagationPolicy: func() *metav1.DeletionPropagation {
 					p := metav1.DeletePropagationBackground
 					return &p
 				}(),
-			})
+			}); delErr != nil && !apierrors.IsNotFound(delErr) {
+				klog.Warningf("Failed to delete webhook probe job %s: %v", job.Name, delErr)
+			}
 			consecutiveSuccesses++
 			if consecutiveSuccesses >= WebhookRequiredSuccesses {
 				klog.Infof("Webhook stable after %d consecutive successes", consecutiveSuccesses)

--- a/test/e2e/testutils/operator_helpers.go
+++ b/test/e2e/testutils/operator_helpers.go
@@ -1,0 +1,438 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	ssv1 "github.com/openshift/kueue-operator/pkg/apis/kueueoperator/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	kueuev1beta2 "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	upstreamkueueclient "sigs.k8s.io/kueue/client-go/clientset/versioned"
+)
+
+const (
+	WebhookStabilityPoll     = 3 * time.Second
+	WebhookRequiredSuccesses = 3
+	ConfigRestoreTimeout     = 30 * time.Second
+	ConfigRestorePoll        = 2 * time.Second
+)
+
+// ApplyKueueConfig updates the Kueue CR config and waits for the operand to be
+// redeployed and healthy.
+func ApplyKueueConfig(ctx context.Context, config ssv1.KueueConfiguration, tc *TestClients) {
+	By("Fetching Kueue Instance")
+	kueueInstance, err := tc.KueueClient.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred(), "Failed to fetch Kueue instance")
+
+	configChanged := !reflect.DeepEqual(kueueInstance.Spec.Config, config)
+
+	initialDeployment, err := tc.KubeClient.AppsV1().Deployments(OperatorNamespace).Get(ctx, "kueue-controller-manager", metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred(), "Failed to fetch kueue-controller-manager deployment")
+	initialResourceVersion := initialDeployment.ResourceVersion
+
+	By("Updating Kueue config (with conflict retry)")
+	Eventually(func() error {
+		instance, err := tc.KueueClient.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to fetch Kueue instance: %w", err)
+		}
+		configChanged = !reflect.DeepEqual(instance.Spec.Config, config)
+		instance.Spec.Config = config
+		_, err = tc.KueueClient.KueueV1().Kueues().Update(ctx, instance, metav1.UpdateOptions{})
+		return err
+	}, ConfigRestoreTimeout, ConfigRestorePoll).Should(Succeed(), "Failed to update Kueue config")
+
+	if configChanged {
+		By(fmt.Sprintf("Waiting for kueue-controller-manager resource version to change from %s", initialResourceVersion))
+		Eventually(func() error {
+			dep, err := tc.KubeClient.AppsV1().Deployments(OperatorNamespace).Get(ctx, "kueue-controller-manager", metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to fetch manager deployment: %v", err)
+			}
+			if dep.ResourceVersion == initialResourceVersion {
+				return fmt.Errorf("deployment resource version has not changed yet (still %s)", initialResourceVersion)
+			}
+			return nil
+		}, OperatorReadyTime, OperatorPoll).Should(Succeed(), "kueue-controller-manager deployment resource version did not change")
+	} else {
+		By("Skipping deployment update wait - config unchanged")
+	}
+
+	WaitForManagerReady(ctx, tc.KubeClient)
+
+	By("Waiting for webhook configurations to exist")
+	Eventually(func() error {
+		_, err := tc.KubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, "kueue-mutating-webhook-configuration", metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("mutating webhook configuration not found: %w", err)
+		}
+		_, err = tc.KubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, "kueue-validating-webhook-configuration", metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("validating webhook configuration not found: %w", err)
+		}
+		return nil
+	}, OperatorReadyTime, OperatorPoll).Should(Succeed(), "webhook configurations not found")
+
+	WaitForWebhookReady(ctx, tc.KubeClient)
+
+	By("Verifying kueue CRDs are servable")
+	Eventually(func() error {
+		_, err := tc.UpstreamKueueClient.KueueV1beta2().ClusterQueues().List(ctx, metav1.ListOptions{Limit: 1})
+		return err
+	}, OperatorReadyTime, OperatorPoll).Should(Succeed(), "kueue CRDs not servable after reconfiguration")
+}
+
+// WaitForManagerReady waits for the kueue-controller-manager deployment to have
+// all replicas ready.
+func WaitForManagerReady(ctx context.Context, kubeClient *kubernetes.Clientset) {
+	Eventually(func() error {
+		dep, err := kubeClient.AppsV1().Deployments(OperatorNamespace).Get(ctx, "kueue-controller-manager", metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to fetch manager deployment: %v", err)
+		}
+		By(fmt.Sprintf("Checking if deployment replicas: %v matches amount of ready replicas: %v", dep.Status.Replicas, dep.Status.ReadyReplicas))
+		if dep.Status.ReadyReplicas == dep.Status.Replicas {
+			return nil
+		}
+		return fmt.Errorf("deployment is not ready")
+	}, OperatorReadyTime, OperatorPoll).Should(Succeed(), "kueue-controller-manager deployment failed to be ready")
+}
+
+// WaitForWebhookReady waits for the webhook to be responding by creating test
+// jobs and checking for consecutive successes.
+func WaitForWebhookReady(ctx context.Context, kubeClient *kubernetes.Clientset) {
+	By("Waiting for webhook to handle requests successfully")
+
+	consecutiveSuccesses := 0
+
+	Eventually(func() error {
+		endpointSlices, err := kubeClient.DiscoveryV1().EndpointSlices(OperatorNamespace).List(
+			ctx,
+			metav1.ListOptions{
+				LabelSelector: "kubernetes.io/service-name=kueue-webhook-service",
+			},
+		)
+		if err != nil {
+			consecutiveSuccesses = 0
+			return fmt.Errorf("webhook service endpointslices not found: %w", err)
+		}
+
+		readyEndpointCount := 0
+		for _, slice := range endpointSlices.Items {
+			for _, endpoint := range slice.Endpoints {
+				if endpoint.Conditions.Ready != nil && *endpoint.Conditions.Ready {
+					readyEndpointCount++
+				}
+			}
+		}
+		if readyEndpointCount < 2 {
+			consecutiveSuccesses = 0
+			return fmt.Errorf("webhook service has %d ready endpoints, need 2", readyEndpointCount)
+		}
+
+		testJob := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "webhook-test-",
+				Namespace:    OperatorNamespace,
+			},
+			Spec: batchv1.JobSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						RestartPolicy: corev1.RestartPolicyNever,
+						Containers: []corev1.Container{
+							{
+								Name:    "test",
+								Image:   "busybox",
+								Command: []string{"true"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		job, err := kubeClient.BatchV1().Jobs(OperatorNamespace).Create(ctx, testJob, metav1.CreateOptions{})
+		if err == nil {
+			klog.Infof("Webhook test successful, cleaning up test job: %s", job.Name)
+			_ = kubeClient.BatchV1().Jobs(OperatorNamespace).Delete(ctx, job.Name, metav1.DeleteOptions{
+				PropagationPolicy: func() *metav1.DeletionPropagation {
+					p := metav1.DeletePropagationBackground
+					return &p
+				}(),
+			})
+			consecutiveSuccesses++
+			if consecutiveSuccesses >= WebhookRequiredSuccesses {
+				klog.Infof("Webhook stable after %d consecutive successes", consecutiveSuccesses)
+				return nil
+			}
+			klog.Infof("Webhook success %d/%d", consecutiveSuccesses, WebhookRequiredSuccesses)
+			return fmt.Errorf("waiting for webhook stability (%d/%d successes)", consecutiveSuccesses, WebhookRequiredSuccesses)
+		}
+
+		consecutiveSuccesses = 0
+
+		if strings.Contains(err.Error(), "failed calling webhook") ||
+			strings.Contains(err.Error(), "failed to call webhook") ||
+			strings.Contains(err.Error(), "context deadline exceeded") ||
+			strings.Contains(err.Error(), "connection refused") {
+			klog.Infof("Webhook not ready yet: %v", err)
+			return fmt.Errorf("webhook not responding: %w", err)
+		}
+
+		klog.Infof("Webhook is responding (returned error: %v)", err)
+		consecutiveSuccesses++
+		if consecutiveSuccesses >= WebhookRequiredSuccesses {
+			klog.Infof("Webhook stable after %d consecutive successes", consecutiveSuccesses)
+			return nil
+		}
+		klog.Infof("Webhook success %d/%d", consecutiveSuccesses, WebhookRequiredSuccesses)
+		return fmt.Errorf("waiting for webhook stability (%d/%d successes)", consecutiveSuccesses, WebhookRequiredSuccesses)
+	}, OperatorReadyTime, WebhookStabilityPoll).Should(Succeed(), "webhook failed to respond to requests")
+}
+
+// DeployOperand creates the Kueue CR, waits for the operand to be running,
+// CRDs to be established, and webhooks to be ready.
+func DeployOperand(tc *TestClients) error {
+	ctx, cancelFnc := context.WithCancel(context.TODO())
+	defer cancelFnc()
+
+	Eventually(func() error {
+		klog.Infof("Creating Kueue instance")
+		requiredSS := NewKueueDefault()
+		_, err := tc.KueueClient.KueueV1().Kueues().Create(ctx, requiredSS.GetKueue(), metav1.CreateOptions{})
+		if err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return nil
+			}
+			return err
+		}
+		return nil
+	}, OperatorReadyTime, OperatorPoll).Should(Succeed(), "Kueue instance should be deployed")
+
+	Eventually(func() error {
+		podItems, err := tc.KubeClient.CoreV1().Pods(OperatorNamespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to list pods: %v", err)
+		}
+		for _, pod := range podItems.Items {
+			if !strings.HasPrefix(pod.Name, "kueue-controller-manager") {
+				continue
+			}
+			klog.Infof("Checking pod: %v, phase: %v, deletionTS: %v\n", pod.Name, pod.Status.Phase, pod.GetDeletionTimestamp())
+			if pod.Status.Phase == corev1.PodRunning && pod.GetDeletionTimestamp() == nil &&
+				len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].Ready {
+				return nil
+			}
+		}
+		return fmt.Errorf("pod is not ready")
+	}, OperatorReadyTime, OperatorPoll).Should(Succeed(), "kueue pod failed to be ready")
+
+	By("Waiting for all Kueue CRDs to be registered")
+	requiredCRDs := []string{
+		"clusterqueues.kueue.x-k8s.io",
+		"cohorts.kueue.x-k8s.io",
+		"localqueues.kueue.x-k8s.io",
+		"multikueueconfigs.kueue.x-k8s.io",
+		"provisioningrequestconfigs.kueue.x-k8s.io",
+		"resourceflavors.kueue.x-k8s.io",
+		"topologies.kueue.x-k8s.io",
+		"workloadpriorityclasses.kueue.x-k8s.io",
+		"workloads.kueue.x-k8s.io",
+	}
+
+	Eventually(func() error {
+		crdList, err := tc.APIExtClient.CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to list CRDs: %w", err)
+		}
+
+		foundCRDs := make(map[string]bool)
+		for _, crd := range crdList.Items {
+			foundCRDs[crd.Name] = true
+		}
+
+		var missingCRDs []string
+		for _, requiredCRD := range requiredCRDs {
+			if !foundCRDs[requiredCRD] {
+				missingCRDs = append(missingCRDs, requiredCRD)
+			}
+		}
+
+		if len(missingCRDs) > 0 {
+			return fmt.Errorf("missing Kueue CRDs: %v", missingCRDs)
+		}
+
+		for _, requiredCRD := range requiredCRDs {
+			crd, err := tc.APIExtClient.CustomResourceDefinitions().Get(ctx, requiredCRD, metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to get CRD %s: %w", requiredCRD, err)
+			}
+
+			established := false
+			for _, condition := range crd.Status.Conditions {
+				if condition.Type == apiextensionsv1.Established && condition.Status == apiextensionsv1.ConditionTrue {
+					established = true
+					break
+				}
+			}
+
+			if !established {
+				return fmt.Errorf("CRD %s is not established yet", requiredCRD)
+			}
+		}
+
+		klog.Infof("All %d Kueue CRDs are registered and established", len(requiredCRDs))
+		return nil
+	}, OperatorReadyTime, OperatorPoll).Should(Succeed(), "Kueue CRDs failed to be registered")
+
+	WaitForWebhookReady(ctx, tc.KubeClient)
+
+	return nil
+}
+
+// RestoreKueueConfig restores a Kueue CR config with retry on resourceVersion
+// conflicts and waits for the operand to be ready.
+func RestoreKueueConfig(ctx context.Context, config ssv1.KueueConfiguration, tc *TestClients) {
+	initialDeployment, err := tc.KubeClient.AppsV1().Deployments(OperatorNamespace).Get(ctx, "kueue-controller-manager", metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred(), "Failed to fetch kueue-controller-manager deployment before restore")
+	initialResourceVersion := initialDeployment.ResourceVersion
+
+	By("Restoring Kueue config (with conflict retry)")
+	Eventually(func() error {
+		instance, err := tc.KueueClient.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to fetch Kueue instance: %w", err)
+		}
+		instance.Spec.Config = config
+		_, err = tc.KueueClient.KueueV1().Kueues().Update(ctx, instance, metav1.UpdateOptions{})
+		return err
+	}, ConfigRestoreTimeout, ConfigRestorePoll).Should(Succeed(), "Failed to restore Kueue config")
+
+	By("Waiting for kueue-controller-manager deployment to be updated after config restore")
+	Eventually(func() error {
+		dep, err := tc.KubeClient.AppsV1().Deployments(OperatorNamespace).Get(ctx, "kueue-controller-manager", metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to fetch manager deployment: %w", err)
+		}
+		if dep.ResourceVersion == initialResourceVersion {
+			return fmt.Errorf("deployment resource version has not changed yet (still %s)", initialResourceVersion)
+		}
+		return nil
+	}, OperatorReadyTime, OperatorPoll).Should(Succeed(), "kueue-controller-manager deployment resource version did not change after restore")
+
+	WaitForManagerReady(ctx, tc.KubeClient)
+}
+
+// FetchWorkload waits for a Kueue workload matching the given job UID to exist.
+func FetchWorkload(ctx context.Context, kueueClient *upstreamkueueclient.Clientset, namespace, uid string) {
+	Eventually(func() error {
+		workloads, err := kueueClient.KueueV1beta2().Workloads(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("kueue.x-k8s.io/job-uid=%s", uid),
+		})
+		if err != nil {
+			return err
+		}
+		if len(workloads.Items) == 0 {
+			return fmt.Errorf("no workload found")
+		}
+		return nil
+	}, OperatorReadyTime, OperatorPoll).Should(Succeed())
+}
+
+// VerifyWorkloadCreated waits for a Kueue workload matching the given UID to
+// be created and admitted, returning the workload name.
+func VerifyWorkloadCreated(ctx context.Context, kueueClient *upstreamkueueclient.Clientset, namespace, uid string) string {
+	By(fmt.Sprintf("verifying workload created in namespace %s and uid %s", namespace, uid))
+	var workload *kueuev1beta2.Workload
+	Eventually(func() error {
+		workloads, err := kueueClient.KueueV1beta2().Workloads(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("kueue.x-k8s.io/job-uid=%s", uid),
+		})
+		if err != nil {
+			return err
+		}
+		if len(workloads.Items) > 0 {
+			workload = &workloads.Items[0]
+			return nil
+		}
+
+		allWorkloads, err := kueueClient.KueueV1beta2().Workloads(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+
+		for _, wl := range allWorkloads.Items {
+			for _, ownerRef := range wl.OwnerReferences {
+				if ownerRef.UID == types.UID(uid) {
+					workload = &wl
+					return nil
+				}
+			}
+		}
+
+		return fmt.Errorf("no workload found in namespace %s with uid %s", namespace, uid)
+	}, OperatorReadyTime, OperatorPoll).Should(Succeed())
+
+	Eventually(func() error {
+		updatedWorkload, err := kueueClient.KueueV1beta2().Workloads(namespace).Get(ctx, workload.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if apimeta.IsStatusConditionTrue(updatedWorkload.Status.Conditions, kueuev1beta2.WorkloadAdmitted) ||
+			apimeta.IsStatusConditionTrue(updatedWorkload.Status.Conditions, kueuev1beta2.WorkloadFinished) {
+			return nil
+		}
+		return fmt.Errorf("workload %s/%s not admitted or finished", namespace, workload.Name)
+	}, OperatorReadyTime, OperatorPoll).Should(Succeed())
+	return workload.Name
+}
+
+// DeleteNamespace deletes a namespace and waits for it to be gone.
+func DeleteNamespace(ctx context.Context, kubeClient *kubernetes.Clientset, namespace *corev1.Namespace) {
+	if namespace == nil {
+		return
+	}
+	By(fmt.Sprintf("Deleting namespace %s", namespace.Name))
+	err := kubeClient.CoreV1().Namespaces().Delete(ctx, namespace.Name, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(func() error {
+		_, err := kubeClient.CoreV1().Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("namespace %s still exists", namespace.Name)
+	}, DeletionTime, DeletionPoll).Should(Succeed())
+}

--- a/test/e2e/testutils/setup_helpers.go
+++ b/test/e2e/testutils/setup_helpers.go
@@ -1,0 +1,104 @@
+package testutils
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kueuev1beta2 "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+)
+
+var testClients *TestClients
+
+func InitClients(c *TestClients) {
+	testClients = c
+}
+
+// TestEnvironment holds the Kueue test resources created by SetupTestEnvironment.
+type TestEnvironment struct {
+	ResourceFlavor *kueuev1beta2.ResourceFlavor
+	ClusterQueue   *kueuev1beta2.ClusterQueue
+	Namespace      *corev1.Namespace
+	LocalQueue     *kueuev1beta2.LocalQueue
+}
+
+// MustCreateResourceFlavor creates a ResourceFlavor with GenerateName and
+// registers cleanup via DeferCleanup.
+func MustCreateResourceFlavor(ctx context.Context) *kueuev1beta2.ResourceFlavor {
+	rf, cleanup, err := NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, testClients.UpstreamKueueClient)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create ResourceFlavor")
+	DeferCleanup(cleanup)
+	return rf
+}
+
+// MustCreateClusterQueue creates a ClusterQueue with GenerateName and the given
+// flavor name. If cq is non-nil, the caller's customizations are preserved and
+// GenerateName + FlavorName are applied on top. If cq is nil, defaults are used.
+// Registers cleanup via DeferCleanup.
+func MustCreateClusterQueue(ctx context.Context, flavorName string, cq *ClusterQueueWrapper) *kueuev1beta2.ClusterQueue {
+	if cq == nil {
+		cq = NewClusterQueue()
+	}
+	cq.WithGenerateName().WithFlavorName(flavorName)
+	created, cleanup, err := cq.CreateWithObject(ctx, testClients.UpstreamKueueClient)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterQueue")
+	DeferCleanup(cleanup)
+	return created
+}
+
+// MustCreateManagedNamespace creates a namespace with GenerateName and the
+// kueue.openshift.io/managed=true label. Registers cleanup via DeferCleanup.
+func MustCreateManagedNamespace(ctx context.Context, prefix string) *corev1.Namespace {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: prefix,
+			Labels:       map[string]string{OpenShiftManagedLabel: "true"},
+		},
+	}
+	cleanup, err := CreateNamespace(testClients.KubeClient, ns)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create Namespace")
+	DeferCleanup(cleanup)
+	return ns
+}
+
+// MustCreateLocalQueue creates a LocalQueue in the given namespace, pointing
+// to the given ClusterQueue. If lq is non-nil, the caller's customizations are
+// preserved and ClusterQueue is applied on top. If lq is nil, defaults are used.
+// Registers cleanup via DeferCleanup.
+func MustCreateLocalQueue(ctx context.Context, namespace, name, clusterQueueName string, lq *LocalQueueWrapper) *kueuev1beta2.LocalQueue {
+	if lq == nil {
+		lq = NewLocalQueue(namespace, name)
+	} else {
+		lq.Namespace = namespace
+		lq.Name = name
+	}
+	lq.WithClusterQueue(clusterQueueName)
+	created, cleanup, err := lq.CreateWithObject(ctx, testClients.UpstreamKueueClient)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create LocalQueue")
+	DeferCleanup(cleanup)
+	return created
+}
+
+// SetupTestEnvironment creates a standard set of Kueue test resources:
+// ResourceFlavor, ClusterQueue, Namespace, and LocalQueue.
+// If cq is non-nil, the caller's CQ customizations are applied.
+// GenerateName and FlavorName are always set by the helper — do not pre-set them on the wrapper.
+// All resources are registered with DeferCleanup for automatic teardown.
+func SetupTestEnvironment(ctx context.Context, nsPrefix, lqName string, cq *ClusterQueueWrapper) *TestEnvironment {
+	Expect(testClients).NotTo(BeNil(), "testClients is nil — call testutils.InitClients() in BeforeSuite before using setup helpers")
+	By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
+
+	rf := MustCreateResourceFlavor(ctx)
+	createdCQ := MustCreateClusterQueue(ctx, rf.Name, cq)
+	ns := MustCreateManagedNamespace(ctx, nsPrefix)
+	lq := MustCreateLocalQueue(ctx, ns.Name, lqName, createdCQ.Name, nil)
+
+	return &TestEnvironment{
+		ResourceFlavor: rf,
+		ClusterQueue:   createdCQ,
+		Namespace:      ns,
+		LocalQueue:     lq,
+	}
+}


### PR DESCRIPTION
## Summary

- Introduce `SetupTestEnvironment` shared helper in `testutils/setup_helpers.go` that encapsulates the repeated ResourceFlavor → ClusterQueue → Namespace → LocalQueue setup pattern
- Refactor DRA, preemption, and gang scheduling e2e tests to use the new helper, reducing boilerplate and diff size
- Add nil guards in DRA test helpers (`SetDRAJobCPU`, `NewDRAJob`, `AddDRAClaims`) to fail explicitly on improperly constructed objects
- Fix wrong UID in `e2e_local_queue_defaulting_test.go` workload verification (`createdPod.UID` → `createdJob.UID`)
- Handle ignored Job delete error in `WaitForWebhookReady`

Addresses review feedback on PR #1874 and done in cooperation with the testutils extraction work in PR #1946.

Initially applied to `e2e_dra_test.go`, `e2e_preemption_test.go`, and `e2e_dra_extended_resources_test.go`. Once the pattern is approved, it can be extended to the remaining e2e test files.

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go vet ./...` passes
- [x] E2E tests run on extended resources cluster (DRA, preemption, gang scheduling, visibility, metrics, TLS, operator all pass)
- [ ] CI green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated end-to-end test utilities and helpers into shared testutils packages to reduce code duplication and improve test maintainability across DRA, operator configuration, and test setup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->