### PR TITLE
renovate: disable renovate for rpm-lockfile maintenance 

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,12 @@
   "rebaseWhen": "behind-base-branch",
   "recreateWhen": "always",
   "commitMessageSuffix": "{{baseBranch}}",
+  "rpm-lockfile": {
+    "enabled": false,
+    "lockFileMaintenance": {
+      "enabled": false
+    }
+  },
   "git-submodules": {
     "enabled": true,
     "schedule": "* 4 * * 2",


### PR DESCRIPTION
## Summary by CodeRabbit

* **Chores**
  * Disabled RPM lockfile handling and automated RPM lockfile maintenance in Renovate configuration.
  * Prevents Renovate from creating or updating RPM lockfiles and stops scheduled lockfile maintenance tasks.
  * No runtime or public-facing API changes; this is a configuration-only update with limited operational impact.

## Timeline

  **May 30, 2026**: Renovate creates commit `aaeff425` updating `konflux/rpms.lock.yaml` with single-arch (x86_64 only) lockfile

  **June 2, 2026**: PR #1979 created - "migrate to multiarch images" - updates lockfile to include aarch64, ppc64le, s390x, x86_64

  **June 3, 2026 (morning)**: PR #1979 merged to main - main branch now has multi-arch lockfile structure

  **June 3, 2026 (later)**: PR #1984 opened by Renovate using the May 30 commit (`aaeff425`) - still contains single-arch lockfile

  **Result**: Merge conflict - Renovate's single-arch lockfile from May 30 conflicts with main's multi-arch lockfile structure

  **Expected behavior**: When opening PR #1984 on June 3, Renovate should have detected that main changed and either:
  - Rebased the commit against current main, or
  - Created a fresh commit from current main

  Instead, it opened a PR with a 4-day-old stale commit without rebasing.