### PR TITLE
remove metrics ports from operator as we aren't really using thes yet

### DIFF
--- a/bundle/manifests/kueue-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kueue-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
       ]
     capabilities: Basic Install
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2026-05-19T01:59:43Z"
+    createdAt: "2026-05-29T20:16:51Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -279,9 +279,6 @@ spec:
                 image: registry.redhat.io/kueue/kueue-rhel9-operator:latest
                 imagePullPolicy: Always
                 name: openshift-kueue-operator
-                ports:
-                - containerPort: 60000
-                  name: metrics
                 resources: {}
                 securityContext:
                   allowPrivilegeEscalation: false

--- a/deploy/07_deployment.yaml
+++ b/deploy/07_deployment.yaml
@@ -31,9 +31,6 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: "/tmp"
-          ports:
-            - containerPort: 60000
-              name: metrics
           command:
             - kueue-operator
           args:

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/openshift/library-go v0.0.0-20260303171201-5d9eb6295ff6
 	github.com/openshift/lws-operator v0.0.0-20260117095057-194a9dea5308
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.86.1
-	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
 	k8s.io/api v0.35.2
 	k8s.io/apiextensions-apiserver v0.35.2
@@ -95,6 +94,7 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect

--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -10,9 +10,11 @@ import (
 )
 
 func NewOperator() *cobra.Command {
-	cmd := controllercmd.
-		NewControllerCommandConfig("openshift-kueue-operator", version.Get(), operator.RunOperator, clock.RealClock{}).
-		NewCommand()
+	config := controllercmd.
+		NewControllerCommandConfig("openshift-kueue-operator", version.Get(), operator.RunOperator, clock.RealClock{})
+	config.DisableServing = true
+
+	cmd := config.NewCommand()
 	cmd.Use = "operator"
 	cmd.Short = "Start the Cluster Kueue Operator"
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,8 +1,6 @@
 package version
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
-
 	"k8s.io/apimachinery/pkg/version"
 )
 
@@ -31,17 +29,4 @@ func Get() version.Info {
 		GitVersion: versionFromGit,
 		BuildDate:  buildDate,
 	}
-}
-
-func init() {
-	buildInfo := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "openshift_kueue_build_info",
-			Help: "A metric with a constant '1' value labeled by major, minor, git commit & git version from which OpenShift Kueue Operator was built.",
-		},
-		[]string{"major", "minor", "gitCommit", "gitVersion"},
-	)
-	buildInfo.WithLabelValues(majorFromGit, minorFromGit, commitFromGit, versionFromGit).Set(1)
-
-	prometheus.MustRegister(buildInfo)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * Updated operator manifest metadata and YAML layout
  * Removed exposure of the operator metrics port
  * Added a temporary emptyDir volume mount to the operator pod

* **Removed Features**
  * Removed the operator's exported build/version metrics information
<!-- end of auto-generated comment: release notes by coderabbit.ai -->