### PR TITLE
Update linter and golang to 1.26.

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: builder
   namespace: ocp
-  tag: rhel-9-golang-1.25-openshift-4.21
+  tag: rhel-9-golang-1.26-openshift-5.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,9 @@ linters:
       - linters:
           - staticcheck
         path: test/e2e/*
+      - linters:
+          - goconst
+        path: (.*_test\.go|test/.*)
     paths:
       - third_party$
       - builtin$

--- a/Makefile
+++ b/Makefile
@@ -152,12 +152,12 @@ lint-api-fix: golangci-lint-kal
 CONTROLLER_TOOLS_VERSION ?= v0.17.1
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v2.7.2
+GOLANGCI_LINT_VERSION ?= v2.12.2
 GOLANGCI_LINT_KAL = $(shell pwd)/bin/golangci-lint-kube-api-linter
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) $(GOLANGCI_LINT_VERSION) ;\
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) $(GOLANGCI_LINT_VERSION) ;\
 	}
 
 .PHONY: golangci-lint-kal

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/kueue-operator
 
-go 1.25.0
+go 1.26.0
 
 replace sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.12.1-0.20250402141027-24f590ca0886
 

--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -32,6 +32,8 @@ import (
 	kueue "github.com/openshift/kueue-operator/pkg/apis/kueueoperator/v1"
 )
 
+const controllerManagerConfigYaml = "controller_manager_config.yaml"
+
 func BuildConfigMap(namespace string, kueueCfg kueue.KueueConfiguration, gvrToKind map[string]string, draSupported bool, draExtendedResourceEnabled bool, tlsOpts *configapi.TLSOptions) (*corev1.ConfigMap, error) {
 	config, err := defaultKueueConfigurationTemplate(namespace, kueueCfg, gvrToKind, draSupported, draExtendedResourceEnabled, tlsOpts)
 	if err != nil {
@@ -46,7 +48,7 @@ func BuildConfigMap(namespace string, kueueCfg kueue.KueueConfiguration, gvrToKi
 			Name:      "kueue-manager-config",
 			Namespace: namespace,
 		},
-		Data: map[string]string{"controller_manager_config.yaml": string(cfg)},
+		Data: map[string]string{controllerManagerConfigYaml: string(cfg)},
 	}
 	return cfgMap, nil
 }
@@ -83,7 +85,7 @@ func buildFrameworkList(kueuelist []kueue.KueueIntegration) []string {
 	conversionMap[string(kueue.KueueIntegrationTrainJob)] = "trainer.kubeflow.org/trainjob"
 	conversionMap[string(kueue.KueueIntegrationSparkApplication)] = "sparkoperator.k8s.io/sparkapplication"
 
-	ret := []string{}
+	ret := make([]string, 0, len(kueuelist))
 	for _, val := range kueuelist {
 		ret = append(ret, conversionMap[string(val)])
 	}
@@ -91,7 +93,7 @@ func buildFrameworkList(kueuelist []kueue.KueueIntegration) []string {
 }
 
 func buildExternalFrameworkList(kueuelist []kueue.ExternalFramework) []string {
-	ret := []string{}
+	ret := make([]string, 0, len(kueuelist))
 	for _, val := range kueuelist {
 		ret = append(ret, fmt.Sprintf("%s.%s.%s", val.Resource, val.Version, val.Group))
 	}
@@ -99,7 +101,7 @@ func buildExternalFrameworkList(kueuelist []kueue.ExternalFramework) []string {
 }
 
 func buildLabelKeysCopy(labelKeys []kueue.LabelKeys) []string {
-	ret := []string{}
+	ret := make([]string, 0, len(labelKeys))
 	for _, val := range labelKeys {
 		ret = append(ret, val.Key)
 	}
@@ -116,7 +118,7 @@ func mapOperatorMultiKueueToKueue(multiKueue *kueue.MultiKueue, gvrToKind map[st
 }
 
 func buildMultiKueueExternalFrameworkList(kueuelist []kueue.ExternalFramework, gvrToKind map[string]string) []configapi.MultiKueueExternalFramework {
-	ret := []configapi.MultiKueueExternalFramework{}
+	ret := make([]configapi.MultiKueueExternalFramework, 0, len(kueuelist))
 	for _, val := range kueuelist {
 		kind := val.Resource
 		if k, ok := gvrToKind[fmt.Sprintf("%s/%s/%s", val.Group, val.Version, val.Resource)]; ok {

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -45,7 +45,7 @@ func TestBuildConfigMap(t *testing.T) {
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -103,7 +103,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -164,7 +164,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -220,7 +220,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -281,7 +281,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -339,7 +339,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -401,7 +401,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -462,7 +462,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -517,7 +517,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -579,7 +579,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -649,7 +649,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -721,7 +721,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -787,7 +787,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -856,7 +856,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -921,7 +921,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -976,7 +976,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -1029,7 +1029,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -1082,7 +1082,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -1135,7 +1135,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `apiVersion: config.kueue.x-k8s.io/v1beta2
+					controllerManagerConfigYaml: `apiVersion: config.kueue.x-k8s.io/v1beta2
 clientConnection:
   burst: 100
   qps: 50
@@ -1197,7 +1197,7 @@ webhook:
 			},
 			wantCfgMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"controller_manager_config.yaml": `admissionFairSharing:
+					controllerManagerConfigYaml: `admissionFairSharing:
   resourceWeights:
     cpu: 0.5
     memory: 2
@@ -1254,7 +1254,7 @@ webhook:
 			if err != nil && tc.wantErr == nil {
 				t.Fatalf("Unexpected error: want=%v, got=%v", tc.wantErr, err)
 			}
-			if diff := cmp.Diff(got.Data["controller_manager_config.yaml"], tc.wantCfgMap.Data["controller_manager_config.yaml"]); len(diff) != 0 {
+			if diff := cmp.Diff(got.Data[controllerManagerConfigYaml], tc.wantCfgMap.Data[controllerManagerConfigYaml]); len(diff) != 0 {
 				t.Errorf("Unexpected buckets (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -44,7 +44,7 @@ func stripStatusTransform(obj interface{}) (interface{}, error) {
 	v := reflect.ValueOf(obj)
 
 	// Handle pointer types
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -78,6 +78,22 @@ import (
 const (
 	KueueConfigMap = "kueue-manager-config"
 	KueueFinalizer = "kueue.openshift.io/finalizer"
+
+	groupCertManager                = "cert-manager.io"
+	kindIssuer                      = "Issuer"
+	certManagerAPIVersion           = "cert-manager.io/v1"
+	kueueAPIVersion                 = "kueue.openshift.io/v1"
+	kindKueue                       = "Kueue"
+	secretMetricsServerCert         = "metrics-server-cert"
+	certMetricsCerts                = "metrics-certs"
+	secretKueueVisibilityServerCert = "kueue-visibility-server-cert"
+	appLabelName                    = "app.kubernetes.io/name"
+	appLabelComponent               = "app.kubernetes.io/component"
+	appComponentController          = "controller"
+	appNameKueue                    = "kueue"
+	keyCaCrt                        = "ca.crt"
+	keyTlsCrt                       = "tls.crt"
+	keyTlsKey                       = "tls.key"
 )
 
 type TargetConfigReconciler struct {
@@ -163,7 +179,7 @@ func NewTargetConfigReconciler(
 		openshiftConfigClient:      openshiftConfigClient,
 	}
 
-	_, err := operatorClientInformer.Informer().AddEventHandler(c.eventHandler(queueItem{kind: "kueue"}))
+	_, err := operatorClientInformer.Informer().AddEventHandler(c.eventHandler(queueItem{kind: appNameKueue}))
 	if err != nil {
 		return nil, err
 	}
@@ -269,9 +285,9 @@ func (c *TargetConfigReconciler) sync(ctx context.Context, syncCtx factory.SyncC
 	}
 
 	found, err := c.isResourceRegisteredCached(schema.GroupVersionKind{
-		Group:   "cert-manager.io",
+		Group:   groupCertManager,
 		Version: "v1",
-		Kind:    "Issuer",
+		Kind:    kindIssuer,
 	})
 	if err != nil {
 		klog.Errorf("unable to check cert-manager is installed: %v", err)
@@ -374,8 +390,8 @@ func (c *TargetConfigReconciler) sync(ctx context.Context, syncCtx factory.SyncC
 	}
 
 	ownerReference := metav1.OwnerReference{
-		APIVersion: "kueue.openshift.io/v1",
-		Kind:       "Kueue",
+		APIVersion: kueueAPIVersion,
+		Kind:       kindKueue,
 		Name:       kueue.Name,
 		UID:        kueue.UID,
 	}
@@ -449,8 +465,8 @@ func (c *TargetConfigReconciler) sync(ctx context.Context, syncCtx factory.SyncC
 				fmt.Sprintf("kueue-controller-manager-metrics-service.%s.svc.cluster.local", c.operatorNamespace),
 			},
 			commonName:      "kueue-metrics",
-			secretName:      "metrics-server-cert",
-			certificateName: "metrics-certs",
+			secretName:      secretMetricsServerCert,
+			certificateName: certMetricsCerts,
 		},
 		{
 			dnsNames: []interface{}{
@@ -458,8 +474,8 @@ func (c *TargetConfigReconciler) sync(ctx context.Context, syncCtx factory.SyncC
 				fmt.Sprintf("kueue-visibility-server.%s.svc.cluster.local", c.operatorNamespace),
 			},
 			commonName:      "kueue-visibility-server",
-			secretName:      "kueue-visibility-server-cert",
-			certificateName: "kueue-visibility-server-cert",
+			secretName:      secretKueueVisibilityServerCert,
+			certificateName: secretKueueVisibilityServerCert,
 		},
 	}
 
@@ -484,13 +500,13 @@ func (c *TargetConfigReconciler) sync(ctx context.Context, syncCtx factory.SyncC
 		return err
 	}
 
-	err = cert.WaitForCertificateReady(ctx, c.dynamicClient, c.operatorNamespace, "metrics-certs", 2*time.Minute)
+	err = cert.WaitForCertificateReady(ctx, c.dynamicClient, c.operatorNamespace, certMetricsCerts, 2*time.Minute)
 	if err != nil {
 		klog.Warningf("Metrics certificate not ready yet: %v - will retry on next reconciliation", err)
 		return err
 	}
 
-	err = cert.WaitForCertificateReady(ctx, c.dynamicClient, c.operatorNamespace, "kueue-visibility-server-cert", 2*time.Minute)
+	err = cert.WaitForCertificateReady(ctx, c.dynamicClient, c.operatorNamespace, secretKueueVisibilityServerCert, 2*time.Minute)
 	if err != nil {
 		klog.Warningf("Kueue Visibility certificate not ready yet: %v - will retry on next reconciliation", err)
 		return err
@@ -1065,17 +1081,17 @@ func (c *TargetConfigReconciler) cleanUpResources(ctx context.Context) error {
 		klog.Infof("Successfully deleted Secret: %s/%s", c.operatorNamespace, "kueue-webhook-server-cert")
 	}
 
-	klog.Infof("Deleting Secret: %s/%s", c.operatorNamespace, "metrics-server-cert")
+	klog.Infof("Deleting Secret: %s/%s", c.operatorNamespace, secretMetricsServerCert)
 	err = retry.OnError(retry.DefaultBackoff, errors.IsTooManyRequests, func() error {
 		return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			return c.kubeClient.CoreV1().Secrets(c.operatorNamespace).Delete(ctx, "metrics-server-cert", metav1.DeleteOptions{})
+			return c.kubeClient.CoreV1().Secrets(c.operatorNamespace).Delete(ctx, secretMetricsServerCert, metav1.DeleteOptions{})
 		})
 	})
 	if err != nil {
-		klog.Errorf("Failed to delete Secret %s/%s: %v", c.operatorNamespace, "metrics-server-cert", err)
+		klog.Errorf("Failed to delete Secret %s/%s: %v", c.operatorNamespace, secretMetricsServerCert, err)
 		errorList = append(errorList, err)
 	} else {
-		klog.Infof("Successfully deleted Secret: %s/%s", c.operatorNamespace, "metrics-server-cert")
+		klog.Infof("Successfully deleted Secret: %s/%s", c.operatorNamespace, secretMetricsServerCert)
 	}
 
 	if len(errorList) > 0 {
@@ -1162,7 +1178,7 @@ func (c *TargetConfigReconciler) cleanUpCertificatesAndIssuers(ctx context.Conte
 
 	for _, resource := range certManagerCRDs {
 		gvr := schema.GroupVersionResource{
-			Group:    "cert-manager.io",
+			Group:    groupCertManager,
 			Version:  "v1",
 			Resource: resource,
 		}
@@ -1708,9 +1724,9 @@ func (c *TargetConfigReconciler) manageOpenshiftClusterRolesForKueue(ctx context
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"app.kubernetes.io/component": "controller",
-				"app.kubernetes.io/name":      "kueue",
-				"control-plane":               "controller-manager",
+				appLabelComponent: appComponentController,
+				appLabelName:      appNameKueue,
+				"control-plane":   "controller-manager",
 			},
 			Name: "kueue-openshift-roles",
 		},
@@ -1790,10 +1806,10 @@ func (c *TargetConfigReconciler) manageDeployment(ctx context.Context, kueueoper
 
 	// Add metrics certificate volume.
 	metricsCertVolume := v1.Volume{
-		Name: "metrics-certs",
+		Name: certMetricsCerts,
 		VolumeSource: v1.VolumeSource{
 			Secret: &v1.SecretVolumeSource{
-				SecretName: "metrics-server-cert",
+				SecretName: secretMetricsServerCert,
 			},
 		},
 	}
@@ -1803,20 +1819,20 @@ func (c *TargetConfigReconciler) manageDeployment(ctx context.Context, kueueoper
 			required.Spec.Template.Spec.Volumes[i].EmptyDir = nil
 			required.Spec.Template.Spec.Volumes[i].VolumeSource = v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
-					SecretName: "kueue-visibility-server-cert",
+					SecretName: secretKueueVisibilityServerCert,
 					Optional:   ptr.To(false),
 					Items: []v1.KeyToPath{
 						{
-							Key:  "ca.crt",
-							Path: "ca.crt",
+							Key:  keyCaCrt,
+							Path: keyCaCrt,
 						},
 						{
-							Key:  "tls.crt",
-							Path: "tls.crt",
+							Key:  keyTlsCrt,
+							Path: keyTlsCrt,
 						},
 						{
-							Key:  "tls.key",
-							Path: "tls.key",
+							Key:  keyTlsKey,
+							Path: keyTlsKey,
 						},
 					},
 				},
@@ -1828,7 +1844,7 @@ func (c *TargetConfigReconciler) manageDeployment(ctx context.Context, kueueoper
 
 	// Add volume mount to the container.
 	metricsCertVolumeMount := v1.VolumeMount{
-		Name:      "metrics-certs",
+		Name:      certMetricsCerts,
 		MountPath: "/etc/kueue/metrics/certs",
 		ReadOnly:  true,
 	}
@@ -1857,8 +1873,8 @@ func (c *TargetConfigReconciler) manageDeployment(ctx context.Context, kueueoper
 					PodAffinityTerm: v1.PodAffinityTerm{
 						LabelSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
-								"control-plane":          "controller-manager",
-								"app.kubernetes.io/name": "kueue",
+								"control-plane": "controller-manager",
+								appLabelName:    appNameKueue,
 							},
 						},
 						TopologyKey: "kubernetes.io/hostname",
@@ -1925,22 +1941,23 @@ func (c *TargetConfigReconciler) manageDeployment(ctx context.Context, kueueoper
 	return deploy, updated, err
 }
 
+//nolint:goconst
 func (c *TargetConfigReconciler) manageIssuerCR(ctx context.Context, kueue *kueuev1.Kueue) (*unstructured.Unstructured, bool, error) {
 	gvr := schema.GroupVersionResource{
-		Group:    "cert-manager.io",
+		Group:    groupCertManager,
 		Version:  "v1",
 		Resource: "issuers",
 	}
 
 	required := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "cert-manager.io/v1",
-			"kind":       "Issuer",
+			"apiVersion": certManagerAPIVersion,
+			"kind":       kindIssuer,
 			"metadata": map[string]interface{}{
 				"ownerReferences": []interface{}{
 					map[string]interface{}{
-						"apiVersion":         "kueue.openshift.io/v1",
-						"kind":               "Kueue",
+						"apiVersion":         kueueAPIVersion,
+						"kind":               kindKueue,
 						"name":               kueue.Name,
 						"uid":                string(kueue.UID),
 						"controller":         false,
@@ -1959,21 +1976,22 @@ func (c *TargetConfigReconciler) manageIssuerCR(ctx context.Context, kueue *kueu
 	return resourceapply.ApplyUnstructuredResourceImproved(ctx, c.dynamicClient, c.eventRecorder, required, c.resourceCache, gvr, nil, nil)
 }
 
+//nolint:goconst
 func (c *TargetConfigReconciler) manageCertificateCR(ctx context.Context, kueue *kueuev1.Kueue, dnsNames []interface{}, commonName, secretName, certificateName string) (*unstructured.Unstructured, bool, error) {
 	gvr := schema.GroupVersionResource{
-		Group:    "cert-manager.io",
+		Group:    groupCertManager,
 		Version:  "v1",
 		Resource: "certificates",
 	}
 	required := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "cert-manager.io/v1",
+			"apiVersion": certManagerAPIVersion,
 			"kind":       "Certificate",
 			"metadata": map[string]interface{}{
 				"ownerReferences": []interface{}{
 					map[string]interface{}{
-						"apiVersion":         "kueue.openshift.io/v1",
-						"kind":               "Kueue",
+						"apiVersion":         kueueAPIVersion,
+						"kind":               kindKueue,
 						"name":               kueue.Name,
 						"uid":                string(kueue.UID),
 						"controller":         false,
@@ -1986,7 +2004,7 @@ func (c *TargetConfigReconciler) manageCertificateCR(ctx context.Context, kueue 
 			"spec": map[string]interface{}{
 				"dnsNames": dnsNames,
 				"issuerRef": map[string]interface{}{
-					"kind": "Issuer",
+					"kind": kindIssuer,
 					"name": "selfsigned",
 				},
 				"secretName": secretName,
@@ -2024,7 +2042,7 @@ func (c *TargetConfigReconciler) manageServiceMonitor(ctx context.Context, kueue
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app.kubernetes.io/component": "metrics-service",
-					"app.kubernetes.io/name":      "kueue",
+					appLabelName:                  appNameKueue,
 				},
 			},
 			Endpoints: []monitoringv1.Endpoint{
@@ -2040,24 +2058,24 @@ func (c *TargetConfigReconciler) manageServiceMonitor(ctx context.Context, kueue
 							CA: monitoringv1.SecretOrConfigMap{
 								Secret: &v1.SecretKeySelector{
 									LocalObjectReference: v1.LocalObjectReference{
-										Name: "metrics-server-cert",
+										Name: secretMetricsServerCert,
 									},
-									Key: "ca.crt",
+									Key: keyCaCrt,
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
 								Secret: &v1.SecretKeySelector{
 									LocalObjectReference: v1.LocalObjectReference{
-										Name: "metrics-server-cert",
+										Name: secretMetricsServerCert,
 									},
-									Key: "tls.crt",
+									Key: keyTlsCrt,
 								},
 							},
 							KeySecret: &v1.SecretKeySelector{
 								LocalObjectReference: v1.LocalObjectReference{
-									Name: "metrics-server-cert",
+									Name: secretMetricsServerCert,
 								},
-								Key: "tls.key",
+								Key: keyTlsKey,
 							},
 							ServerName: ptr.To("kueue-controller-manager-metrics-service.openshift-kueue-operator.svc"),
 						},

--- a/pkg/util/resourceapply/flowcontrol.go
+++ b/pkg/util/resourceapply/flowcontrol.go
@@ -20,6 +20,11 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const (
+	annotationAllowNominalConcurrencySharesUpdate = "kueue.openshift.io/allow-nominal-concurrency-shares-update"
+	annotationValueTrue                           = "true"
+)
+
 // TODO: move to library-go
 var (
 	flowcontrolScheme                = runtime.NewScheme()
@@ -109,7 +114,7 @@ func ApplyPriorityLevelConfiguration(ctx context.Context, getter flowcontrolclie
 		return current, false, nil
 	}
 
-	if current.Annotations != nil && current.Annotations["kueue.openshift.io/allow-nominal-concurrency-shares-update"] == "true" {
+	if current.Annotations != nil && current.Annotations[annotationAllowNominalConcurrencySharesUpdate] == annotationValueTrue {
 		nominalConcurrencyShares := *current.Spec.Limited.NominalConcurrencyShares
 		if (nominalConcurrencyShares >= *want.Spec.Limited.NominalConcurrencyShares && nominalConcurrencyShares <= 5) || nominalConcurrencyShares == 0 {
 			return current, false, nil

--- a/pkg/webhook/pod_webhook.go
+++ b/pkg/webhook/pod_webhook.go
@@ -231,7 +231,7 @@ func defaultLabelSelector() *metav1.LabelSelector {
 			{
 				Key:      kueueManagedLabel,
 				Operator: metav1.LabelSelectorOpIn,
-				Values:   []string{"true"},
+				Values:   []string{"true"}, //nolint:goconst
 			},
 		},
 	}


### PR DESCRIPTION
Fix all linter failures updating linter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pointer type detection in operator logic.

* **Chores**
  * Updated Go toolchain to version 1.26.
  * Updated build image to support OpenShift 5.0.
  * Updated linting toolchain and configuration.
  * Improved internal code quality through constant centralization and memory preallocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->