### PR TITLE
[wip][poc] Add skills and test documentation models

### DIFF
--- a/.claude/commands/create-release-plan.md
+++ b/.claude/commands/create-release-plan.md
@@ -1,0 +1,326 @@
+# Create Release Test Plan
+
+Generate a release testing plan document for a Kueue operator release, following
+the project's test plan model. Supports both a full narrative format and a light
+checklist format.
+
+## Usage
+
+```
+/create-release-plan 1.5
+/create-release-plan 1.5 full
+/create-release-plan 1.5 light
+```
+
+- Pass a version number to generate the release testing plan
+- Optionally specify `full` or `light` format (defaults to generating both)
+- The skill will ask for missing information (features, dates, OCP versions)
+
+## Arguments
+
+- $ARGUMENTS: Release version (e.g., `1.5`) and optionally the format
+  (`full` or `light`). Examples:
+  - `1.5` — generates both full and light versions
+  - `1.5 full` — generates only the full version
+  - `1.5 light` — generates only the light version
+
+## Process
+
+### Step 1: Gather Release Information
+
+Ask the user for the following information (skip any they've already provided):
+
+1. **Release version** (from argument, e.g., `1.5`)
+2. **Previous version** (default: decrement minor version, e.g., `1.4`)
+3. **Target release date or sprint** (e.g., "Sprint 295" or "2026-09-15")
+4. **In-scope features** — list of features with JIRA links. For each:
+   - Feature name
+   - JIRA link (OCPSTRAT-* or OCPKUEUE-*)
+5. **Out-of-scope features** — list with reasons (e.g., "Dev Preview", "Deferred")
+6. **OCP version range** — min and max (e.g., 4.19 through 4.23)
+7. **Format** — full, light, or both (from argument or ask)
+
+### Step 2: Scan the Repository
+
+Automatically gather information from the repo:
+
+1. **Test files:** List all `test/e2e/e2e_*_test.go` files for the test cases
+   traceability table
+2. **Existing test case docs:** Check `test/docs/cases/` for which `.md` files
+   already exist (link them) vs. mark as "TBD"
+3. **Previous release plans:** Check `test/docs/plans/` for existing plans to
+   maintain consistency
+4. **CI job patterns:** Derive Prow job names from the repo org/name and the
+   release version using the naming convention:
+   ```
+   periodic-ci-openshift-kueue-operator-release-{VERSION}-test-e2e-{OCP_VERSION}
+   ```
+
+### Step 3: Calculate Schedule
+
+Using the formulas:
+
+```
+ReleaseStartTestingDate = ReleaseDate - TestingDuration - ReleaseWorkBuffer
+BranchingStarts = ReleaseStartTestingDate - 1 week
+```
+
+Ask the user for `TestingDuration` and `ReleaseWorkBuffer` if not known from
+previous plans. Check existing plans in `test/docs/plans/` for precedent values.
+
+Account for adjustments the user mentions (holidays, PTO, company events).
+
+### Step 4: Build the OCP Upgrade Matrix
+
+From the OCP version range, generate:
+
+**OCP Upgrade pairs:**
+```
+OCP {MIN} + Product {VERSION} -> OCP {MIN+1}
+OCP {MIN+1} + Product {VERSION} -> OCP {MIN+2}
+...
+OCP {MAX-1} + Product {VERSION} -> OCP {MAX}
+```
+
+**Product version upgrade:**
+```
+OCP {MAX}: Product {VERSION-1} -> Product {VERSION}
+  - Operator-only uninstall
+  - Full operator + operand uninstall
+```
+
+### Step 5: Build the DAST API List
+
+Check the repo for CRD definitions or ask the user:
+
+- `kueue.openshift.io` API versions
+- `kueue.x-k8s.io` API versions
+- `visibility.kueue.x-k8s.io` API versions
+- Any new or deprecated API versions for this release
+
+If previous release plans exist, use their DAST API list as a starting point and
+ask if anything changed.
+
+### Step 6: Generate the Document(s)
+
+Create files in `test/docs/plans/`:
+
+- Full format: `kueue-{VERSION}-full.md`
+- Light format: `kueue-{VERSION}-light.md`
+
+#### Full Format Structure
+
+```markdown
+# Release Kueue {VERSION} Testing Plan
+
+## 1. Introduction
+
+### 1.1. Overview
+
+This document outlines the testing strategy, objectives, and procedures for the
+Kueue {VERSION} release. The goal is to ensure the quality, stability, and
+performance of new features and to verify that existing functionality remains
+regression-free.
+
+### 1.2. Scope
+
+**In Scope**
+
+- <feature> - [JIRA-ID](https://redhat.atlassian.net/browse/JIRA-ID)
+...
+
+**Out of Scope**
+
+- <feature> - <reason>
+...
+
+### 1.3. Key Features
+
+- <bullet list of headline features>
+
+## 2. Release Testing Strategy
+
+### 2.1. Schedule
+
+| Milestone | Date / Sprint | Notes |
+|-----------|---------------|-------|
+| Branching | ... | Release branch created |
+| Testing Start | ... | Environments provisioned |
+| Week 1: Core Testing | ... | Regression, features, DAST, bugs |
+| Week 2: Upgrade | ... | OCP + Kueue upgrade matrix |
+| Release Work | ... | Artifacts, sign-off |
+| Release | ... | Published |
+
+### 2.2. Test Types
+
+- **Integration Tests:** ...
+- **Feature Tests:** ...
+- **Regression Tests:** ...
+- **Bug Verification:** ...
+- **Upgrade Tests:** ...
+- **Security Tests (DAST):** ...
+
+### 2.3. Test Environments
+
+- **CI/CD:** Prow Periodics
+- **Staging Clusters:**
+  - OCP versions
+  - FIPS
+  - Disconnected
+  - Multi-ARCH
+  - Hypershift on AWS
+
+## 3. Test Areas & Test Cases
+
+**Tracking Epic:** <epic name> -
+[JIRA-ID](https://redhat.atlassian.net/browse/JIRA-ID)
+
+### 3.1. Key Test Activities
+
+| Activity | JIRA | Cadence | Est. Duration |
+|----------|------|---------|---------------|
+| Upgrade testing | [JIRA-ID](link) | Re-execute on rebuilds | ~3 days |
+| RapidDAST | [JIRA-ID](link) | Once unless API changes | ~2 days |
+| Regression & New Features | [JIRA-ID](link) | Daily on new builds | ~1-1.5 days |
+| Bug verification | [JIRA-ID](link) | On new builds as needed | ~2 days |
+
+### 3.2. Test Cases
+
+<traceability table linking test case docs to Go files>
+
+## 4. Test Details
+
+### 4.1. Feature Test Execution
+
+<spike -> scenarios -> manual -> automation workflow>
+
+### 4.2. Release Test Execution
+
+<CI periodic jobs list, upgrade jobs, manual testing areas>
+
+### 4.3. Upgrade Plan
+
+<OCP upgrade matrix + product version upgrade with uninstall scenarios>
+
+### 4.4. Security Scanning (DAST APIs)
+
+<API groups/versions table>
+
+## 5. Bug Tracking
+
+### 5.1. Bugs to Be Tested
+
+- TBD (label: `Kueue-{VERSION}`)
+
+### 5.2. Bugs Found During Release Testing (Out of Scope)
+
+- TBD
+
+## 6. Risks
+
+| Risk | JIRA | Impact | Mitigation |
+|------|------|--------|------------|
+...
+
+## 7. Exit Criteria
+
+The Kueue {VERSION} release will be considered ready when:
+
+- All in-scope features are verified
+- No open release-blocking regressions
+- All release test activities are complete
+- All identified risks are resolved or accepted
+```
+
+#### Light Format Structure
+
+```markdown
+# Kueue {VERSION} Release Testing Plan
+
+## Scope
+
+| Feature | JIRA | Status |
+|---------|------|--------|
+...
+
+**Tracking Epic:** [JIRA-ID](link)
+
+## Schedule
+
+| Milestone | Target |
+|-----------|--------|
+...
+
+## Test Matrix
+
+**OCP Versions:** ...
+**Variants:** FIPS, Disconnected, arm64, Hypershift (AWS)
+
+## Test Activities
+
+| Activity | JIRA | Cadence |
+|----------|------|---------|
+...
+
+## Test Cases
+
+<traceability table>
+
+## Upgrade Matrix
+
+**OCP Upgrade:** ...
+**Kueue Upgrade:** ...
+
+## DAST APIs
+
+| API Group | Version | Notes |
+|-----------|---------|-------|
+...
+
+## Bugs
+
+- TBD (label: `Kueue-{VERSION}`)
+
+## Risks
+
+- [ ] <risk> — [JIRA-ID](link)
+...
+
+## Exit Criteria
+
+- [ ] All in-scope features verified
+- [ ] No release-blocking regressions
+- [ ] All test activities complete
+- [ ] All risks resolved or accepted
+```
+
+### Step 7: Present Results
+
+Show the user:
+1. The path(s) to the created file(s)
+2. A summary: number of features in scope, OCP version range, number of test
+   cases linked vs. TBD
+3. Remind them to:
+   - Create the tracking epic and child JIRA items if not yet done
+   - Fill in the bugs section once bugs are labeled
+   - Update risks as they're identified
+4. Ask if they want to modify anything
+
+## Important Guidelines
+
+- **All JIRA references must be clickable links** — use the format
+  `[JIRA-ID](https://redhat.atlassian.net/browse/JIRA-ID)`
+- **Test case docs that don't exist yet must be marked as "TBD"** — not fake
+  filenames
+- **Test case docs that exist must be linked** — check `test/docs/cases/`
+- **OCP version matrix must be complete** — every supported version pair in the
+  upgrade plan
+- **CI job names follow the naming convention** — derive from repo org/name
+- **Reuse patterns from existing plans** — if previous release plans exist in
+  `test/docs/plans/`, follow their patterns for consistency
+- **Do NOT hardcode durations** — ask the user or derive from previous plans
+- **Schedule formulas produce estimates** — the user should confirm dates
+- **Do NOT carry over content from previous plans when the user says TBD** — if
+  the user chooses TBD for any section (features, risks, out-of-scope, etc.),
+  leave it as TBD. Never pre-fill with data from a prior release plan unless the
+  user explicitly asks to reuse it

--- a/.claude/commands/create-test-case.md
+++ b/.claude/commands/create-test-case.md
@@ -1,0 +1,218 @@
+# Create Test Case Documentation
+
+Generate a markdown test case document from a Ginkgo E2E test file, following the
+project's test documentation model. The generated document serves as a manual
+fallback for when automation cannot be executed.
+
+## Usage
+
+```
+/create-test-case test/e2e/e2e_dra_test.go
+/create-test-case test/e2e/e2e_preemption_test.go
+/create-test-case
+```
+
+- Pass the path to a Go test file to generate its test case doc
+- If no argument is provided, the skill lists all available test files and asks
+  you to pick one
+
+## Arguments
+
+- $ARGUMENTS: Path to a Go test file (e.g., `test/e2e/e2e_dra_test.go`)
+
+## Process
+
+### Step 1: Validate Input
+
+1. Check that the provided file path exists and ends with `_test.go`
+2. If no argument is provided, run
+   `find test/e2e -maxdepth 1 -name "e2e_*_test.go" | sort` to get all test
+   files (exclude `e2e_suite_test.go`). Show the first 5 files as numbered
+   options. After the list, always show a line like
+   "... and N more files. Type 'all' to see the full list, or type a filename."
+   where N is the count of remaining files. Mark files that already have a doc
+   in `test/docs/cases/` with "(doc exists)"
+3. Check if a test case doc already exists in `test/docs/cases/` for this file —
+   if so, ask the user whether to overwrite or skip
+
+### Step 2: Analyze the Go Test File
+
+Read the entire test file and extract:
+
+1. **Describe block:** the top-level `Describe("Name", Label("..."), ...)` —
+   this gives the feature name and labels
+2. **When/It blocks:** each `When` + `It` pair is one test scenario. Extract:
+   - The `When` description (context)
+   - The `It` description (expected behavior)
+   - The full Ginkgo path: `When ... / It ...`
+3. **By() steps:** these are the execution steps within each `It` block. Each
+   `By("...")` call maps to one manual step
+4. **BeforeAll / BeforeEach:** these are shared prerequisites or setup that
+   applies to all scenarios
+5. **DeferCleanup calls:** these tell you what resources need cleanup. Extract
+   the resource type and name pattern
+6. **Skip conditions:** look for `Skip("...")` calls — these indicate
+   environment constraints (e.g., HyperShift not supported)
+7. **Comments referencing bugs:** look for comments mentioning upstream issues,
+   OCPBUGS, or known limitations
+8. **Helper functions:** check functions called within tests to understand what
+   setup they perform (e.g., `enableAdmissionFairSharing`, `createClusterRoleBinding`)
+9. **JIRA references:** check imports, comments, and related files for JIRA
+   ticket references (OCPSTRAT-*, OCPKUEUE-*, OCPBUGS-*)
+
+### Step 3: Classify Each Step
+
+For each `By()` step in each scenario, classify it as:
+
+- **Action step** — creates, submits, deletes, or modifies a resource. These
+  are written as plain text instructions (no `oc` commands). Examples:
+  - "Submit job X on queue Y requesting Z CPU"
+  - "Delete job X to free quota"
+  - "Set the APIServer TLS profile to Modern"
+
+- **Verification step** — checks, verifies, waits for, or validates a
+  condition. These include `oc` commands with expected output. Examples:
+  - "Verify workload is admitted" → include `oc get workloads` command
+  - "Wait for consumedResources.cpu > 0" → include `oc get localqueue` command
+  - "Check Degraded condition" → include `oc get kueue cluster` command
+
+The rule: if the step contains `Expect`, `Eventually`, `Consistently`,
+`Should`, or `ShouldNot`, it's a verification step and needs an `oc` command.
+
+### Step 4: Determine Verification Commands
+
+For common verification patterns, use these `oc` commands:
+
+| What to verify | Command |
+|---------------|---------|
+| Workload admitted | `oc get workloads -n <namespace> -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.conditions[?(@.type=="Admitted")].status}{"\n"}{end}'` |
+| Job suspended | `oc get job <name> -n <namespace> -o jsonpath='{.spec.suspend}'` |
+| Pod running | `oc get pods -n <namespace> -l job-name=<name> -o jsonpath='{.items[0].status.phase}'` |
+| LocalQueue usage | `oc get localqueue <name> -n <namespace> -o jsonpath='{.status.fairSharing.admissionFairSharingStatus.consumedResources.cpu}'` |
+| Pending workloads | `oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/clusterqueues/<name>/pendingworkloads` |
+| ConfigMap content | `oc get configmap <name> -n <namespace> -o jsonpath='{.data.controller_manager_config\.yaml}'` |
+| Operator conditions | `oc get kueue cluster -o jsonpath='{range .status.conditions[*]}{.type}={.status} reason={.reason}{"\n"}{end}'` |
+| Deployment ready | `oc get deployment <name> -n <namespace> -o jsonpath='{.status.readyReplicas}/{.status.replicas}'` |
+| Events | `oc get events -n <namespace> --field-selector reason=<Reason>` |
+| DRA resource usage | `oc get workload -n <namespace> -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{range .status.admission.podSetAssignments[*]}{range $k,$v := .resourceUsage}  {$k}={$v}{"\n"}{end}{end}'` |
+
+If the test creates Kubernetes resources inline (ResourceFlavor, ClusterQueue,
+LocalQueue, ResourceClaimTemplate, etc.), include the YAML manifests in the
+setup steps using heredoc format:
+
+```bash
+cat <<'EOF' | oc apply -f -
+apiVersion: ...
+kind: ...
+...
+EOF
+```
+
+### Step 5: Generate the Markdown
+
+Create the file at `test/docs/cases/<filename>.md` where `<filename>` is the Go
+file name without the `_test.go` suffix (e.g., `e2e_dra.md` from
+`e2e_dra_test.go`).
+
+Use this structure:
+
+```markdown
+# Test Case: <Feature Name>
+
+- **Test file:** [`test/e2e/<filename>_test.go`](../../e2e/<filename>_test.go)
+- **Feature:** <feature name from Describe block>
+- **JIRA:** <JIRA link if found, otherwise "TBD">
+- **Automation status:** Automated
+- **Since release:** <version if known, otherwise "TBD">
+- **Labels:** `<labels from Describe block>`
+
+## Description
+
+<2-3 sentences explaining what the feature does and what these tests validate.
+Derive this from the Describe block name and the test scenarios.>
+
+## Scenarios
+
+1. [Scenario title](#1-scenario-title-slug)
+2. [Scenario title](#2-scenario-title-slug)
+...
+
+## Prerequisites
+
+<Extract from BeforeAll, imports, and skip conditions. Include:>
+- Required operator/component state
+- Required cluster configuration
+- Environment constraints (e.g., "Not supported on HyperShift")
+- RBAC requirements
+
+## Test Scenarios
+
+### 1. <Short scenario title>
+
+- **Ginkgo:** `When <context> / <It description>`
+<If there's a skip condition, add:>
+- **Skipped on:** <condition>
+<If it's a negative test, add:>
+- **Type:** Negative test
+<If there's a known issue, add:>
+- **Known issue:** <bug reference and description>
+<If the scenario changes global config, add:>
+- **Important:** <warning about side effects>
+
+**Setup:**
+
+<Numbered list of setup steps. Plain text for actions.>
+
+**Execution:**
+
+<Numbered list of execution steps. Plain text for actions, oc commands for
+verification steps. Each verification step includes:>
+```bash
+<oc command>
+# Expected: <what to look for>
+```
+
+**Expected Result:**
+
+<Bulleted list of expected outcomes. Include oc commands for verification.>
+
+**Cleanup:**
+
+```bash
+<oc delete commands in reverse creation order>
+```
+
+---
+
+<Repeat for each scenario>
+```
+
+### Step 6: Update Test Plan References
+
+After creating the test case doc:
+
+1. Check if `test/docs/plans/` contains any test plan files
+2. If test plans exist, look for the test cases traceability table
+3. If the new test case is listed as "TBD", update it with a link to the new doc
+4. If the test case is not listed at all, inform the user they may want to add it
+
+### Step 7: Present Results
+
+Show the user:
+1. The path to the created file
+2. A summary of what was generated (number of scenarios, any skipped conditions,
+   any known issues found)
+3. Ask if they want to review or modify anything
+
+## Important Guidelines
+
+- **Do NOT invent test scenarios** — only document what exists in the Go file
+- **Do NOT add steps not in the Go file** — the doc must match the automation
+- **Action steps = plain text, verification steps = oc commands** — this is the
+  consistent pattern
+- **Include cleanup for every scenario** — derived from DeferCleanup calls
+- **Flag global config changes** — if a scenario modifies cluster-wide config
+  (APIServer CR, Kueue operand), add an Important note
+- **Preserve the Ginkgo path exactly** — it's the traceability link to the code
+- **Include YAML manifests** when tests create resources inline — someone running
+  manually needs the actual YAML, not just "create a ClusterQueue"

--- a/.claude/commands/create-test-code.md
+++ b/.claude/commands/create-test-code.md
@@ -1,0 +1,428 @@
+# Create Test Code from Manual Test Case
+
+Generate a Ginkgo E2E test file (`.go`) from a manual test case document
+(`.md`), following the patterns and conventions used in the existing test suite.
+
+## Usage
+
+```
+/create-test-code test/docs/cases/e2e_dra.md
+/create-test-code test/docs/cases/e2e_preemption.md
+/create-test-code
+```
+
+- Pass the path to a test case markdown file to generate Go test code
+- If no argument is provided, the skill lists available `.md` files in
+  `test/docs/cases/` and asks you to pick one
+
+## Arguments
+
+- $ARGUMENTS: Path to a test case markdown file (e.g.,
+  `test/docs/cases/e2e_dra.md`)
+
+## Process
+
+### Step 1: Validate Input
+
+1. Check that the provided file path exists and ends with `.md`
+2. If no argument is provided, list all `.md` files under `test/docs/cases/`.
+   Show the first 5 files as numbered options, then add an option "Show all
+   files" to display the complete list, and allow the user to type a filename
+   directly
+3. Determine the output Go file name: derive from the markdown filename by
+   adding `_test.go` suffix (e.g., `e2e_dra.md` → `e2e_dra_test.go`)
+4. Check if the Go test file already exists in `test/e2e/` — if so, ask the
+   user whether to overwrite, merge (add missing scenarios), or skip
+
+### Step 2: Read the Manual Test Case
+
+Read the markdown file and extract:
+
+1. **Feature name and labels** from the header metadata (Test file, Feature,
+   Labels fields)
+2. **Prerequisites** — these become `BeforeAll` / `BeforeEach` setup
+3. **Each scenario** — map to a `When` / `It` block:
+   - Scenario title → `When("...", func() {`
+   - Ginkgo path (if present) → use the exact `When` and `It` descriptions
+   - Setup steps → code before the main assertions
+   - Execution steps → the body of the `It` block, wrapped in `By("...")` calls
+   - Expected results → `Expect` / `Eventually` / `Consistently` assertions
+   - Cleanup steps → `DeferCleanup` calls
+4. **Skip conditions** (e.g., "Skipped on: HyperShift") → `Skip("...")` calls
+5. **Known issues** — add as comments in the test
+6. **Important notes** about global config changes — save/restore patterns
+
+### Step 3: Learn the Repo Patterns
+
+Before generating code, read and understand the existing patterns. This is
+critical — the generated code must look like it belongs in this repo.
+
+#### 3a: Read Test Utilities
+
+Read ALL files in `test/e2e/testutils/`:
+
+- `builders.go` — resource builders (NewClusterQueue, NewLocalQueue,
+  NewResourceFlavor, etc.). Learn the builder API: which methods are available,
+  what they return, how cleanup functions work
+- `client.go` — client setup and available client types
+- `constants.go` — shared constants (timeouts, labels, namespaces, image refs)
+- `utils.go` — helper functions (WaitForAllPodsInNamespaceDeleted,
+  IsJobSuspended, IsJobPodRunning, DumpKueueControllerManagerLogs, etc.)
+
+#### 3b: Read Existing Test Files
+
+Read ALL `e2e_*_test.go` files in `test/e2e/` to learn:
+
+1. **Import patterns** — which packages are imported and how they're aliased
+   (e.g., `ssv1`, `kueuev1beta2`, `metav1`)
+2. **Global variables** — what's available from `e2e_suite_test.go` (e.g.,
+   `kubeClient`, `clients`, `visibilityClient`)
+3. **Helper functions defined in test files** — functions like
+   `enableAdmissionFairSharing`, `createClusterRoleBinding`,
+   `checkWorkloadCondition`, `newLongRunningJob`, `applyKueueConfig`. These
+   are NOT in testutils but in specific test files. If a needed helper exists
+   in another test file, reuse the pattern — do NOT duplicate the function if
+   it's in the same package
+4. **Resource creation patterns:**
+   - Builders: `testutils.NewClusterQueue().WithGenerateName().WithCPU("2").WithMemory("200Mi").WithFlavorName(rf.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)`
+   - Raw client: `kubeClient.BatchV1().Jobs(namespace.Name).Create(ctx, job, metav1.CreateOptions{})`
+   - Namespace creation with labels
+5. **Cleanup patterns:**
+   - `DeferCleanup(cleanupFunc)` for builder-created resources
+   - `DeferCleanup(func(ctx context.Context) { ... })` for inline cleanup
+   - Cleanup order: resources deleted in reverse creation order
+6. **Assertion patterns:**
+   - `Eventually(func() bool { ... }, timeout, poll).Should(BeTrue(), "message")`
+   - `Eventually(func(g Gomega) { g.Expect(...) }, timeout, poll).Should(Succeed())`
+   - `Consistently(func() bool { ... }, timeout, poll).Should(BeTrue())`
+   - `Expect(err).NotTo(HaveOccurred(), "message")`
+7. **By() step descriptions** — how they're worded (e.g., "Creating Resource
+   Flavor", "Verifying Job1 workload is admitted")
+8. **Describe/When/It structure:**
+   - `Describe("Feature Name", Label("label"), Ordered, func() {`
+   - `When("context description", func() {`
+   - `It("should do something", func(ctx context.Context) {`
+9. **JustAfterEach for debug logging:**
+   - `JustAfterEach(func(ctx context.Context) { testutils.DumpKueueControllerManagerLogs(ctx, kubeClient, 500) })`
+10. **Config save/restore patterns:**
+    - Save in `BeforeAll` or at the start of an `It`
+    - Restore via `DeferCleanup`
+
+### Step 4: Map Manual Steps to Go Code
+
+For each scenario in the markdown:
+
+1. **Setup steps** → translate to resource creation code:
+   - "Create a ResourceFlavor" → use `testutils.NewResourceFlavor()` builder
+   - "Create a ClusterQueue with 2 CPUs..." → use
+     `testutils.NewClusterQueue().WithCPU("2").WithMemory("200Mi")...`
+   - "Create a namespace with the openshift-managed label" → use
+     `kubeClient.CoreV1().Namespaces().Create(...)` with label map
+   - "Create LocalQueue X with fairSharingWeight: Y" → use
+     `testutils.NewLocalQueue(...).WithFairSharingWeight("Y")...`
+   - "Save the current Kueue operand config" → get + save + DeferCleanup
+     restore
+
+2. **Action steps** (plain text in the markdown) → translate to API calls:
+   - "Submit job X on queue Y requesting Z CPU" → create a Job using the
+     pattern from existing test files (check for helpers like
+     `newLongRunningJob`)
+   - "Delete job X" → `kubeClient.BatchV1().Jobs(ns).Delete(...)`
+   - "Set the APIServer TLS profile to Modern" → use
+     `updateAPIServerTLSProfile` if it exists, otherwise create the function
+
+3. **Verification steps** (with `oc` commands in the markdown) → translate to
+   assertions:
+   - "Verify workload is admitted" → `checkWorkloadCondition(ctx, ns, uid, kueuev1beta2.WorkloadAdmitted, name)` if the helper exists, otherwise write an `Eventually` block
+   - "Verify job is suspended" → `testutils.IsJobSuspended(ctx, kubeClient, ns, name)`
+   - "Verify pod is running" → `testutils.IsJobPodRunning(ctx, kubeClient, ns, name)`
+   - "Wait for consumedResources.cpu > 0" → `Eventually` with client get +
+     status check
+   - "Verify Degraded condition" → `Eventually` checking
+     `kueueInstance.Status.Conditions`
+
+4. **Cleanup steps** → translate to `DeferCleanup`:
+   - Builder-created resources: use the cleanup function returned by
+     `CreateWithObject`
+   - Namespaces: `DeferCleanup(func(ctx context.Context) { kubeClient.CoreV1().Namespaces().Delete(...) })`
+   - Config restore: `DeferCleanup(func(ctx context.Context) { applyKueueConfig(ctx, savedConfig, kubeClient) })`
+
+### Step 5: Generate the Go File
+
+Create the file at `test/e2e/<filename>_test.go`.
+
+Structure:
+
+```go
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+...
+*/
+
+package e2e
+
+import (
+    // standard library imports
+    // third-party imports (ginkgo, gomega, openshift APIs)
+    // internal imports (testutils, kueue APIs)
+    // kubernetes imports
+)
+
+var _ = Describe("<Feature Name>", Label("<labels>"), Ordered, func() {
+    // shared variables
+    var (
+        ...
+    )
+
+    JustAfterEach(func(ctx context.Context) {
+        testutils.DumpKueueControllerManagerLogs(ctx, kubeClient, 500)
+    })
+
+    BeforeAll(func(ctx context.Context) {
+        // shared setup from prerequisites
+    })
+
+    When("<context from scenario>", func() {
+        It("<expected behavior>", func(ctx context.Context) {
+            By("<step description>")
+            // step code
+
+            By("<step description>")
+            // step code
+            ...
+        })
+    })
+
+    // repeat for each scenario
+})
+
+// helper functions at the bottom of the file
+```
+
+### Step 6: Ensure Test Case Doc Exists in the Repo
+
+After generating the Go file, check if a corresponding test case markdown doc
+exists at `test/docs/cases/`:
+
+1. Derive the expected doc path from the Go filename:
+   `e2e_dra_er_alpha2_test.go` → `test/docs/cases/e2e_dra_er_alpha2.md`
+2. If the doc already exists, skip this step
+3. If it does NOT exist, generate it using the same model as `/create-test-case`:
+   - Use the input markdown as the source for scenarios, steps, and
+     prerequisites
+   - Adapt it to the repo's test case doc format (header metadata, description,
+     scenarios list, setup/execution/expected result/cleanup per scenario)
+   - Follow the Option B pattern: `oc` commands only on verification steps
+   - Place it at `test/docs/cases/<name>.md`
+4. Update any test plan files in `test/docs/plans/` that have a traceability
+   table — if the test case was listed as "TBD", update it with a link to the
+   new doc
+
+This ensures both the Go code and its manual test case doc are always in sync
+inside the repo, regardless of where the source markdown came from.
+
+### Step 7: Verify the Generated Code
+
+After generating:
+
+1. Check that the file compiles:
+   ```bash
+   cd test/e2e && go vet ./...
+   ```
+2. If there are compilation errors, fix them by:
+   - Checking import paths
+   - Verifying builder method names exist in `testutils/builders.go`
+   - Verifying helper function signatures match
+3. Report any functions that need to be created (not found in existing code)
+
+### Step 8: Present Results
+
+Show the user:
+1. The path to the created file
+2. A summary: number of scenarios generated, any helper functions that were
+   reused from other test files, any new helpers that need to be created
+3. If new helper functions are needed, suggest where to put them (in the test
+   file itself or in `testutils/`)
+4. Ask if they want to review or modify anything
+
+## Important Guidelines
+
+- **Match existing code style exactly** — indentation, naming, import ordering,
+  error message format must match what exists in the repo
+- **Reuse helpers, don't duplicate** — if `checkWorkloadCondition` exists in
+  another test file in the same package, call it directly (same package = no
+  import needed). Do NOT copy-paste the function
+- **Reuse builder patterns** — always use `testutils.New*()` builders when
+  available instead of raw API calls
+- **Use the same timeouts** — `testutils.OperatorReadyTime`,
+  `testutils.OperatorPoll`, `testutils.ConsistentlyTimeout`, etc.
+- **Use the same image refs** — `testutils.GetContainerImageForWorkloads()`
+  for workload containers
+- **Every By() step must match a step in the markdown** — the Go code and the
+  manual doc should be traceable to each other
+- **Include the copyright header** — use the same license header as other test
+  files
+- **Do NOT invent scenarios** — only generate code for scenarios in the markdown
+- **If a helper function doesn't exist and is needed**, create it at the bottom
+  of the test file (not in testutils) unless it would be useful across multiple
+  test files
+
+## Kueue E2E Test Patterns (Mandatory)
+
+These patterns are the project's established conventions. All generated code
+MUST follow them.
+
+### Kueue Config Updates
+
+Use `applyKueueConfig(ctx, config, kubeClient)` to update the Kueue instance
+config. It handles fetching, updating, waiting for deployment resource version
+change, and waiting for readiness. Do NOT manually patch + wait for deployment.
+
+In `AfterAll` or `DeferCleanup`, call `applyKueueConfig` with the saved initial
+config — no need to patch-remove fields first. For robust restoration, use
+`restoreKueueConfig` which includes conflict retry via `Eventually`.
+
+### Job Suspension Checks
+
+Use `testutils.IsJobSuspended(ctx, kubeClient, namespace, jobName)`. Do NOT
+fetch Workloads and iterate OwnerReferences.
+
+```go
+// Verify a job stays pending
+Consistently(func() bool {
+    return testutils.IsJobSuspended(ctx, kubeClient, ns, name)
+}, testutils.ConsistentlyTimeout, testutils.ConsistentlyPoll).Should(BeTrue())
+
+// Verify a job gets admitted
+Eventually(func() bool {
+    return !testutils.IsJobSuspended(ctx, kubeClient, ns, name)
+}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
+```
+
+### Cleanup with DeferCleanup
+
+Prefer Ginkgo's `DeferCleanup` over Go's `defer`. Always register
+`DeferCleanup` immediately after capturing the state you need to restore,
+BEFORE any assertions that could fail. If `DeferCleanup` is registered after
+a failing assertion, cleanup never runs and state leaks.
+
+```go
+// Good — cleanup registered before assertions
+savedConfig := kueueInstance.Spec.Config
+DeferCleanup(func(ctx context.Context) {
+    applyKueueConfig(ctx, savedConfig, kubeClient)
+})
+applyKueueConfig(ctx, desiredConfig, kubeClient)
+Eventually(...).Should(Succeed())
+
+// Bad — cleanup registered after assertions
+applyKueueConfig(ctx, desiredConfig, kubeClient)
+Eventually(...).Should(Succeed()) // if this fails, DeferCleanup never registers
+DeferCleanup(func(ctx context.Context) { ... })
+```
+
+### Cleanup Function Nil-Guards
+
+When cleanup functions are declared as `var` and assigned in
+`BeforeEach`/`BeforeAll`, always nil-check before calling in
+`AfterEach`/`AfterAll`. If setup fails partway, unassigned cleanup functions
+will be nil and panic.
+
+```go
+AfterEach(func(ctx context.Context) {
+    deleteNamespace(ctx, ns)
+    if cleanupLQ != nil { cleanupLQ() }
+    if cleanupCQ != nil { cleanupCQ() }
+    if cleanupRF != nil { cleanupRF() }
+})
+```
+
+### Always Capture Cleanup Functions
+
+Never discard cleanup functions returned by resource creation helpers. Every
+test in the repo captures and defers/calls them.
+
+```go
+// Good
+lq, cleanupLQ, err := testutils.NewLocalQueue(ns.Name, "lq").
+    WithClusterQueue(cq.Name).
+    CreateWithObject(ctx, clients.UpstreamKueueClient)
+
+// Bad — cleanup discarded
+lq, _, err := testutils.NewLocalQueue(ns.Name, "lq").
+    WithClusterQueue(cq.Name).
+    CreateWithObject(ctx, clients.UpstreamKueueClient)
+```
+
+### Test Resource Isolation
+
+Create test resources (ResourceFlavor, ClusterQueue, Namespace, LocalQueue)
+inside each `It` block rather than in `BeforeAll`/`BeforeEach`. This keeps
+tests self-contained and avoids shared state issues.
+
+### Timeout Constants
+
+Use `testutils` constants — never hardcode durations:
+
+- `testutils.ConsistentlyTimeout` / `testutils.ConsistentlyPoll` — short
+  consistency checks
+- `testutils.ConsistentlyLongTimeout` / `testutils.ConsistentlyLongPoll` —
+  longer consistency checks
+- `testutils.OperatorReadyTime` / `testutils.OperatorPoll` — Eventually checks
+
+### Descriptive Failure Messages
+
+Always include a descriptive failure message in
+`Expect(err).NotTo(HaveOccurred())` calls:
+
+```go
+// Good
+Expect(err).NotTo(HaveOccurred(), "Failed to create resource flavor")
+
+// Bad
+Expect(err).NotTo(HaveOccurred())
+```
+
+### Error Variable Reuse
+
+Reuse a single `err` variable across all resource creation calls. Do NOT
+introduce `err2`, `err3`, etc.
+
+```go
+var err error
+ns, err = kubeClient.CoreV1().Namespaces().Create(...)
+Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
+
+rf, cleanupRF, err = testutils.NewResourceFlavor()...
+Expect(err).NotTo(HaveOccurred(), "Failed to create resource flavor")
+```
+
+### Reuse Existing Job Helpers
+
+Do not create duplicate job builder functions. If a parameterized job builder
+already exists in the same file or package (e.g.,
+`newLongRunningJob(name, namespace, queueName, cpu, memory)`), reuse it.
+
+### Job Deletion — Inline Delete
+
+Do not create custom job deletion helpers. Use inline delete with
+`DeletePropagationBackground` and let `Eventually` handle waiting:
+
+```go
+err = kubeClient.BatchV1().Jobs(ns.Name).Delete(ctx, job.Name, metav1.DeleteOptions{
+    PropagationPolicy: ptr.To(metav1.DeletePropagationBackground),
+})
+Expect(err).NotTo(HaveOccurred(), "Failed to delete job")
+```
+
+### Describe Labels
+
+Use kebab-case for `Label()` values. Include `"operator"` only if needed
+(like DRA tests):
+
+```go
+Label("admission-fair-sharing")
+Label("operator", "dra", "dra-extended-resources")
+```

--- a/test/docs/cases/e2e_admission_fair_sharing.md
+++ b/test/docs/cases/e2e_admission_fair_sharing.md
@@ -1,0 +1,339 @@
+# Test Case: Admission Fair Sharing
+
+- **Test file:**
+  [`test/e2e/e2e_admission_fair_sharing_test.go`](../../e2e/e2e_admission_fair_sharing_test.go)
+- **Feature:** Admission Fair Sharing
+- **JIRA:** [OCPSTRAT-2588](https://redhat.atlassian.net/browse/OCPSTRAT-2588)
+- **Automation status:** Automated
+- **Since release:** 1.4
+- **Labels:** `admission-fair-sharing`
+
+## Description
+
+Admission Fair Sharing enables usage-based scheduling across LocalQueues within
+a ClusterQueue. Instead of FIFO ordering, Kueue tracks historical resource
+consumption per queue and prioritizes queues that have consumed fewer resources
+relative to their weight. This ensures fair distribution of cluster capacity
+among competing tenants.
+
+These tests validate that the fair sharing mechanism correctly prioritizes
+workloads based on queue weights, resource usage history, and configurable
+resource scoring weights.
+
+## Scenarios
+
+1. [Higher-weight LocalQueue gets priority](#1-higher-weight-localqueue-gets-priority)
+2. [Sampling interval controls lastUpdate cadence](#2-sampling-interval-controls-lastupdate-cadence)
+3. [Visibility API reflects usage-based ordering](#3-visibility-api-reflects-usage-based-ordering)
+4. [Resource weights customize scoring](#4-resource-weights-customize-scoring)
+
+## Prerequisites
+
+- Kueue operator installed and running
+- AdmissionFairSharing enabled on the Kueue operand CR with:
+  - `usageHalfLifeTimeSeconds: 60`
+  - `usageSamplingIntervalSeconds: 5`
+- Namespace with the `openshift-managed` label
+- RBAC for visibility API access (scenario 3 only)
+
+## Test Scenarios
+
+### 1. Higher-weight LocalQueue gets priority
+
+- **Ginkgo:** `When LocalQueues have different FairSharing weight values /
+  should prioritize the higher-weight LocalQueue when quota frees up`
+
+**Setup:**
+
+1. Create a ResourceFlavor
+2. Create a ClusterQueue with 2 CPUs, 200Mi memory, scope
+   `UsageBasedAdmissionFairSharing`
+3. Create a namespace with the `openshift-managed` label
+4. Create LocalQueue `lq-heavy` with `fairSharingWeight: 1`
+5. Create LocalQueue `lq-light` with `fairSharingWeight: 2`
+
+**Execution:**
+
+1. Submit `job-heavy-1` on `lq-heavy` requesting 1 CPU, 50Mi memory
+2. Verify `job-heavy-1` workload is admitted:
+   ```bash
+   oc get workloads -n <namespace> -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.conditions[?(@.type=="Admitted")].status}{"\n"}{end}'
+   # Expected: job-heavy-1 workload shows Admitted=True
+   ```
+3. Verify `job-heavy-1` pod is running:
+   ```bash
+   oc get pods -n <namespace> -l job-name=job-heavy-1 -o jsonpath='{.items[0].status.phase}'
+   # Expected: Running
+   ```
+4. Submit `job-light-1` on `lq-light` requesting 1 CPU, 50Mi memory
+5. Verify `job-light-1` workload is admitted and pod is running (same commands
+   as steps 2-3)
+6. Verify both LocalQueues show `consumedResources.cpu > 0`:
+   ```bash
+   oc get localqueue lq-heavy -n <namespace> -o jsonpath='{.status.fairSharing.admissionFairSharingStatus.consumedResources.cpu}'
+   oc get localqueue lq-light -n <namespace> -o jsonpath='{.status.fairSharing.admissionFairSharingStatus.consumedResources.cpu}'
+   # Expected: both values > 0
+   ```
+7. Submit `job-heavy-2` on `lq-heavy` requesting 800m CPU, 100Mi memory
+8. Submit `job-light-2` on `lq-light` requesting 800m CPU, 50Mi memory
+9. Verify both pending jobs are suspended:
+   ```bash
+   oc get job job-heavy-2 -n <namespace> -o jsonpath='{.spec.suspend}'
+   oc get job job-light-2 -n <namespace> -o jsonpath='{.spec.suspend}'
+   # Expected: both return true
+   ```
+10. Wait ~30 seconds and verify both jobs remain suspended (same command as
+    step 9)
+11. Delete `job-heavy-1` to free 1 CPU
+
+**Expected Result:**
+
+- `job-light-2` (lq-light, weight=2) is admitted:
+  ```bash
+  oc get job job-light-2 -n <namespace> -o jsonpath='{.spec.suspend}'
+  # Expected: false
+  ```
+- `job-heavy-2` (lq-heavy, weight=1) remains suspended:
+  ```bash
+  oc get job job-heavy-2 -n <namespace> -o jsonpath='{.spec.suspend}'
+  # Expected: true
+  ```
+
+**Cleanup:**
+
+```bash
+oc delete jobs --all -n <namespace>
+oc delete localqueue lq-heavy lq-light -n <namespace>
+oc delete clusterqueue <cq-name>
+oc delete resourceflavor <rf-name>
+oc delete namespace <namespace>
+```
+
+---
+
+### 2. Sampling interval controls lastUpdate cadence
+
+- **Ginkgo:** `When usageSamplingIntervalSeconds controls lastUpdate cadence /
+  should advance lastUpdate timestamps at approximately the configured sampling
+  interval`
+
+**Setup:**
+
+1. Create a ResourceFlavor
+2. Create a ClusterQueue with 2 CPUs, 200Mi memory, scope
+   `UsageBasedAdmissionFairSharing`
+3. Create a namespace with the `openshift-managed` label
+4. Create LocalQueue `lq-sampling`
+
+**Execution:**
+
+1. Submit `job-sampling` on `lq-sampling` requesting 1 CPU, 50Mi memory
+2. Verify the workload is admitted and the pod is running:
+   ```bash
+   oc get workloads -n <namespace> -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.conditions[?(@.type=="Admitted")].status}{"\n"}{end}'
+   # Expected: Admitted=True
+   oc get pods -n <namespace> -l job-name=job-sampling -o jsonpath='{.items[0].status.phase}'
+   # Expected: Running
+   ```
+3. Wait for the initial `lastUpdate` timestamp to appear:
+   ```bash
+   oc get localqueue lq-sampling -n <namespace> -o jsonpath='{.status.fairSharing.admissionFairSharingStatus.lastUpdate}'
+   # Expected: non-empty timestamp
+   ```
+4. Record the `lastUpdate` timestamp
+5. Wait ~5-10 seconds, then check that `lastUpdate` has advanced (same command
+   as step 3) — record the new value
+6. Repeat step 5 two more times (3 consecutive intervals total)
+7. Calculate the interval between each pair of consecutive timestamps
+
+**Expected Result:**
+
+- Each interval between consecutive `lastUpdate` timestamps is approximately
+  equal to the configured `usageSamplingIntervalSeconds` (5s), within a
+  tolerance of -2s / +5s
+
+**Cleanup:**
+
+```bash
+oc delete job job-sampling -n <namespace>
+oc delete localqueue lq-sampling -n <namespace>
+oc delete clusterqueue <cq-name>
+oc delete resourceflavor <rf-name>
+oc delete namespace <namespace>
+```
+
+---
+
+### 3. Visibility API reflects usage-based ordering
+
+- **Ginkgo:** `When VisibilityOnDemand reflects usage-based ordering / should
+  report pending workloads in usage-based order, not FIFO`
+
+**Setup:**
+
+1. Create a ClusterRoleBinding for visibility API access (bind `default` SA in
+   the operator namespace to `kueue-batch-admin-role`)
+2. Create a ResourceFlavor
+3. Create a ClusterQueue with 2 CPUs, 2Gi memory, scope
+   `UsageBasedAdmissionFairSharing`
+4. Create a namespace with the `openshift-managed` label
+5. Create LocalQueue `lq1` (will accumulate usage)
+6. Create LocalQueue `lq2` (will stay at zero usage)
+
+**Execution:**
+
+1. Submit `job1` on `lq1` requesting 1 CPU, 200Mi
+2. Submit `job2` on `lq1` requesting 1 CPU, 200Mi
+3. Verify both jobs are admitted and running:
+   ```bash
+   oc get workloads -n <namespace> -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.conditions[?(@.type=="Admitted")].status}{"\n"}{end}'
+   # Expected: both workloads show Admitted=True
+   ```
+4. Verify ClusterQueue is saturated (2/2 CPU used):
+   ```bash
+   oc get clusterqueue <cq-name> -o jsonpath='{.status.flavorsUsage[0].resources[?(@.name=="cpu")].total}'
+   # Expected: 2 (or equivalent)
+   ```
+5. Verify `lq1` has accumulated usage (`consumedResources.cpu > 0`):
+   ```bash
+   oc get localqueue lq1 -n <namespace> -o jsonpath='{.status.fairSharing.admissionFairSharingStatus.consumedResources.cpu}'
+   # Expected: > 0
+   ```
+6. Verify `lq2` has zero CPU usage:
+   ```bash
+   oc get localqueue lq2 -n <namespace> -o jsonpath='{.status.fairSharing.admissionFairSharingStatus.consumedResources.cpu}'
+   # Expected: 0
+   ```
+7. Submit `job3` on `lq1` (high-usage queue) requesting 1 CPU, 200Mi
+8. Submit `job4` on `lq2` (zero-usage queue) requesting 1 CPU, 200Mi
+9. Verify both `job3` and `job4` are suspended:
+   ```bash
+   oc get job job3 -n <namespace> -o jsonpath='{.spec.suspend}'
+   oc get job job4 -n <namespace> -o jsonpath='{.spec.suspend}'
+   # Expected: both true
+   ```
+10. Query the VisibilityOnDemand API and verify usage-based ordering:
+    ```bash
+    oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/clusterqueues/<cq-name>/pendingworkloads
+    # Expected ordering:
+    #   Position 0 (positionInClusterQueue: 0): job4 workload (lq2, zero usage)
+    #   Position 1 (positionInClusterQueue: 1): job3 workload (lq1, high usage)
+    ```
+11. Delete `job1` to free 1 CPU
+
+**Expected Result:**
+
+- `job4` (lq2, position 0) is admitted:
+  ```bash
+  oc get job job4 -n <namespace> -o jsonpath='{.spec.suspend}'
+  # Expected: false
+  ```
+- `job3` (lq1, position 1) remains suspended:
+  ```bash
+  oc get job job3 -n <namespace> -o jsonpath='{.spec.suspend}'
+  # Expected: true
+  ```
+
+**Cleanup:**
+
+```bash
+oc delete jobs --all -n <namespace>
+oc delete localqueue lq1 lq2 -n <namespace>
+oc delete clusterqueue <cq-name>
+oc delete resourceflavor <rf-name>
+oc delete clusterrolebinding test-visibility
+oc delete namespace <namespace>
+```
+
+---
+
+### 4. Resource weights customize scoring
+
+- **Ginkgo:** `When resourceWeights customizes which resources drive fair
+  sharing scoring / should deprioritize the queue with higher weighted CPU usage
+  when cpu weight is 10 and memory weight is 0`
+- **Known issue:** Upstream bug kubernetes-sigs/kueue#10434 (OCPBUGS-85113) —
+  memory resourceWeights are counted in raw bytes instead of GiB, so non-zero
+  memory weights produce unintuitive scores. Workaround: set memory weight to
+  "0".
+- **Important:** This scenario reconfigures the global Kueue operand CR with
+  different values (`usageHalfLifeTimeSeconds: 10`,
+  `usageSamplingIntervalSeconds: 1`). If running scenarios out of order, ensure
+  the Kueue config is set correctly before each scenario. The automated test
+  saves and restores the original config via `DeferCleanup`.
+
+**Setup:**
+
+1. Save the current Kueue operand config (to restore later)
+2. Configure Kueue operand with AdmissionFairSharing:
+   - `usageHalfLifeTimeSeconds: 10`
+   - `usageSamplingIntervalSeconds: 1`
+   - `resourceWeights: [{name: cpu, weight: "10"}, {name: memory, weight: "0"}]`
+3. Verify `kueue-manager-config` ConfigMap reflects the settings:
+   ```bash
+   oc get configmap kueue-manager-config -n openshift-kueue-operator -o jsonpath='{.data.controller_manager_config\.yaml}'
+   # Expected: contains usageHalfLifeTime: 10s, usageSamplingInterval: 1s,
+   #           cpu: 10, memory: 0
+   ```
+4. Create a ResourceFlavor
+5. Create a ClusterQueue with 2 CPUs, 2Gi memory, scope
+   `UsageBasedAdmissionFairSharing`
+6. Create a namespace with the `openshift-managed` label
+7. Create LocalQueue `lq-cpu-heavy` with `fairSharingWeight: 1`
+8. Create LocalQueue `lq-cpu-light` with `fairSharingWeight: 1`
+
+**Execution:**
+
+1. Submit `job-heavy` on `lq-cpu-heavy` requesting 1500m CPU, 500Mi memory
+2. Submit `job-light` on `lq-cpu-light` requesting 500m CPU, 1Mi memory
+3. Verify both jobs are admitted and running:
+   ```bash
+   oc get workloads -n <namespace> -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.conditions[?(@.type=="Admitted")].status}{"\n"}{end}'
+   # Expected: both workloads show Admitted=True
+   oc get pods -n <namespace> -l job-name=job-heavy -o jsonpath='{.items[0].status.phase}'
+   oc get pods -n <namespace> -l job-name=job-light -o jsonpath='{.items[0].status.phase}'
+   # Expected: both Running
+   ```
+4. Verify both LocalQueues show `consumedResources.cpu > 0`:
+   ```bash
+   oc get localqueue lq-cpu-heavy -n <namespace> -o jsonpath='{.status.fairSharing.admissionFairSharingStatus.consumedResources.cpu}'
+   oc get localqueue lq-cpu-light -n <namespace> -o jsonpath='{.status.fairSharing.admissionFairSharingStatus.consumedResources.cpu}'
+   # Expected: both > 0
+   ```
+5. Submit `job-heavy-pending` on `lq-cpu-heavy` requesting 1500m CPU, 500Mi
+6. Submit `job-light-pending` on `lq-cpu-light` requesting 1500m CPU, 1Mi
+7. Verify both pending jobs are suspended:
+   ```bash
+   oc get job job-heavy-pending -n <namespace> -o jsonpath='{.spec.suspend}'
+   oc get job job-light-pending -n <namespace> -o jsonpath='{.spec.suspend}'
+   # Expected: both true
+   ```
+8. Wait ~30 seconds and verify both jobs remain suspended (same command as
+   step 7)
+9. Delete `job-heavy` to free 1500m CPU
+
+**Expected Result:**
+
+- `job-light-pending` (lq-cpu-light, lower weighted CPU usage) is admitted:
+  ```bash
+  oc get job job-light-pending -n <namespace> -o jsonpath='{.spec.suspend}'
+  # Expected: false
+  ```
+- `job-heavy-pending` (lq-cpu-heavy, higher weighted CPU usage) remains
+  suspended:
+  ```bash
+  oc get job job-heavy-pending -n <namespace> -o jsonpath='{.spec.suspend}'
+  # Expected: true
+  ```
+- Memory usage does not affect the scoring (memory weight is 0)
+
+**Cleanup:**
+
+```bash
+oc delete jobs --all -n <namespace>
+oc delete localqueue lq-cpu-heavy lq-cpu-light -n <namespace>
+oc delete clusterqueue <cq-name>
+oc delete resourceflavor <rf-name>
+oc delete namespace <namespace>
+oc apply -f kueue-config-backup.yaml
+```

--- a/test/docs/cases/e2e_dra_er_alpha2.md
+++ b/test/docs/cases/e2e_dra_er_alpha2.md
@@ -1,0 +1,597 @@
+# Test Case: DRA Extended Resources Alpha-2
+
+- **Test file:**
+  [`test/e2e/e2e_dra_er_alpha2_test.go`](../../e2e/e2e_dra_er_alpha2_test.go)
+- **Feature:** DRA Extended Resources — Late DeviceClass Creation
+- **JIRA:** [OCPKUEUE-657](https://redhat.atlassian.net/browse/OCPKUEUE-657)
+- **KEP:** [2941-DRA — Late DeviceClass Creation](https://github.com/kubernetes-sigs/kueue/tree/main/keps/2941-DRA#late-deviceclass-creation)
+- **Automation status:** Partial (S1, S2 automated)
+- **Since release:** TBD
+- **Labels:** `dra`, `dra-extended-resources`
+
+## Description
+
+When a DeviceClass has `extendedResourceName` set, Kueue uses the DRA path to
+manage GPU workloads instead of the traditional extended resource path. These
+tests validate Kueue's behavior when the DeviceClass lifecycle changes relative
+to workload submission — specifically what happens when no DeviceClass exists,
+when one is created late, when one is deleted, and when its
+`extendedResourceName` is updated.
+
+This is a stateful test sequence: S1 and S2 share state (the workload created
+in S1 persists into S2 where the DeviceClass creation triggers DRA activation).
+S3 and S4 are independent but require a DeviceClass to exist at the start.
+
+## Scenarios
+
+1. [No DeviceClass — workload uses non-DRA path](#1-no-deviceclass--workload-uses-non-dra-path)
+2. [Late DeviceClass creation — DRA activation via scheduler](#2-late-deviceclass-creation--dra-activation-via-scheduler)
+3. [DeviceClass deleted — pending workloads not requeued](#3-deviceclass-deleted--pending-workloads-not-requeued)
+4. [Update extendedResourceName — affected workloads not requeued](#4-update-extendedresourcename--affected-workloads-not-requeued)
+
+## Prerequisites
+
+- OpenShift cluster with DRA feature gates enabled (`DynamicResourceAllocation`,
+  `DRAResourceClaimDeviceStatus`, `DRAExtendedResource`)
+- NVIDIA GPU nodes available (e.g., Tesla T4)
+- NVIDIA DRA driver installed (ResourceSlices available for `gpu.nvidia.com`)
+- Kueue operator installed and running
+- DeviceClass `gpu.nvidia.com` must NOT exist at the start of S1 (delete it if
+  present)
+- Kueue operand should NOT have `deviceClassMappings` configured
+
+Verify prerequisites:
+
+```bash
+oc get featuregate cluster -o yaml | grep DRAExtendedResource
+# Expected: DRAExtendedResource in the enabled list
+
+oc get resourceslices -o jsonpath='{range .items[?(@.spec.driver=="gpu.nvidia.com")]}{.metadata.name}{"\n"}{end}'
+# Expected: at least one ResourceSlice from gpu.nvidia.com
+
+oc get kueue cluster -o jsonpath='{.spec.config.resources}'
+# Expected: empty (no deviceClassMappings)
+```
+
+## Shared Setup
+
+Create the test namespace and Kueue resources used by all scenarios:
+
+```bash
+oc create namespace kueue-er-alpha2
+oc label namespace kueue-er-alpha2 kueue.openshift.io/managed="true"
+
+cat <<'EOF' | oc apply -f -
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: gpu-nodes
+spec:
+  nodeLabels:
+    nvidia.com/gpu.present: "true"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: gpu-cluster-queue
+spec:
+  namespaceSelector: {}
+  resourceGroups:
+  - coveredResources: [cpu, memory, nvidia.com/gpu]
+    flavors:
+    - name: gpu-nodes
+      resources:
+      - name: cpu
+        nominalQuota: 4
+      - name: memory
+        nominalQuota: "4Gi"
+      - name: nvidia.com/gpu
+        nominalQuota: 2
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: test-queue
+  namespace: kueue-er-alpha2
+spec:
+  clusterQueue: gpu-cluster-queue
+EOF
+```
+
+## Test Scenarios
+
+### 1. No DeviceClass — workload uses non-DRA path
+
+- **Ginkgo:** `When no DeviceClass with extendedResourceName exists / should
+  admit workload via non-DRA extended resource path but leave pod pending`
+- **Type:** Negative test — validates fallback behavior when DRA is not
+  configured
+- **Important:** S1 and S2 are sequential — the workload created here persists
+  into S2.
+
+**Setup:**
+
+1. Delete DeviceClass `gpu.nvidia.com` if it exists
+
+**Execution:**
+
+1. Verify DeviceClass does not exist:
+   ```bash
+   oc get deviceclass gpu.nvidia.com
+   # Expected: NotFound
+   ```
+2. Submit a job requesting `nvidia.com/gpu: 1`:
+   ```bash
+   cat <<'EOF' | oc apply -f -
+   apiVersion: batch/v1
+   kind: Job
+   metadata:
+     name: s1-no-deviceclass
+     namespace: kueue-er-alpha2
+     labels:
+       kueue.x-k8s.io/queue-name: test-queue
+   spec:
+     template:
+       spec:
+         restartPolicy: Never
+         securityContext:
+           seccompProfile:
+             type: RuntimeDefault
+         containers:
+         - name: test
+           image: registry.k8s.io/e2e-test-images/agnhost:2.53
+           command: ["/bin/sh"]
+           args: ["-c", "sleep 60"]
+           resources:
+             requests:
+               cpu: "100m"
+               memory: "100Mi"
+               nvidia.com/gpu: 1
+             limits:
+               nvidia.com/gpu: 1
+   EOF
+   ```
+3. Verify the workload is admitted (non-DRA extended resource path):
+   ```bash
+   oc get workloads -n kueue-er-alpha2 -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.conditions[?(@.type=="Admitted")].status}{"\n"}{end}'
+   # Expected: Admitted=True (Kueue treats nvidia.com/gpu as a regular ER)
+   ```
+4. Verify the job is unsuspended:
+   ```bash
+   oc get job s1-no-deviceclass -n kueue-er-alpha2 -o jsonpath='{.spec.suspend}'
+   # Expected: false
+   ```
+5. Verify the pod stays Pending (GPU only available via DRA, no device plugin):
+   ```bash
+   oc get pods -n kueue-er-alpha2 -l job-name=s1-no-deviceclass -o jsonpath='{.items[0].status.phase}'
+   # Expected: Pending (consistently — no device plugin advertises nvidia.com/gpu)
+   ```
+6. Verify no ResourceClaim was created (non-DRA path):
+   ```bash
+   oc get resourceclaim -n kueue-er-alpha2
+   # Expected: No resources found
+   ```
+7. Verify ClusterQueue shows nvidia.com/gpu quota consumed:
+   ```bash
+   oc get clusterqueue gpu-cluster-queue -o jsonpath='{.status.flavorsUsage}'
+   # Expected: nvidia.com/gpu total=1
+   ```
+
+**Expected Result:**
+
+- Workload is admitted via non-DRA extended resource path (Admitted=True)
+- Job is unsuspended
+- Pod stays Pending (no device plugin for nvidia.com/gpu)
+- No ResourceClaim created
+- ClusterQueue quota consumed (nvidia.com/gpu=1)
+
+**Cleanup:**
+
+Do NOT clean up — S2 depends on the workload created here.
+
+---
+
+### 2. Late DeviceClass creation — DRA activation via scheduler
+
+- **Ginkgo:** `When DeviceClass is created after workload submission / should
+  transition pod to running via scheduler-level DRA activation`
+- **Important:** Depends on S1 — the workload from S1 must still be pending.
+  Kueue does NOT requeue the workload; the DRA path activates at the scheduler
+  level after ~2 min backoff.
+
+**Setup:**
+
+1. Verify the workload from S1 is still present and the pod is Pending
+
+**Execution:**
+
+1. Verify DeviceClass does not exist:
+   ```bash
+   oc get deviceclass gpu.nvidia.com
+   # Expected: NotFound
+   ```
+2. Create DeviceClass with `extendedResourceName`:
+   ```bash
+   cat <<'EOF' | oc apply -f -
+   apiVersion: resource.k8s.io/v1
+   kind: DeviceClass
+   metadata:
+     name: gpu.nvidia.com
+   spec:
+     extendedResourceName: nvidia.com/gpu
+     selectors:
+     - cel:
+         expression: "device.driver == 'gpu.nvidia.com' && device.attributes['gpu.nvidia.com'].type == 'gpu'"
+   EOF
+   ```
+3. Verify DeviceClass was created:
+   ```bash
+   oc get deviceclass gpu.nvidia.com -o jsonpath='{.spec.extendedResourceName}'
+   # Expected: nvidia.com/gpu
+   ```
+4. Wait ~2 minutes for scheduler backoff retry, then verify the pod transitions
+   to Running:
+   ```bash
+   oc get pods -n kueue-er-alpha2 -l job-name=s1-no-deviceclass -o jsonpath='{.items[0].status.phase}'
+   # Expected: Running (after scheduler retry with new DeviceClass)
+   ```
+5. Verify a ResourceClaim was created (DRA path activated by scheduler):
+   ```bash
+   oc get resourceclaim -n kueue-er-alpha2
+   # Expected: ResourceClaim exists with STATE=allocated,reserved
+   ```
+
+**Expected Result:**
+
+- DeviceClass creation does NOT trigger Kueue-level requeue (workload was
+  already admitted in S1)
+- Scheduler-level DRA activation creates a ResourceClaim after backoff retry
+- Pod transitions from Pending to Running (~2 min delay)
+- ResourceClaim is allocated and reserved
+
+**Cleanup:**
+
+```bash
+oc delete job s1-no-deviceclass -n kueue-er-alpha2
+# Wait for workload and CQ usage to drain
+sleep 10
+oc get workloads -n kueue-er-alpha2
+# Expected: no workloads
+oc get clusterqueue gpu-cluster-queue -o jsonpath='{.status.flavorsUsage}'
+# Expected: nvidia.com/gpu total=0
+```
+
+---
+
+### 3. DeviceClass deleted — pending workloads not requeued
+
+- **Ginkgo:** TBD (not yet automated)
+- **Type:** Negative test — validates that Kueue does NOT react to DeviceClass
+  deletion
+- **Known issue:** Kueue does not watch for DeviceClass deletion events. KEP
+  2941-DRA "Late DeviceClass Creation" only covers creation, not deletion.
+
+**Setup:**
+
+1. Verify DeviceClass `gpu.nvidia.com` exists with
+   `extendedResourceName: nvidia.com/gpu`
+
+**Execution:**
+
+1. Submit two jobs to exhaust GPU quota (2 GPUs):
+   ```bash
+   cat <<'EOF' | oc apply -f -
+   apiVersion: batch/v1
+   kind: Job
+   metadata:
+     name: s3-fill-gpu-1
+     namespace: kueue-er-alpha2
+     labels:
+       kueue.x-k8s.io/queue-name: test-queue
+   spec:
+     template:
+       spec:
+         restartPolicy: Never
+         securityContext:
+           seccompProfile:
+             type: RuntimeDefault
+         containers:
+         - name: test
+           image: registry.k8s.io/e2e-test-images/agnhost:2.53
+           command: ["/bin/sh"]
+           args: ["-c", "sleep 900"]
+           resources:
+             requests:
+               cpu: "100m"
+               memory: "100Mi"
+               nvidia.com/gpu: 1
+             limits:
+               nvidia.com/gpu: 1
+   ---
+   apiVersion: batch/v1
+   kind: Job
+   metadata:
+     name: s3-fill-gpu-2
+     namespace: kueue-er-alpha2
+     labels:
+       kueue.x-k8s.io/queue-name: test-queue
+   spec:
+     template:
+       spec:
+         restartPolicy: Never
+         securityContext:
+           seccompProfile:
+             type: RuntimeDefault
+         containers:
+         - name: test
+           image: registry.k8s.io/e2e-test-images/agnhost:2.53
+           command: ["/bin/sh"]
+           args: ["-c", "sleep 900"]
+           resources:
+             requests:
+               cpu: "100m"
+               memory: "100Mi"
+               nvidia.com/gpu: 1
+             limits:
+               nvidia.com/gpu: 1
+   EOF
+   ```
+2. Verify both jobs are admitted and pods are running:
+   ```bash
+   oc get workloads -n kueue-er-alpha2
+   # Expected: both admitted
+   oc get pods -n kueue-er-alpha2
+   # Expected: both Running
+   ```
+3. Verify CQ usage shows quota exhausted:
+   ```bash
+   oc get clusterqueue gpu-cluster-queue -o jsonpath='{.status.flavorsUsage}'
+   # Expected: nvidia.com/gpu total=2
+   ```
+4. Submit a third job requesting 1 GPU (will be pending — quota full):
+   ```bash
+   cat <<'EOF' | oc apply -f -
+   apiVersion: batch/v1
+   kind: Job
+   metadata:
+     name: s3-pending-job
+     namespace: kueue-er-alpha2
+     labels:
+       kueue.x-k8s.io/queue-name: test-queue
+   spec:
+     template:
+       spec:
+         restartPolicy: Never
+         securityContext:
+           seccompProfile:
+             type: RuntimeDefault
+         containers:
+         - name: test
+           image: registry.k8s.io/e2e-test-images/agnhost:2.53
+           command: ["/bin/sh"]
+           args: ["-c", "sleep 60"]
+           resources:
+             requests:
+               cpu: "100m"
+               memory: "100Mi"
+               nvidia.com/gpu: 1
+             limits:
+               nvidia.com/gpu: 1
+   EOF
+   ```
+5. Verify third job is pending (not admitted):
+   ```bash
+   oc get workloads -n kueue-er-alpha2
+   # Expected: s3-pending-job NOT admitted
+   ```
+6. Record the pending workload's `resourceVersion` and `lastTransitionTime`:
+   ```bash
+   oc get workload -n kueue-er-alpha2 -o custom-columns='NAME:.metadata.name,RESOURCE_VERSION:.metadata.resourceVersion,LAST_TRANSITION:.status.conditions[?(@.type=="QuotaReserved")].lastTransitionTime'
+   ```
+7. Delete DeviceClass `gpu.nvidia.com`
+8. Wait ~15 seconds, then check if the pending workload was requeued:
+   ```bash
+   oc get workload -n kueue-er-alpha2 -o custom-columns='NAME:.metadata.name,RESOURCE_VERSION:.metadata.resourceVersion,LAST_TRANSITION:.status.conditions[?(@.type=="QuotaReserved")].lastTransitionTime'
+   # Expected (known issue): resourceVersion and lastTransitionTime UNCHANGED
+   ```
+9. Check controller logs for requeue activity:
+   ```bash
+   oc logs -n openshift-kueue-operator deployment/kueue-controller-manager --since=5m | grep -i "requeue\|deviceclass\|extended.resource"
+   # Expected (known issue): NO requeue entries
+   ```
+
+**Expected Result:**
+
+- **Known issue:** DeviceClass deletion does NOT trigger requeue of pending
+  workloads
+- Pending workload `resourceVersion` and `lastTransitionTime` remain unchanged
+- Running jobs are not affected
+- No controller log entries for DeviceClass deletion
+
+**Cleanup:**
+
+```bash
+oc delete job s3-fill-gpu-1 s3-fill-gpu-2 s3-pending-job -n kueue-er-alpha2
+sleep 15
+# Recreate DeviceClass for S4
+cat <<'EOF' | oc apply -f -
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: gpu.nvidia.com
+spec:
+  extendedResourceName: nvidia.com/gpu
+  selectors:
+  - cel:
+      expression: "device.driver == 'gpu.nvidia.com' && device.attributes['gpu.nvidia.com'].type == 'gpu'"
+EOF
+```
+
+---
+
+### 4. Update extendedResourceName — affected workloads not requeued
+
+- **Ginkgo:** TBD (not yet automated)
+- **Type:** Negative test — validates that Kueue does NOT react to DeviceClass
+  updates
+- **Known issue:** Combined with S3, only DeviceClass creation triggers
+  scheduler-level DRA activation. Updates and deletions are not watched by
+  Kueue.
+
+**Setup:**
+
+1. Verify DeviceClass `gpu.nvidia.com` exists with
+   `extendedResourceName: nvidia.com/gpu`
+
+**Execution:**
+
+1. Submit a job requesting 2 GPUs to exhaust quota:
+   ```bash
+   cat <<'EOF' | oc apply -f -
+   apiVersion: batch/v1
+   kind: Job
+   metadata:
+     name: s4-fill-gpu
+     namespace: kueue-er-alpha2
+     labels:
+       kueue.x-k8s.io/queue-name: test-queue
+   spec:
+     template:
+       spec:
+         restartPolicy: Never
+         securityContext:
+           seccompProfile:
+             type: RuntimeDefault
+         containers:
+         - name: test
+           image: registry.k8s.io/e2e-test-images/agnhost:2.53
+           command: ["/bin/sh"]
+           args: ["-c", "sleep 900"]
+           resources:
+             requests:
+               cpu: "100m"
+               memory: "100Mi"
+               nvidia.com/gpu: 2
+             limits:
+               nvidia.com/gpu: 2
+   EOF
+   ```
+2. Verify the job is admitted and CQ quota is exhausted:
+   ```bash
+   oc get workloads -n kueue-er-alpha2
+   # Expected: admitted
+   oc get clusterqueue gpu-cluster-queue -o jsonpath='{.status.flavorsUsage}'
+   # Expected: nvidia.com/gpu total=2
+   ```
+3. Submit a GPU-pending job (quota full):
+   ```bash
+   cat <<'EOF' | oc apply -f -
+   apiVersion: batch/v1
+   kind: Job
+   metadata:
+     name: s4-gpu-pending
+     namespace: kueue-er-alpha2
+     labels:
+       kueue.x-k8s.io/queue-name: test-queue
+   spec:
+     template:
+       spec:
+         restartPolicy: Never
+         securityContext:
+           seccompProfile:
+             type: RuntimeDefault
+         containers:
+         - name: test
+           image: registry.k8s.io/e2e-test-images/agnhost:2.53
+           command: ["/bin/sh"]
+           args: ["-c", "sleep 60"]
+           resources:
+             requests:
+               cpu: "100m"
+               memory: "100Mi"
+               nvidia.com/gpu: 1
+             limits:
+               nvidia.com/gpu: 1
+   EOF
+   ```
+4. Submit a CPU-only pending job (cpu quota full):
+   ```bash
+   cat <<'EOF' | oc apply -f -
+   apiVersion: batch/v1
+   kind: Job
+   metadata:
+     name: s4-cpu-only
+     namespace: kueue-er-alpha2
+     labels:
+       kueue.x-k8s.io/queue-name: test-queue
+   spec:
+     template:
+       spec:
+         restartPolicy: Never
+         securityContext:
+           seccompProfile:
+             type: RuntimeDefault
+         containers:
+         - name: test
+           image: registry.k8s.io/e2e-test-images/agnhost:2.53
+           command: ["/bin/sh"]
+           args: ["-c", "sleep 60"]
+           resources:
+             requests:
+               cpu: "4"
+               memory: "100Mi"
+   EOF
+   ```
+5. Verify both pending jobs are not admitted:
+   ```bash
+   oc get workloads -n kueue-er-alpha2
+   # Expected: s4-gpu-pending and s4-cpu-only NOT admitted
+   ```
+6. Record `resourceVersion` and `lastTransitionTime` for both pending workloads:
+   ```bash
+   oc get workload -n kueue-er-alpha2 -o custom-columns='NAME:.metadata.name,RESOURCE_VERSION:.metadata.resourceVersion,LAST_TRANSITION:.status.conditions[?(@.type=="QuotaReserved")].lastTransitionTime'
+   ```
+7. Update DeviceClass `extendedResourceName` to a different value:
+   ```bash
+   oc patch deviceclass gpu.nvidia.com --type='merge' -p '{"spec":{"extendedResourceName":"nvidia.com/gpu-updated"}}'
+   ```
+8. Verify the update was applied:
+   ```bash
+   oc get deviceclass gpu.nvidia.com -o jsonpath='{.spec.extendedResourceName}'
+   # Expected: nvidia.com/gpu-updated
+   ```
+9. Wait ~30 seconds, then check if workloads were requeued:
+   ```bash
+   oc get workload -n kueue-er-alpha2 -o custom-columns='NAME:.metadata.name,RESOURCE_VERSION:.metadata.resourceVersion,LAST_TRANSITION:.status.conditions[?(@.type=="QuotaReserved")].lastTransitionTime'
+   # Expected (known issue): BOTH unchanged — neither GPU nor CPU workload requeued
+   ```
+10. Check controller logs:
+    ```bash
+    oc logs -n openshift-kueue-operator deployment/kueue-controller-manager --since=5m | grep -i "requeue\|deviceclass\|extended.resource"
+    # Expected (known issue): NO requeue entries
+    ```
+
+**Expected Result:**
+
+- **Known issue:** DeviceClass update does NOT trigger targeted requeue
+- GPU-pending workload `resourceVersion` and `lastTransitionTime` unchanged
+- CPU-only workload also unchanged (correctly — but for the wrong reason, since
+  neither was requeued)
+
+**Cleanup:**
+
+```bash
+oc delete job s4-fill-gpu s4-gpu-pending s4-cpu-only -n kueue-er-alpha2
+sleep 15
+# Restore extendedResourceName to original value
+oc patch deviceclass gpu.nvidia.com --type='merge' -p '{"spec":{"extendedResourceName":"nvidia.com/gpu"}}'
+```
+
+## Full Cleanup
+
+```bash
+oc delete namespace kueue-er-alpha2
+oc delete clusterqueue gpu-cluster-queue
+oc delete resourceflavor gpu-nodes
+oc patch deviceclass gpu.nvidia.com --type='merge' -p '{"spec":{"extendedResourceName":"nvidia.com/gpu"}}'
+```

--- a/test/docs/cases/e2e_tls_profile.md
+++ b/test/docs/cases/e2e_tls_profile.md
@@ -1,0 +1,299 @@
+# Test Case: TLS Security Profile
+
+- **Test file:**
+  [`test/e2e/e2e_tls_profile_test.go`](../../e2e/e2e_tls_profile_test.go)
+- **Feature:** Central TLS Profile consistency
+- **JIRA:** [OCPKUEUE-418](https://redhat.atlassian.net/browse/OCPKUEUE-418)
+- **Automation status:** Automated
+- **Since release:** 1.4
+- **Labels:** `tls-profile`
+
+## Description
+
+OpenShift provides a cluster-wide TLS security profile configured via the
+APIServer CR (`apiserver.config.openshift.io/cluster`). The Kueue operator must
+read this configuration and propagate the appropriate TLS settings (minimum
+version and cipher suites) to the `kueue-manager-config` ConfigMap so that the
+Kueue controller manager enforces the cluster's TLS policy.
+
+These tests validate that the operator correctly handles all TLS profile types
+(Intermediate, Modern, Old, Custom), including negative cases where the profile
+is unsupported or contains invalid ciphers.
+
+## Scenarios
+
+1. [Default Intermediate TLS profile is configured](#1-default-intermediate-tls-profile-is-configured)
+2. [Modern TLS profile (TLS 1.3) propagates to operand](#2-modern-tls-profile-tls-13-propagates-to-operand)
+3. [Old TLS profile (TLS 1.0) sets Degraded condition](#3-old-tls-profile-tls-10-sets-degraded-condition)
+4. [Custom TLS profile propagates to operand](#4-custom-tls-profile-propagates-to-operand)
+5. [Custom TLS profile with invalid ciphers emits warning](#5-custom-tls-profile-with-invalid-ciphers-emits-warning)
+
+## Prerequisites
+
+- Kueue operator installed and running
+- Access to the APIServer CR (`oc get apiserver cluster`)
+- Not running on HyperShift (scenarios 2-5 are skipped on HyperShift because
+  APIServer TLS profile mutation is not supported)
+
+## Test Scenarios
+
+### 1. Default Intermediate TLS profile is configured
+
+- **Ginkgo:** `When the default Intermediate TLS profile is configured / should
+  have Intermediate TLS settings in the initial operand ConfigMap`
+
+**Setup:**
+
+1. No special setup — this validates the default state after operator install
+
+**Execution:**
+
+1. Verify the `kueue-manager-config` ConfigMap contains Intermediate TLS
+   settings:
+   ```bash
+   oc get configmap kueue-manager-config -n openshift-kueue-operator -o jsonpath='{.data.controller_manager_config\.yaml}'
+   # Look for the tls section in the output
+   ```
+2. Check the `minVersion` value:
+   ```bash
+   oc get configmap kueue-manager-config -n openshift-kueue-operator -o jsonpath='{.data.controller_manager_config\.yaml}' | grep minVersion
+   # Expected: VersionTLS12
+   ```
+3. Check that cipher suites are present:
+   ```bash
+   oc get configmap kueue-manager-config -n openshift-kueue-operator -o jsonpath='{.data.controller_manager_config\.yaml}' | grep -A 20 cipherSuites
+   # Expected: list of Intermediate-profile cipher suites (non-empty)
+   ```
+
+**Expected Result:**
+
+- ConfigMap contains `minVersion: VersionTLS12`
+- ConfigMap contains the Intermediate profile cipher suites (non-empty list)
+
+**Cleanup:**
+
+None required.
+
+---
+
+### 2. Modern TLS profile (TLS 1.3) propagates to operand
+
+- **Ginkgo:** `When the cluster TLS profile is set to Modern (TLS 1.3) / should
+  propagate TLS 1.3 settings to the operand ConfigMap`
+- **Skipped on:** HyperShift clusters
+
+**Setup:**
+
+1. Save the current APIServer TLS profile (to restore later):
+   ```bash
+   oc get apiserver cluster -o jsonpath='{.spec.tlsSecurityProfile}' > tls-backup.json
+   ```
+
+**Execution:**
+
+1. Set the APIServer TLS profile to Modern:
+   ```bash
+   oc patch apiserver cluster --type=merge -p '{"spec":{"tlsSecurityProfile":{"type":"Modern","modern":{}}}}'
+   ```
+2. Wait for the operand ConfigMap to reflect TLS 1.3 settings (this may take a
+   few minutes as the APIServer rolls out):
+   ```bash
+   oc get configmap kueue-manager-config -n openshift-kueue-operator -o jsonpath='{.data.controller_manager_config\.yaml}' | grep minVersion
+   # Expected: VersionTLS13
+   ```
+3. Verify cipher suites are empty (TLS 1.3 ciphers are not configurable in Go):
+   ```bash
+   oc get configmap kueue-manager-config -n openshift-kueue-operator -o jsonpath='{.data.controller_manager_config\.yaml}' | grep -A 5 cipherSuites
+   # Expected: empty list or no cipherSuites key
+   ```
+4. Verify the operand deployment is fully rolled out:
+   ```bash
+   oc get deployment kueue-controller-manager -n openshift-kueue-operator -o jsonpath='{.status.readyReplicas}/{.status.replicas}'
+   # Expected: replicas match (e.g., 1/1)
+   ```
+
+**Expected Result:**
+
+- ConfigMap contains `minVersion: VersionTLS13`
+- ConfigMap contains empty cipher suites
+- Operand deployment is fully rolled out with all replicas ready
+
+**Cleanup:**
+
+```bash
+oc patch apiserver cluster --type=merge -p '{"spec":{"tlsSecurityProfile":null}}'
+# Wait for ConfigMap to reconcile back to Intermediate settings
+```
+
+---
+
+### 3. Old TLS profile (TLS 1.0) sets Degraded condition
+
+- **Ginkgo:** `When the cluster TLS profile is set to Old (TLS 1.0) / should
+  set Degraded condition instead of crashing the controller`
+- **Skipped on:** HyperShift clusters
+- **Type:** Negative test
+
+**Setup:**
+
+1. Save the current APIServer TLS profile (to restore later)
+
+**Execution:**
+
+1. Set the APIServer TLS profile to Old:
+   ```bash
+   oc patch apiserver cluster --type=merge -p '{"spec":{"tlsSecurityProfile":{"type":"Old","old":{}}}}'
+   ```
+2. Wait for the operator to report Degraded condition (may take up to 10
+   minutes because changing the APIServer TLS profile triggers a
+   kube-apiserver rollout):
+   ```bash
+   oc get kueue cluster -o jsonpath='{range .status.conditions[*]}{.type}={.status} reason={.reason}{"\n"}{end}'
+   # Expected: Degraded=True reason=UnsupportedTLSProfile
+   ```
+3. Verify the operator also reports Available=False:
+   ```bash
+   oc get kueue cluster -o jsonpath='{.status.conditions[?(@.type=="Available")].status}'
+   # Expected: False
+   oc get kueue cluster -o jsonpath='{.status.conditions[?(@.type=="Available")].reason}'
+   # Expected: UnsupportedTLSProfile
+   ```
+4. Restore the TLS profile to Intermediate to recover:
+   ```bash
+   oc patch apiserver cluster --type=merge -p '{"spec":{"tlsSecurityProfile":null}}'
+   ```
+5. Verify the operator recovers and becomes Available:
+   ```bash
+   oc get kueue cluster -o jsonpath='{.status.conditions[?(@.type=="Available")].status}'
+   # Expected: True
+   ```
+
+**Expected Result:**
+
+- Operator sets `Degraded=True` with reason `UnsupportedTLSProfile` (does NOT
+  crash)
+- Operator sets `Available=False` with reason `UnsupportedTLSProfile`
+- After restoring to Intermediate, operator recovers to `Available=True`
+
+**Cleanup:**
+
+```bash
+oc patch apiserver cluster --type=merge -p '{"spec":{"tlsSecurityProfile":null}}'
+# Wait for operator to recover to Available=True
+```
+
+---
+
+### 4. Custom TLS profile propagates to operand
+
+- **Ginkgo:** `When the cluster TLS profile is set to Custom / should propagate
+  custom TLS settings to the operand ConfigMap`
+- **Skipped on:** HyperShift clusters
+
+**Setup:**
+
+1. Save the current APIServer TLS profile (to restore later)
+
+**Execution:**
+
+1. Set the APIServer TLS profile to Custom with specific ciphers:
+   ```bash
+   oc patch apiserver cluster --type=merge -p '{
+     "spec": {
+       "tlsSecurityProfile": {
+         "type": "Custom",
+         "custom": {
+           "ciphers": [
+             "ECDHE-ECDSA-AES128-GCM-SHA256",
+             "ECDHE-RSA-AES128-GCM-SHA256"
+           ],
+           "minTLSVersion": "VersionTLS12"
+         }
+       }
+     }
+   }'
+   ```
+2. Wait for the operand ConfigMap to reflect custom TLS settings:
+   ```bash
+   oc get configmap kueue-manager-config -n openshift-kueue-operator -o jsonpath='{.data.controller_manager_config\.yaml}' | grep minVersion
+   # Expected: VersionTLS12
+   ```
+3. Verify exactly 2 cipher suites are present (matching the 2 OpenSSL ciphers
+   mapped to IANA names):
+   ```bash
+   oc get configmap kueue-manager-config -n openshift-kueue-operator -o jsonpath='{.data.controller_manager_config\.yaml}' | grep -A 5 cipherSuites
+   # Expected: 2 cipher suites
+   ```
+
+**Expected Result:**
+
+- ConfigMap contains `minVersion: VersionTLS12`
+- ConfigMap contains exactly 2 cipher suites (the IANA equivalents of the
+  specified OpenSSL ciphers)
+
+**Cleanup:**
+
+```bash
+oc patch apiserver cluster --type=merge -p '{"spec":{"tlsSecurityProfile":null}}'
+```
+
+---
+
+### 5. Custom TLS profile with invalid ciphers emits warning
+
+- **Ginkgo:** `When the cluster TLS profile is set to Custom with invalid cipher
+  suites / should emit an InvalidTLSCipherSuites warning event for unmapped
+  ciphers`
+- **Skipped on:** HyperShift clusters
+- **Type:** Negative test
+
+**Setup:**
+
+1. Save the current APIServer TLS profile (to restore later)
+
+**Execution:**
+
+1. Set the APIServer TLS profile to Custom with a mix of valid and invalid
+   ciphers:
+   ```bash
+   oc patch apiserver cluster --type=merge -p '{
+     "spec": {
+       "tlsSecurityProfile": {
+         "type": "Custom",
+         "custom": {
+           "ciphers": [
+             "ECDHE-RSA-AES128-GCM-SHA256",
+             "TLS_ALICE_POLY1305_SHA256",
+             "INVALID-CIPHER"
+           ],
+           "minTLSVersion": "VersionTLS12"
+         }
+       }
+     }
+   }'
+   ```
+2. Wait for the operand ConfigMap to contain only the valid cipher:
+   ```bash
+   oc get configmap kueue-manager-config -n openshift-kueue-operator -o jsonpath='{.data.controller_manager_config\.yaml}' | grep -A 5 cipherSuites
+   # Expected: only 1 cipher suite (the valid one)
+   ```
+3. Verify that an `InvalidTLSCipherSuites` warning event was emitted:
+   ```bash
+   oc get events -n openshift-kueue-operator --field-selector reason=InvalidTLSCipherSuites
+   # Expected: at least one Warning event with reason=InvalidTLSCipherSuites
+   ```
+
+**Expected Result:**
+
+- ConfigMap contains only 1 cipher suite (the valid one:
+  `ECDHE-RSA-AES128-GCM-SHA256`)
+- Invalid ciphers (`TLS_ALICE_POLY1305_SHA256`, `INVALID-CIPHER`) are silently
+  dropped from the ConfigMap
+- A `Warning` event with reason `InvalidTLSCipherSuites` is emitted in the
+  operator namespace
+
+**Cleanup:**
+
+```bash
+oc patch apiserver cluster --type=merge -p '{"spec":{"tlsSecurityProfile":null}}'
+```

--- a/test/docs/cases/e2e_visibility_on_demand.md
+++ b/test/docs/cases/e2e_visibility_on_demand.md
@@ -1,0 +1,706 @@
+# Test Case: Visibility On Demand
+
+- **Test file:** [`test/e2e/e2e_visibility_on_demand_test.go`](../../e2e/e2e_visibility_on_demand_test.go)
+- **Feature:** VisibilityOnDemand
+- **JIRA:** TBD
+- **Automation status:** Automated
+- **Since release:** TBD
+- **Labels:** `visibility-on-demand`
+
+## Description
+
+The Visibility On Demand feature provides the ability to query pending workloads through the Kueue Visibility API (`visibility.kueue.x-k8s.io/v1beta2`). These tests validate that the PriorityLevelConfiguration for the visibility API can be modified within allowed bounds, that pending workloads are correctly ordered by priority, that RBAC controls restrict access appropriately across ClusterQueues and LocalQueues, and that the correct FlowSchema and PriorityLevelConfiguration are used for API requests. Tests also cover LeaderWorkerSet (LWS) and JobSet workloads appearing in pending workload lists.
+
+## Scenarios
+
+1. [Allow nominal concurrency shares set to 0](#1-allow-nominal-concurrency-shares-set-to-0)
+2. [Allow nominal concurrency shares set to 5](#2-allow-nominal-concurrency-shares-set-to-5)
+3. [Reject nominal concurrency shares set to 1](#3-reject-nominal-concurrency-shares-set-to-1)
+4. [Reject nominal concurrency shares set to 6](#4-reject-nominal-concurrency-shares-set-to-6)
+5. [Non-admin cannot modify nominal concurrency shares](#5-non-admin-cannot-modify-nominal-concurrency-shares)
+6. [ClusterQueue pending workloads with admin access and priority ordering](#6-clusterqueue-pending-workloads-with-admin-access-and-priority-ordering)
+7. [LocalQueue access scoped to bound namespaces](#7-localqueue-access-scoped-to-bound-namespaces)
+8. [PriorityLevelConfiguration and FlowSchema for visibility endpoints](#8-prioritylevelconfiguration-and-flowschema-for-visibility-endpoints)
+9. [LWS pending workloads ordered by priority with sequential admission](#9-lws-pending-workloads-ordered-by-priority-with-sequential-admission)
+10. [Suspended JobSet shows on pending workloads list](#10-suspended-jobset-shows-on-pending-workloads-list)
+
+## Prerequisites
+
+- Kueue operator is installed and running in `openshift-kueue-operator` namespace
+- The `kueue-visibility` PriorityLevelConfiguration exists (created by the operator)
+- The `visibility` FlowSchema exists (created by the operator)
+- ClusterRoles `kueue-batch-admin-role` and `kueue-batch-user-role` exist
+- LeaderWorkerSet CRD is installed (for scenario 9)
+- JobSet CRD is installed (for scenario 10)
+
+## Shared Setup (Scenarios 1-5)
+
+These scenarios share setup via `BeforeAll`:
+
+1. Create a namespace with label `kueue.openshift.io/managed: "true"`
+2. Create a ClusterQueue, LocalQueue (`test-queue`), and ResourceFlavor
+3. Create a RoleBinding granting `kueue-batch-user-role` to the `default` service account in `openshift-kueue-operator` namespace for the test namespace
+
+## Test Scenarios
+
+### 1. Allow nominal concurrency shares set to 0
+
+- **Ginkgo:** `When kueue.openshift.io/allow-nominal-concurrency-shares-update annotation is set to true / It should allow modification of the nominal concurrency shares to 0`
+- **Important:** Modifies cluster-wide PriorityLevelConfiguration
+
+**Setup:**
+
+No additional setup beyond shared setup.
+
+**Execution:**
+
+1. Modify the `kueue-visibility` PriorityLevelConfiguration: set `nominalConcurrencyShares` to `0` and add annotation `kueue.openshift.io/allow-nominal-concurrency-shares-update: "true"`
+
+```bash
+oc annotate prioritylevelconfiguration kueue-visibility \
+  kueue.openshift.io/allow-nominal-concurrency-shares-update=true --overwrite
+oc patch prioritylevelconfiguration kueue-visibility --type=merge \
+  -p '{"spec":{"limited":{"nominalConcurrencyShares":0}}}'
+```
+
+2. Verify that the nominal concurrency shares value is `0`
+
+```bash
+oc get prioritylevelconfiguration kueue-visibility \
+  -o jsonpath='{.spec.limited.nominalConcurrencyShares}'
+# Expected: 0
+```
+
+3. Attempt to access pending workloads via the visibility API
+
+```bash
+oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/<namespace>/localqueues/test-queue/pendingworkloads
+# Expected: HTTP 429 Too Many Requests (rate limited because concurrency shares = 0)
+```
+
+**Expected Result:**
+
+- The PriorityLevelConfiguration is updated to `nominalConcurrencyShares: 0`
+- Requests to the visibility API return `429 Too Many Requests` because the concurrency is fully restricted
+
+**Cleanup:**
+
+The operator will reconcile the PriorityLevelConfiguration back to defaults.
+
+---
+
+### 2. Allow nominal concurrency shares set to 5
+
+- **Ginkgo:** `When kueue.openshift.io/allow-nominal-concurrency-shares-update annotation is set to true / It should allow modification of the nominal concurrency shares to 5`
+- **Important:** Modifies cluster-wide PriorityLevelConfiguration
+
+**Setup:**
+
+No additional setup beyond shared setup.
+
+**Execution:**
+
+1. Modify the `kueue-visibility` PriorityLevelConfiguration: set `nominalConcurrencyShares` to `5` with the allow annotation
+
+```bash
+oc annotate prioritylevelconfiguration kueue-visibility \
+  kueue.openshift.io/allow-nominal-concurrency-shares-update=true --overwrite
+oc patch prioritylevelconfiguration kueue-visibility --type=merge \
+  -p '{"spec":{"limited":{"nominalConcurrencyShares":5}}}'
+```
+
+2. Access the pending workloads via the visibility API
+
+```bash
+oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/<namespace>/localqueues/test-queue/pendingworkloads
+# Expected: HTTP 200 OK (empty list of pending workloads)
+```
+
+3. Access the pending workloads again to confirm continued access
+
+```bash
+oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/<namespace>/localqueues/test-queue/pendingworkloads
+# Expected: HTTP 200 OK
+```
+
+**Expected Result:**
+
+- The PriorityLevelConfiguration is updated to `nominalConcurrencyShares: 5`
+- Requests to the visibility API succeed with HTTP 200
+
+**Cleanup:**
+
+The operator will reconcile the PriorityLevelConfiguration back to defaults.
+
+---
+
+### 3. Reject nominal concurrency shares set to 1
+
+- **Ginkgo:** `When kueue.openshift.io/allow-nominal-concurrency-shares-update annotation is set to true / It should not allow modification of the nominal concurrency shares to 1`
+- **Important:** Modifies cluster-wide PriorityLevelConfiguration; operator reconciles it back to default (2)
+
+**Setup:**
+
+No additional setup beyond shared setup.
+
+**Execution:**
+
+1. Modify the `kueue-visibility` PriorityLevelConfiguration: set `nominalConcurrencyShares` to `1` with the allow annotation
+
+```bash
+oc annotate prioritylevelconfiguration kueue-visibility \
+  kueue.openshift.io/allow-nominal-concurrency-shares-update=true --overwrite
+oc patch prioritylevelconfiguration kueue-visibility --type=merge \
+  -p '{"spec":{"limited":{"nominalConcurrencyShares":1}}}'
+```
+
+2. Wait and verify that the operator reconciles the value back to the default (`2`)
+
+```bash
+# Poll until the value reverts
+oc get prioritylevelconfiguration kueue-visibility \
+  -o jsonpath='{.spec.limited.nominalConcurrencyShares}'
+# Expected: 2 (operator reconciles back to default)
+```
+
+**Expected Result:**
+
+- The value `1` is outside the allowed range; the operator automatically reverts `nominalConcurrencyShares` to the default value of `2`
+
+**Cleanup:**
+
+No cleanup needed; operator auto-reconciles.
+
+---
+
+### 4. Reject nominal concurrency shares set to 6
+
+- **Ginkgo:** `When kueue.openshift.io/allow-nominal-concurrency-shares-update annotation is set to true / It should not allow modification of the nominal concurrency shares to 6`
+- **Important:** Modifies cluster-wide PriorityLevelConfiguration; operator reconciles it back to default (2)
+
+**Setup:**
+
+No additional setup beyond shared setup.
+
+**Execution:**
+
+1. Modify the `kueue-visibility` PriorityLevelConfiguration: set `nominalConcurrencyShares` to `6` with the allow annotation
+
+```bash
+oc annotate prioritylevelconfiguration kueue-visibility \
+  kueue.openshift.io/allow-nominal-concurrency-shares-update=true --overwrite
+oc patch prioritylevelconfiguration kueue-visibility --type=merge \
+  -p '{"spec":{"limited":{"nominalConcurrencyShares":6}}}'
+```
+
+2. Wait and verify that the operator reconciles the value back to the default (`2`)
+
+```bash
+# Poll until the value reverts
+oc get prioritylevelconfiguration kueue-visibility \
+  -o jsonpath='{.spec.limited.nominalConcurrencyShares}'
+# Expected: 2 (operator reconciles back to default)
+```
+
+**Expected Result:**
+
+- The value `6` is outside the allowed range; the operator automatically reverts `nominalConcurrencyShares` to the default value of `2`
+
+**Cleanup:**
+
+No cleanup needed; operator auto-reconciles.
+
+---
+
+### 5. Non-admin cannot modify nominal concurrency shares
+
+- **Ginkgo:** `When kueue.openshift.io/allow-nominal-concurrency-shares-update annotation is set to true / It should not allow modification of the nominal concurrency shares if it's not admin`
+- **Type:** Negative test
+
+**Setup:**
+
+No additional setup beyond shared setup. The test impersonates the `deployer` service account in the test namespace.
+
+**Execution:**
+
+1. As the `deployer` service account (non-admin), attempt to modify the `kueue-visibility` PriorityLevelConfiguration with `nominalConcurrencyShares` set to `4`
+
+```bash
+oc --as=system:serviceaccount:<namespace>:deployer \
+  patch prioritylevelconfiguration kueue-visibility --type=merge \
+  -p '{"metadata":{"annotations":{"kueue.openshift.io/allow-nominal-concurrency-shares-update":"true"}},"spec":{"limited":{"nominalConcurrencyShares":4}}}'
+# Expected: Error - Forbidden
+```
+
+**Expected Result:**
+
+- The API returns a `403 Forbidden` error; non-admin users cannot modify PriorityLevelConfigurations
+
+**Cleanup:**
+
+No cleanup needed; the update was rejected.
+
+---
+
+### 6. ClusterQueue pending workloads with admin access and priority ordering
+
+- **Ginkgo:** `When PendingWorkloads list should be checked for a ClusterQueue and LocalQueue / It Should allow admin to access ClusterQueues, deny user access, and order pending workloads by priority`
+
+**Setup:**
+
+1. Create a ResourceFlavor
+
+```bash
+cat <<'EOF' | oc apply -f -
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  generateName: resource-flavor-
+EOF
+```
+
+2. Create two ClusterQueues (A and B) each with 2 CPU and 1Gi memory quota referencing the ResourceFlavor
+
+```bash
+cat <<'EOF' | oc apply -f -
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  generateName: cluster-queue-
+spec:
+  resourceGroups:
+  - coveredResources: ["cpu", "memory"]
+    flavors:
+    - name: <resource-flavor-name>
+      resources:
+      - name: cpu
+        nominalQuota: "2"
+      - name: memory
+        nominalQuota: 1Gi
+EOF
+```
+
+3. Create two namespaces (A and B) with `kueue.openshift.io/managed: "true"` label
+4. Create LocalQueue-A in namespace-A pointing to ClusterQueue-A, and LocalQueue-B in namespace-B pointing to ClusterQueue-B
+5. Create three PriorityClasses: high (value=100), medium (value=75), low (value=50)
+6. Create a ServiceAccount and bind it to `kueue-batch-admin-role` via ClusterRoleBinding
+7. Create a ServiceAccount and bind it to `kueue-batch-user-role` via ClusterRoleBinding
+
+**Execution:**
+
+1. Create a blocker job in namespace-A on LocalQueue-A with high priority requesting 2 CPU, 1Gi (consumes all quota)
+2. Create three pending jobs in namespace-A on LocalQueue-A: `job-high-a` (high, 1 CPU), `job-medium-a` (medium, 1 CPU), `job-low-a` (low, 1 CPU)
+3. Create a blocker job in namespace-B on LocalQueue-B with high priority requesting 2 CPU, 1Gi
+4. Create a pending job in namespace-B on LocalQueue-B: `job-high-b` (high, 1 CPU)
+5. Wait for blocker job pods to be created in namespace-A
+6. Query pending workloads for ClusterQueue-A using the admin visibility client
+
+```bash
+oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/clusterqueues/<cluster-queue-a>/pendingworkloads
+# Expected: 3 items, ordered by priority: 100, 75, 50
+```
+
+7. Wait for blocker job pods in namespace-B, then query pending workloads for ClusterQueue-B
+
+```bash
+oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/clusterqueues/<cluster-queue-b>/pendingworkloads
+# Expected: 1 item with priority 100
+```
+
+8. Verify all workloads are eventually created
+9. Verify pending workloads lists become empty after all workloads complete
+
+```bash
+oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/clusterqueues/<cluster-queue-a>/pendingworkloads
+# Expected: empty items list
+
+oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/clusterqueues/<cluster-queue-b>/pendingworkloads
+# Expected: empty items list
+```
+
+10. Verify an unauthorized user (not-authorized-user) cannot access ClusterQueue pending workloads
+
+```bash
+oc --as=system:serviceaccount:<namespace-a>:not-authorized-user \
+  get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/clusterqueues/<cluster-queue-a>/pendingworkloads
+# Expected: 403 Forbidden
+```
+
+11. Verify a user with `kueue-batch-user-role` cannot access ClusterQueue pending workloads
+
+```bash
+oc --as=system:serviceaccount:<namespace-a>:<user-sa> \
+  get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/clusterqueues/<cluster-queue-a>/pendingworkloads
+# Expected: 403 Forbidden
+```
+
+**Expected Result:**
+
+- Pending workloads are returned ordered by priority (highest first)
+- 3 pending workloads on ClusterQueue-A, 1 on ClusterQueue-B
+- All pending workloads lists become empty after jobs complete
+- Unauthorized users get `403 Forbidden`
+- Users with `kueue-batch-user-role` (not admin) get `403 Forbidden` on ClusterQueue endpoints
+
+**Cleanup:**
+
+```bash
+oc delete job job-blocker job-high-a job-medium-a job-low-a -n <namespace-a>
+oc delete job job-blocker-b job-high-b -n <namespace-b>
+oc delete clusterrolebinding <admin-binding> <user-binding>
+oc delete localqueue local-queue-a -n <namespace-a>
+oc delete localqueue local-queue-b -n <namespace-b>
+oc delete namespace <namespace-a> <namespace-b>
+oc delete clusterqueue <cluster-queue-a> <cluster-queue-b>
+oc delete resourceflavor <resource-flavor>
+oc delete priorityclass <high> <medium> <low>
+```
+
+---
+
+### 7. LocalQueue access scoped to bound namespaces
+
+- **Ginkgo:** `When PendingWorkloads list should be checked for a ClusterQueue and LocalQueue / It Should allow access to LocalQueues in bound namespaces and deny access to unbound namespaces`
+
+**Setup:**
+
+1. Create a ResourceFlavor
+2. Create a single ClusterQueue with 2 CPU and 1Gi memory quota
+3. Create two namespaces (A and B) with `kueue.openshift.io/managed: "true"` label
+4. Create LocalQueue-A in namespace-A and LocalQueue-B in namespace-B, both pointing to the same ClusterQueue
+5. Create a ServiceAccount in each namespace and bind each to `kueue-batch-user-role` via RoleBinding (namespace-scoped)
+6. Create two PriorityClasses: high (value=100) and low (value=50)
+
+**Execution:**
+
+1. Create a blocker job in namespace-A with high priority (2 CPU, 1Gi) and a pending `job-high-a` with low priority (1 CPU)
+2. Create a blocker job in namespace-B with high priority (2 CPU, 1Gi) and a pending `job-low-b` with low priority (1 CPU)
+3. Wait for blocker job pods, then query pending workloads for LocalQueue-A using user-A's visibility client
+
+```bash
+oc --as=system:serviceaccount:<namespace-a>:<sa-a> \
+  get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/<namespace-a>/localqueues/local-queue-a/pendingworkloads
+# Expected: 1 item with priority 50
+```
+
+4. Query pending workloads for LocalQueue-B using user-B's visibility client
+
+```bash
+oc --as=system:serviceaccount:<namespace-b>:<sa-b> \
+  get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/<namespace-b>/localqueues/local-queue-b/pendingworkloads
+# Expected: 1 item with priority 50
+```
+
+5. Verify user-B cannot access LocalQueue-A (cross-namespace)
+
+```bash
+oc --as=system:serviceaccount:<namespace-b>:<sa-b> \
+  get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/<namespace-a>/localqueues/local-queue-a/pendingworkloads
+# Expected: 403 Forbidden
+```
+
+6. Verify user-A cannot access LocalQueue-B (cross-namespace)
+
+```bash
+oc --as=system:serviceaccount:<namespace-a>:<sa-a> \
+  get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/<namespace-b>/localqueues/local-queue-b/pendingworkloads
+# Expected: 403 Forbidden
+```
+
+7. Verify pending workloads lists become empty after workloads complete
+
+**Expected Result:**
+
+- Each user can only see pending workloads in their own namespace's LocalQueue
+- Cross-namespace access is denied with `403 Forbidden`
+- Pending workloads lists become empty after workloads are executed
+
+**Cleanup:**
+
+```bash
+oc delete job job-blocker job-high-a -n <namespace-a>
+oc delete job job-blocker-b job-low-b -n <namespace-b>
+oc delete rolebinding <rb-a> -n <namespace-a>
+oc delete rolebinding <rb-b> -n <namespace-b>
+oc delete localqueue local-queue-a -n <namespace-a>
+oc delete localqueue local-queue-b -n <namespace-b>
+oc delete namespace <namespace-a> <namespace-b>
+oc delete clusterqueue <cluster-queue>
+oc delete resourceflavor <resource-flavor>
+oc delete priorityclass <high> <low>
+```
+
+---
+
+### 8. PriorityLevelConfiguration and FlowSchema for visibility endpoints
+
+- **Ginkgo:** `When PendingWorkloads Endpoints should be checked / It Should use the correct PriorityLevelConfiguration and FlowSchema for ClusterQueue and LocalQueue`
+
+**Setup:**
+
+1. Create a ResourceFlavor
+2. Create a ClusterQueue referencing the ResourceFlavor
+3. Create a namespace with `kueue.openshift.io/managed: "true"` label
+4. Create a LocalQueue pointing to the ClusterQueue
+5. Create a ClusterRoleBinding granting `kueue-batch-admin-role` to the `default` service account
+
+**Execution:**
+
+1. Get the `kueue-visibility` PriorityLevelConfiguration and record its UID
+
+```bash
+oc get prioritylevelconfiguration kueue-visibility -o jsonpath='{.metadata.uid}'
+```
+
+2. Get the `visibility` FlowSchema and record its UID
+
+```bash
+oc get flowschema visibility -o jsonpath='{.metadata.uid}'
+```
+
+3. Query the ClusterQueue pending workloads endpoint and inspect the response headers
+
+```bash
+# The response should include these headers:
+# X-Kubernetes-Pf-Prioritylevel-Uid: <kueue-visibility UID>
+# X-Kubernetes-Pf-Flowschema-Uid: <visibility FlowSchema UID>
+curl -k -H "Authorization: Bearer <token>" \
+  https://<api-server>/apis/visibility.kueue.x-k8s.io/v1beta2/clusterqueues/<cq>/pendingworkloads \
+  -D - 2>/dev/null | grep -i 'X-Kubernetes-Pf-'
+# Expected: UIDs match kueue-visibility PLC and visibility FlowSchema
+```
+
+4. Query the LocalQueue pending workloads endpoint and inspect the response headers
+
+```bash
+# The response should include the same headers:
+# X-Kubernetes-Pf-Prioritylevel-Uid: <kueue-visibility UID>
+# X-Kubernetes-Pf-Flowschema-Uid: <visibility FlowSchema UID>
+curl -k -H "Authorization: Bearer <token>" \
+  https://<api-server>/apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/<ns>/localqueues/<lq>/pendingworkloads \
+  -D - 2>/dev/null | grep -i 'X-Kubernetes-Pf-'
+# Expected: UIDs match kueue-visibility PLC and visibility FlowSchema
+```
+
+**Expected Result:**
+
+- The `X-Kubernetes-Pf-Prioritylevel-Uid` response header matches the UID of `kueue-visibility` PriorityLevelConfiguration for both ClusterQueue and LocalQueue endpoints
+- The `X-Kubernetes-Pf-Flowschema-Uid` response header matches the UID of `visibility` FlowSchema for both endpoints
+
+**Cleanup:**
+
+```bash
+oc delete clusterrolebinding <binding>
+oc delete localqueue local-queue -n <namespace>
+oc delete namespace <namespace>
+oc delete clusterqueue <cluster-queue>
+oc delete resourceflavor <resource-flavor>
+```
+
+---
+
+### 9. LWS pending workloads ordered by priority with sequential admission
+
+- **Ginkgo:** `When PendingWorkloads list should be checked for LWS workloads / It Should show pending LWS workloads ordered by priority and admit them sequentially based on resource availability`
+
+**Setup:**
+
+1. Create a ResourceFlavor
+2. Create a ClusterQueue with 400m CPU and 512Mi memory quota
+3. Create two namespaces (A and B) with `kueue.openshift.io/managed: "true"` label
+4. Create LocalQueue-A in namespace-A and LocalQueue-B in namespace-B, both pointing to the ClusterQueue
+5. Create three PriorityClasses: high (100), medium (75), low (50)
+6. Create a ServiceAccount in namespace-A with `kueue-batch-admin-role` via ClusterRoleBinding (for ClusterQueue access)
+7. Create ServiceAccounts in each namespace with `kueue-batch-user-role` via RoleBindings (for LocalQueue access)
+
+**Execution:**
+
+1. Create a blocker LWS (`lws-blocker-a`) in namespace-A on LocalQueue-A with high priority and size=3 (consumes all quota)
+2. Wait for blocker LWS pods to be created (3 pods)
+
+```bash
+oc get pods -n <namespace-a> -l leaderworkerset.sigs.k8s.io/name=lws-blocker-a
+# Expected: 3 pods
+```
+
+3. Create pending LWS workloads: `lws-high-b` (high, size=2) in namespace-B, `lws-medium-a` (medium, size=2) and `lws-low-a` (low, size=2) in namespace-A
+4. Verify all pending workloads are created but not admitted
+5. Query ClusterQueue pending workloads
+
+```bash
+oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/clusterqueues/<cq>/pendingworkloads
+# Expected: 3 items, priorities: 100, 75, 50
+```
+
+6. Query LocalQueue-A pending workloads
+
+```bash
+oc --as=system:serviceaccount:<ns-a>:<sa-a> \
+  get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/<ns-a>/localqueues/local-queue-a/pendingworkloads
+# Expected: 2 items, priorities: 75, 50
+```
+
+7. Query LocalQueue-B pending workloads
+
+```bash
+oc --as=system:serviceaccount:<ns-b>:<sa-b> \
+  get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/<ns-b>/localqueues/local-queue-b/pendingworkloads
+# Expected: 1 item, priority: 100
+```
+
+8. Delete the blocker LWS to free resources
+
+```bash
+oc delete leaderworkerset lws-blocker-a -n <namespace-a>
+```
+
+9. Wait for blocker LWS and its pods to be fully deleted
+10. Verify high priority LWS is admitted and pods are running
+
+```bash
+oc get pods -n <namespace-b> -l leaderworkerset.sigs.k8s.io/name=lws-high-b -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\n"}{end}'
+# Expected: 2 pods in Running state
+```
+
+11. Verify medium priority LWS is admitted and pods are running
+
+```bash
+oc get pods -n <namespace-a> -l leaderworkerset.sigs.k8s.io/name=lws-medium-a -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\n"}{end}'
+# Expected: 2 pods in Running state
+```
+
+12. Verify low priority LWS is still pending (insufficient resources)
+
+```bash
+oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/clusterqueues/<cq>/pendingworkloads
+# Expected: 1 item with priority 50
+```
+
+13. Delete medium priority LWS to free resources
+
+```bash
+oc delete leaderworkerset lws-medium-a -n <namespace-a>
+```
+
+14. Wait for medium LWS and its pods to be deleted
+15. Verify low priority LWS is admitted and pods are running
+
+```bash
+oc get pods -n <namespace-a> -l leaderworkerset.sigs.k8s.io/name=lws-low-a -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\n"}{end}'
+# Expected: 2 pods in Running state
+```
+
+16. Verify pending workloads list is empty
+
+```bash
+oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/clusterqueues/<cq>/pendingworkloads
+# Expected: empty items list
+```
+
+**Expected Result:**
+
+- Pending workloads for LWS are shown in the visibility API, ordered by priority
+- After the blocker is removed, workloads are admitted in priority order (high first, then medium)
+- Low priority remains pending while insufficient quota, and is admitted after medium is deleted
+- Final pending workloads list is empty
+
+**Cleanup:**
+
+```bash
+oc delete leaderworkerset lws-high-b -n <namespace-b>
+oc delete leaderworkerset lws-low-a -n <namespace-a>
+oc delete clusterrolebinding <admin-binding>
+oc delete rolebinding <rb-a> -n <namespace-a>
+oc delete rolebinding <rb-b> -n <namespace-b>
+oc delete localqueue local-queue-a -n <namespace-a>
+oc delete localqueue local-queue-b -n <namespace-b>
+oc delete namespace <namespace-a> <namespace-b>
+oc delete clusterqueue <cluster-queue>
+oc delete resourceflavor <resource-flavor>
+oc delete priorityclass <high> <medium> <low>
+```
+
+---
+
+### 10. Suspended JobSet shows on pending workloads list
+
+- **Ginkgo:** `When JobSet is suspended / It Should show on pending workloads list for local queue and cluster queue`
+
+**Setup:**
+
+1. Create a ResourceFlavor
+2. Create a ClusterQueue with 40m CPU and 512Mi memory quota (intentionally low to keep workload pending)
+3. Create a namespace with `kueue.openshift.io/managed: "true"` label
+4. Create a LocalQueue pointing to the ClusterQueue
+5. Create a ServiceAccount with `kueue-batch-admin-role` via ClusterRoleBinding (admin, for ClusterQueue access)
+6. Create a ServiceAccount with `kueue-batch-user-role` via RoleBinding (user, for LocalQueue access)
+
+**Execution:**
+
+1. Create a JobSet using `testutils.NewTestResourceBuilder`
+
+```bash
+cat <<'EOF' | oc apply -f -
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  generateName: jobset-
+  namespace: <namespace>
+  labels:
+    kueue.x-k8s.io/queue-name: local-queue
+spec:
+  suspend: true
+  replicatedJobs:
+  - name: workers
+    replicas: 1
+    template:
+      spec:
+        parallelism: 1
+        completions: 1
+        template:
+          spec:
+            restartPolicy: Never
+            containers:
+            - name: test-container
+              image: quay.io/prometheus/busybox:latest
+              command: ["sh", "-c", "echo Hello; sleep 10"]
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+EOF
+```
+
+2. Verify the workload is created but not admitted
+3. Query LocalQueue pending workloads using the user visibility client
+
+```bash
+oc --as=system:serviceaccount:<namespace>:<user-sa> \
+  get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/<namespace>/localqueues/local-queue/pendingworkloads
+# Expected: 1 pending workload
+```
+
+4. Query ClusterQueue pending workloads using the admin visibility client
+
+```bash
+oc --as=system:serviceaccount:<namespace>:<admin-sa> \
+  get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/clusterqueues/<cluster-queue>/pendingworkloads
+# Expected: 1 pending workload
+```
+
+**Expected Result:**
+
+- A suspended JobSet generates a workload that appears in both LocalQueue and ClusterQueue pending workloads lists
+- 1 pending workload is visible via both the user (LocalQueue) and admin (ClusterQueue) visibility clients
+
+**Cleanup:**
+
+```bash
+oc delete jobset <jobset-name> -n <namespace>
+oc delete rolebinding <user-rb> -n <namespace>
+oc delete clusterrolebinding <admin-binding>
+oc delete localqueue local-queue -n <namespace>
+oc delete namespace <namespace>
+oc delete clusterqueue <cluster-queue>
+oc delete resourceflavor <resource-flavor>
+```

--- a/test/docs/plans/kueue-1.4-full.md
+++ b/test/docs/plans/kueue-1.4-full.md
@@ -1,0 +1,204 @@
+# Release Kueue 1.4 Testing Plan
+
+## 1. Introduction
+
+### 1.1. Overview
+
+This document outlines the testing strategy, objectives, and procedures for the
+Kueue 1.4 release. The goal is to ensure the quality, stability, and performance
+of new features and to verify that existing functionality remains regression-free.
+
+### 1.2. Scope
+
+**In Scope**
+
+- [Kueue Operator] Central TLS Profile consistency -
+  [OCPKUEUE-418](https://redhat.atlassian.net/browse/OCPKUEUE-418)
+- DRA Attribute-Based GPU with RHBOK (upstream work in 4.21) -
+  [OCPSTRAT-2380](https://redhat.atlassian.net/browse/OCPSTRAT-2380)
+- [GA] Admission Fair Sharing (Kueue) Integration for Multi-Tenant Resource
+  Fairness - [OCPSTRAT-2588](https://redhat.atlassian.net/browse/OCPSTRAT-2588)
+
+**Out of Scope**
+
+- Spark Operator Integration - PR: kubernetes-sigs/kueue#7268
+- Elastic Job Support for Ray in Kueue - kubernetes-sigs/kueue#8651
+- RHBoK (Kueue) - integration with autoscaler to scale/shrink nodes via
+  ProvisioningRequest (Dev Preview) -
+  [OCPSTRAT-2105](https://redhat.atlassian.net/browse/OCPSTRAT-2105)
+
+### 1.3. Key Features
+
+- TLS
+- Kueue + DRA
+- Admission Fair Sharing
+
+## 2. Release Testing Strategy
+
+### 2.1. Schedule
+
+| Milestone | Date / Sprint | Notes |
+|-----------|---------------|-------|
+| Branching | Sprint 288 | Release branch created |
+| Testing Start | Sprint 289 | Environments provisioned |
+| Week 1: Core Testing | Sprint 289 | Regression, features, DAST, bugs |
+| Week 2: Upgrade | Sprint 289 | OCP + Kueue upgrade matrix |
+| Release Work | Sprint 290 | Artifacts, sign-off |
+| Release | Sprint 290 | Published |
+
+### 2.2. Test Types
+
+- **Integration Tests:** Verify interactions between Kueue components and
+  Kubernetes
+- **Feature Tests:** Ensure new/modified features match technical requirements
+- **Regression Tests:** Ensure existing functionality is not broken
+- **Bug Verification:** Ensure all tracked bugs are fixed
+- **Upgrade Tests:** Ensure upgrade works from the previous version
+- **Security Tests (DAST):** Identify and mitigate vulnerabilities (RapidDAST)
+
+### 2.3. Test Environments
+
+- **CI/CD:** Prow Periodics
+- **Staging Clusters:**
+  - OCP: 4.18, 4.19, 4.20, 4.21, 4.22
+  - FIPS
+  - Disconnected
+  - Multi-ARCH (x86_64, arm64)
+  - Hypershift on AWS
+
+## 3. Test Areas & Test Cases
+
+**Tracking Epic:** Kueue 1.4 Release Testing -
+[OCPKUEUE-667](https://redhat.atlassian.net/browse/OCPKUEUE-667)
+
+### 3.1. Key Test Activities
+
+| Activity | JIRA | Cadence | Est. Duration |
+|----------|------|---------|---------------|
+| Upgrade testing | [OCPKUEUE-668](https://redhat.atlassian.net/browse/OCPKUEUE-668) | Re-execute on rebuilds | ~3 days |
+| RapidDAST | [OCPKUEUE-669](https://redhat.atlassian.net/browse/OCPKUEUE-669) | Once unless API changes | ~2 days |
+| Regression & New Features Testing | [OCPKUEUE-670](https://redhat.atlassian.net/browse/OCPKUEUE-670) | Daily on new builds | ~1-1.5 days |
+| Bug verification | [OCPKUEUE-671](https://redhat.atlassian.net/browse/OCPKUEUE-671) | On new builds as needed | ~2 days |
+
+### 3.2. Test Cases
+
+Test case documentation is maintained in [`test/docs/cases/`](../cases/) with a
+1:1 mapping to the e2e test files in [`test/e2e/`](../../e2e/). Each test case
+doc includes manual steps, prerequisites, and a link back to the automated Go
+test file.
+
+| Test Case | Doc | Test File |
+|-----------|-----|-----------|
+| Admission Fair Sharing | [e2e_admission_fair_sharing.md](../cases/e2e_admission_fair_sharing.md) | [e2e_admission_fair_sharing_test.go](../../e2e/e2e_admission_fair_sharing_test.go) |
+| DRA | TBD | [e2e_dra_test.go](../../e2e/e2e_dra_test.go) |
+| DRA Extended Resources | TBD | [e2e_dra_extended_resources_test.go](../../e2e/e2e_dra_extended_resources_test.go) |
+| Gang Scheduling | TBD | [e2e_gangscheduling_test.go](../../e2e/e2e_gangscheduling_test.go) |
+| Local Queue Defaulting | TBD | [e2e_local_queue_defaulting_test.go](../../e2e/e2e_local_queue_defaulting_test.go) |
+| Managed Jobs Namespace Selector | TBD | [e2e_managed_jobs_namespace_selector_test.go](../../e2e/e2e_managed_jobs_namespace_selector_test.go) |
+| Metrics | TBD | [e2e_metrics_test.go](../../e2e/e2e_metrics_test.go) |
+| Operator | TBD | [e2e_operator_test.go](../../e2e/e2e_operator_test.go) |
+| Preemption | TBD | [e2e_preemption_test.go](../../e2e/e2e_preemption_test.go) |
+| Scheduling Gate | TBD | [e2e_scheduling_gate_test.go](../../e2e/e2e_scheduling_gate_test.go) |
+| TLS Profile | [e2e_tls_profile.md](../cases/e2e_tls_profile.md) | [e2e_tls_profile_test.go](../../e2e/e2e_tls_profile_test.go) |
+| Visibility On Demand | [e2e_visibility_on_demand.md](../cases/e2e_visibility_on_demand.md) | [e2e_visibility_on_demand_test.go](../../e2e/e2e_visibility_on_demand_test.go) |
+
+## 4. Test Details
+
+### 4.1. Feature Test Execution
+
+Per-feature testing workflow:
+
+1. **Spike** — Deep dive into requirements/design to understand scope and
+   testing areas
+2. **Test Scenario Creation** — Comprehensive test cases covering functional,
+   non-functional, and edge cases
+3. **Manual Test Execution** — Validate core functionality, ensure basic
+   stability, open bugs and enhancements
+4. **Test Automation** — Implement automated tests for critical paths and
+   regression coverage
+
+### 4.2. Release Test Execution
+
+**CI Periodic Jobs:**
+
+- periodic-ci-openshift-kueue-operator-release-1.4-test-e2e-4-18
+- periodic-ci-openshift-kueue-operator-release-1.4-test-e2e-4-19
+- periodic-ci-openshift-kueue-operator-release-1.4-test-e2e-4-20
+- periodic-ci-openshift-kueue-operator-release-1.4-test-e2e-4-21
+- periodic-ci-openshift-kueue-operator-release-1.4-test-e2e-4-22
+- periodic-ci-openshift-kueue-operator-release-1.4-test-e2e-4-20-disconnected
+- periodic-ci-openshift-kueue-operator-release-1.4-test-e2e-4-20-fips
+- periodic-ci-openshift-kueue-operator-release-1.4-test-e2e-4-20-arm64
+- periodic-ci-openshift-kueue-operator-release-1.4-test-e2e-4-20-hypershift
+
+**Upgrade Jobs:**
+
+- Upgrade-from-4.18-e2e-upgrade-4-18-to-4-19-kueue-1-4
+- Upgrade-from-4.19-e2e-upgrade-4-19-to-4-20-kueue-1-4
+- Upgrade-from-4.20-e2e-upgrade-4-20-to-4-21-kueue-1-4
+- Upgrade-from-4.20-e2e-upgrade-4-21-to-4-22-kueue-1-4
+- Upgrade-from-Kueue-1.3-to-Kueue-1.4 (does not exist yet)
+
+**Manual Testing:**
+
+- UI verification (2 OCP versions)
+
+### 4.3. Upgrade Plan
+
+**OCP Upgrade:** latest version of Kueue is installed and OCP version is
+upgraded.
+
+- OCP 4.18 Kueue 1.4 -> OCP 4.19
+- OCP 4.19 Kueue 1.4 -> OCP 4.20
+- OCP 4.20 Kueue 1.4 -> OCP 4.21
+- OCP 4.21 Kueue 1.4 -> OCP 4.22
+
+**Kueue Upgrade** (seamless upgrade not supported):
+
+- **Operator-Only Uninstall:** Verify resources (ResourceFlavors, ClusterQueues,
+  LocalQueues) are preserved after operator removal.
+- **Full Operator + Operand Uninstall:** Verify complete removal works cleanly.
+  For now resources are still kept (same behavior as Operator-only uninstall).
+- Both tests executed on: OCP 4.22 Kueue 1.3 -> Kueue 1.4
+
+### 4.4. Security Scanning (DAST APIs)
+
+Depending on Kueue upstream version we're adopting, v1beta1 may or may not be
+supported.
+
+| API Group | Version | Notes |
+|-----------|---------|-------|
+| kueue.openshift.io | v1 | |
+| kueue.x-k8s.io | v1beta1 | May be removed |
+| kueue.x-k8s.io | v1beta2 | |
+| visibility.kueue.x-k8s.io | v1beta1 | May be removed |
+| visibility.kueue.x-k8s.io | v1beta2 | |
+
+Results uploaded to ProdSec folder.
+
+## 5. Bug Tracking
+
+### 5.1. Bugs to Be Tested
+
+- TBD (label: `Kueue-1.4`)
+
+### 5.2. Bugs Found During Release Testing (Out of Scope)
+
+- TBD
+
+## 6. Risks
+
+| Risk | JIRA | Impact | Mitigation |
+|------|------|--------|------------|
+| Upgrade tests not fully automated | [OCPKUEUE-427](https://redhat.atlassian.net/browse/OCPKUEUE-427) | Manual effort during testing | Prioritize automation before testing starts |
+| Kueue + DRA integration uncertainty | [OCPKUEUE-573](https://redhat.atlassian.net/browse/OCPKUEUE-573) | Feature may not be testable | Early spike, fallback to partial coverage |
+
+## 7. Exit Criteria
+
+The Kueue 1.4 release will be considered ready when:
+
+- All in-scope features are verified
+- No open release-blocking regressions
+- All release test activities (upgrade, security, regression, bug verification)
+  are complete
+- All identified risks are resolved or accepted

--- a/test/docs/plans/kueue-1.4-light.md
+++ b/test/docs/plans/kueue-1.4-light.md
@@ -1,0 +1,87 @@
+# Kueue 1.4 Release Testing Plan
+
+## Scope
+
+| Feature | JIRA | Status |
+|---------|------|--------|
+| TLS Profile consistency | [OCPKUEUE-418](https://redhat.atlassian.net/browse/OCPKUEUE-418) | In Scope |
+| DRA Attribute-Based GPU | [OCPSTRAT-2380](https://redhat.atlassian.net/browse/OCPSTRAT-2380) | In Scope |
+| Admission Fair Sharing (GA) | [OCPSTRAT-2588](https://redhat.atlassian.net/browse/OCPSTRAT-2588) | In Scope |
+| Spark Operator Integration | kubernetes-sigs/kueue#7268 | Out of Scope |
+| Elastic Job for Ray | kubernetes-sigs/kueue#8651 | Out of Scope |
+| ProvisioningRequest (Dev Preview) | [OCPSTRAT-2105](https://redhat.atlassian.net/browse/OCPSTRAT-2105) | Out of Scope |
+
+## Schedule
+
+| Milestone | Target |
+|-----------|--------|
+| Branching | Sprint 288 |
+| Testing Start | Sprint 289 |
+| Release | Sprint 290 |
+
+## Test Matrix
+
+**OCP Versions:** 4.18, 4.19, 4.20, 4.21, 4.22
+**Variants:** FIPS, Disconnected, arm64, Hypershift (AWS)
+
+**Tracking Epic:**
+[OCPKUEUE-667](https://redhat.atlassian.net/browse/OCPKUEUE-667)
+
+## Test Activities
+
+| Activity | JIRA | Cadence |
+|----------|------|---------|
+| Upgrade testing | [OCPKUEUE-668](https://redhat.atlassian.net/browse/OCPKUEUE-668) | On rebuilds |
+| RapidDAST | [OCPKUEUE-669](https://redhat.atlassian.net/browse/OCPKUEUE-669) | Once |
+| Regression & New Features | [OCPKUEUE-670](https://redhat.atlassian.net/browse/OCPKUEUE-670) | Daily |
+| Bug verification | [OCPKUEUE-671](https://redhat.atlassian.net/browse/OCPKUEUE-671) | On rebuilds |
+
+## Test Cases
+
+Test case docs live in [`test/docs/cases/`](../cases/) — 1:1 with e2e test files.
+
+| Test Case | Doc | Test File |
+|-----------|-----|-----------|
+| Admission Fair Sharing | [e2e_admission_fair_sharing.md](../cases/e2e_admission_fair_sharing.md) | [e2e_admission_fair_sharing_test.go](../../e2e/e2e_admission_fair_sharing_test.go) |
+| DRA | TBD | [e2e_dra_test.go](../../e2e/e2e_dra_test.go) |
+| DRA Extended Resources | TBD | [e2e_dra_extended_resources_test.go](../../e2e/e2e_dra_extended_resources_test.go) |
+| Gang Scheduling | TBD | [e2e_gangscheduling_test.go](../../e2e/e2e_gangscheduling_test.go) |
+| Local Queue Defaulting | TBD | [e2e_local_queue_defaulting_test.go](../../e2e/e2e_local_queue_defaulting_test.go) |
+| Managed Jobs NS Selector | TBD | [e2e_managed_jobs_namespace_selector_test.go](../../e2e/e2e_managed_jobs_namespace_selector_test.go) |
+| Metrics | TBD | [e2e_metrics_test.go](../../e2e/e2e_metrics_test.go) |
+| Operator | TBD | [e2e_operator_test.go](../../e2e/e2e_operator_test.go) |
+| Preemption | TBD | [e2e_preemption_test.go](../../e2e/e2e_preemption_test.go) |
+| Scheduling Gate | TBD | [e2e_scheduling_gate_test.go](../../e2e/e2e_scheduling_gate_test.go) |
+| TLS Profile | [e2e_tls_profile.md](../cases/e2e_tls_profile.md) | [e2e_tls_profile_test.go](../../e2e/e2e_tls_profile_test.go) |
+| Visibility On Demand | [e2e_visibility_on_demand.md](../cases/e2e_visibility_on_demand.md) | [e2e_visibility_on_demand_test.go](../../e2e/e2e_visibility_on_demand_test.go) |
+
+## Upgrade Matrix
+
+**OCP Upgrade:** 4.18->4.19, 4.19->4.20, 4.20->4.21, 4.21->4.22
+**Kueue Upgrade:** 1.3->1.4 on OCP 4.22 (operator-only + full uninstall)
+
+## DAST APIs
+
+| API Group | Version | Notes |
+|-----------|---------|-------|
+| kueue.openshift.io | v1 | |
+| kueue.x-k8s.io | v1beta1 | May be removed |
+| kueue.x-k8s.io | v1beta2 | |
+| visibility.kueue.x-k8s.io | v1beta1 | May be removed |
+| visibility.kueue.x-k8s.io | v1beta2 | |
+
+## Bugs
+
+- TBD (label: `Kueue-1.4`)
+
+## Risks
+
+- [ ] Upgrade tests not fully automated — [OCPKUEUE-427](https://redhat.atlassian.net/browse/OCPKUEUE-427)
+- [ ] Kueue + DRA integration uncertainty — [OCPKUEUE-573](https://redhat.atlassian.net/browse/OCPKUEUE-573)
+
+## Exit Criteria
+
+- [ ] All in-scope features verified
+- [ ] No release-blocking regressions
+- [ ] All test activities complete
+- [ ] All risks resolved or accepted

--- a/test/docs/plans/kueue-1.5-full.md
+++ b/test/docs/plans/kueue-1.5-full.md
@@ -1,0 +1,191 @@
+# Release Kueue 1.5 Testing Plan
+
+## 1. Introduction
+
+### 1.1. Overview
+
+This document outlines the testing strategy, objectives, and procedures for the
+Kueue 1.5 release. The goal is to ensure the quality, stability, and performance
+of new features and to verify that existing functionality remains regression-free.
+
+### 1.2. Scope
+
+**In Scope**
+
+- TBD
+
+**Out of Scope**
+
+- TBD
+
+### 1.3. Key Features
+
+- TBD
+
+## 2. Release Testing Strategy
+
+### 2.1. Schedule
+
+| Milestone | Date / Sprint | Notes |
+|-----------|---------------|-------|
+| Branching | TBD | Release branch created |
+| Testing Start | TBD | Environments provisioned |
+| Week 1: Core Testing | TBD | Regression, features, DAST, bugs |
+| Week 2: Upgrade | TBD | OCP + Kueue upgrade matrix |
+| Release Work | TBD | Artifacts, sign-off |
+| Release | TBD | Published |
+
+### 2.2. Test Types
+
+- **Integration Tests:** Verify interactions between Kueue components and
+  Kubernetes
+- **Feature Tests:** Ensure new/modified features match technical requirements
+- **Regression Tests:** Ensure existing functionality is not broken
+- **Bug Verification:** Ensure all tracked bugs are fixed
+- **Upgrade Tests:** Ensure upgrade works from the previous version
+- **Security Tests (DAST):** Identify and mitigate vulnerabilities (RapidDAST)
+
+### 2.3. Test Environments
+
+- **CI/CD:** Prow Periodics
+- **Staging Clusters:**
+  - OCP: 4.19, 4.20, 4.21, 4.22, 4.23
+  - FIPS
+  - Disconnected
+  - Multi-ARCH (x86_64, arm64)
+  - Hypershift on AWS
+
+## 3. Test Areas & Test Cases
+
+**Tracking Epic:** TBD
+
+### 3.1. Key Test Activities
+
+| Activity | JIRA | Cadence | Est. Duration |
+|----------|------|---------|---------------|
+| Upgrade testing | TBD | Re-execute on rebuilds | ~3 days |
+| RapidDAST | TBD | Once unless API changes | ~2 days |
+| Regression & New Features Testing | TBD | Daily on new builds | ~1-1.5 days |
+| Bug verification | TBD | On new builds as needed | ~2 days |
+
+### 3.2. Test Cases
+
+Test case documentation is maintained in [`test/docs/cases/`](../cases/) with a
+1:1 mapping to the e2e test files in [`test/e2e/`](../../e2e/). Each test case
+doc includes manual steps, prerequisites, and a link back to the automated Go
+test file.
+
+| Test Case | Doc | Test File |
+|-----------|-----|-----------|
+| Admission Fair Sharing | [e2e_admission_fair_sharing.md](../cases/e2e_admission_fair_sharing.md) | [e2e_admission_fair_sharing_test.go](../../e2e/e2e_admission_fair_sharing_test.go) |
+| DRA | TBD | [e2e_dra_test.go](../../e2e/e2e_dra_test.go) |
+| DRA Extended Resources | TBD | [e2e_dra_extended_resources_test.go](../../e2e/e2e_dra_extended_resources_test.go) |
+| Gang Scheduling | TBD | [e2e_gangscheduling_test.go](../../e2e/e2e_gangscheduling_test.go) |
+| Local Queue Defaulting | TBD | [e2e_local_queue_defaulting_test.go](../../e2e/e2e_local_queue_defaulting_test.go) |
+| Managed Jobs Namespace Selector | TBD | [e2e_managed_jobs_namespace_selector_test.go](../../e2e/e2e_managed_jobs_namespace_selector_test.go) |
+| Metrics | TBD | [e2e_metrics_test.go](../../e2e/e2e_metrics_test.go) |
+| Operator | TBD | [e2e_operator_test.go](../../e2e/e2e_operator_test.go) |
+| Preemption | TBD | [e2e_preemption_test.go](../../e2e/e2e_preemption_test.go) |
+| Scheduling Gate | TBD | [e2e_scheduling_gate_test.go](../../e2e/e2e_scheduling_gate_test.go) |
+| TLS Profile | [e2e_tls_profile.md](../cases/e2e_tls_profile.md) | [e2e_tls_profile_test.go](../../e2e/e2e_tls_profile_test.go) |
+| Visibility On Demand | [e2e_visibility_on_demand.md](../cases/e2e_visibility_on_demand.md) | [e2e_visibility_on_demand_test.go](../../e2e/e2e_visibility_on_demand_test.go) |
+
+## 4. Test Details
+
+### 4.1. Feature Test Execution
+
+Per-feature testing workflow:
+
+1. **Spike** — Deep dive into requirements/design to understand scope and
+   testing areas
+2. **Test Scenario Creation** — Comprehensive test cases covering functional,
+   non-functional, and edge cases
+3. **Manual Test Execution** — Validate core functionality, ensure basic
+   stability, open bugs and enhancements
+4. **Test Automation** — Implement automated tests for critical paths and
+   regression coverage
+
+### 4.2. Release Test Execution
+
+**CI Periodic Jobs:**
+
+- periodic-ci-openshift-kueue-operator-release-1.5-test-e2e-4-19
+- periodic-ci-openshift-kueue-operator-release-1.5-test-e2e-4-20
+- periodic-ci-openshift-kueue-operator-release-1.5-test-e2e-4-21
+- periodic-ci-openshift-kueue-operator-release-1.5-test-e2e-4-22
+- periodic-ci-openshift-kueue-operator-release-1.5-test-e2e-4-23
+- periodic-ci-openshift-kueue-operator-release-1.5-test-e2e-4-21-disconnected
+- periodic-ci-openshift-kueue-operator-release-1.5-test-e2e-4-21-fips
+- periodic-ci-openshift-kueue-operator-release-1.5-test-e2e-4-21-arm64
+- periodic-ci-openshift-kueue-operator-release-1.5-test-e2e-4-21-hypershift
+
+**Upgrade Jobs:**
+
+- Upgrade-from-4.19-e2e-upgrade-4-19-to-4-20-kueue-1-5
+- Upgrade-from-4.20-e2e-upgrade-4-20-to-4-21-kueue-1-5
+- Upgrade-from-4.21-e2e-upgrade-4-21-to-4-22-kueue-1-5
+- Upgrade-from-4.22-e2e-upgrade-4-22-to-4-23-kueue-1-5
+- Upgrade-from-Kueue-1.4-to-Kueue-1.5 (does not exist yet)
+
+**Manual Testing:**
+
+- UI verification (2 OCP versions)
+
+### 4.3. Upgrade Plan
+
+**OCP Upgrade:** latest version of Kueue is installed and OCP version is
+upgraded.
+
+- OCP 4.19 Kueue 1.5 -> OCP 4.20
+- OCP 4.20 Kueue 1.5 -> OCP 4.21
+- OCP 4.21 Kueue 1.5 -> OCP 4.22
+- OCP 4.22 Kueue 1.5 -> OCP 4.23
+
+**Kueue Upgrade** (seamless upgrade not supported):
+
+- **Operator-Only Uninstall:** Verify resources (ResourceFlavors, ClusterQueues,
+  LocalQueues) are preserved after operator removal.
+- **Full Operator + Operand Uninstall:** Verify complete removal works cleanly.
+  For now resources are still kept (same behavior as Operator-only uninstall).
+- Both tests executed on: OCP 4.23 Kueue 1.4 -> Kueue 1.5
+
+### 4.4. Security Scanning (DAST APIs)
+
+Depending on Kueue upstream version we're adopting, v1beta1 may or may not be
+supported.
+
+| API Group | Version | Notes |
+|-----------|---------|-------|
+| kueue.openshift.io | v1 | |
+| kueue.x-k8s.io | v1beta1 | May be removed |
+| kueue.x-k8s.io | v1beta2 | |
+| visibility.kueue.x-k8s.io | v1beta1 | May be removed |
+| visibility.kueue.x-k8s.io | v1beta2 | |
+
+Results uploaded to ProdSec folder.
+
+## 5. Bug Tracking
+
+### 5.1. Bugs to Be Tested
+
+- TBD (label: `Kueue-1.5`)
+
+### 5.2. Bugs Found During Release Testing (Out of Scope)
+
+- TBD
+
+## 6. Risks
+
+| Risk | JIRA | Impact | Mitigation |
+|------|------|--------|------------|
+| TBD | TBD | TBD | TBD |
+
+## 7. Exit Criteria
+
+The Kueue 1.5 release will be considered ready when:
+
+- All in-scope features are verified
+- No open release-blocking regressions
+- All release test activities (upgrade, security, regression, bug verification)
+  are complete
+- All identified risks are resolved or accepted

--- a/test/docs/plans/kueue-1.5-light.md
+++ b/test/docs/plans/kueue-1.5-light.md
@@ -1,0 +1,80 @@
+# Kueue 1.5 Release Testing Plan
+
+## Scope
+
+| Feature | JIRA | Status |
+|---------|------|--------|
+| TBD | TBD | TBD |
+
+**Tracking Epic:** TBD
+
+## Schedule
+
+| Milestone | Target |
+|-----------|--------|
+| Branching | TBD |
+| Testing Start | TBD |
+| Release | TBD |
+
+## Test Matrix
+
+**OCP Versions:** 4.19, 4.20, 4.21, 4.22, 4.23
+**Variants:** FIPS, Disconnected, arm64, Hypershift (AWS)
+
+## Test Activities
+
+| Activity | JIRA | Cadence |
+|----------|------|---------|
+| Upgrade testing | TBD | On rebuilds |
+| RapidDAST | TBD | Once |
+| Regression & New Features | TBD | Daily |
+| Bug verification | TBD | On rebuilds |
+
+## Test Cases
+
+Test case docs live in [`test/docs/cases/`](../cases/) — 1:1 with e2e test files.
+
+| Test Case | Doc | Test File |
+|-----------|-----|-----------|
+| Admission Fair Sharing | [e2e_admission_fair_sharing.md](../cases/e2e_admission_fair_sharing.md) | [e2e_admission_fair_sharing_test.go](../../e2e/e2e_admission_fair_sharing_test.go) |
+| DRA | TBD | [e2e_dra_test.go](../../e2e/e2e_dra_test.go) |
+| DRA Extended Resources | TBD | [e2e_dra_extended_resources_test.go](../../e2e/e2e_dra_extended_resources_test.go) |
+| Gang Scheduling | TBD | [e2e_gangscheduling_test.go](../../e2e/e2e_gangscheduling_test.go) |
+| Local Queue Defaulting | TBD | [e2e_local_queue_defaulting_test.go](../../e2e/e2e_local_queue_defaulting_test.go) |
+| Managed Jobs NS Selector | TBD | [e2e_managed_jobs_namespace_selector_test.go](../../e2e/e2e_managed_jobs_namespace_selector_test.go) |
+| Metrics | TBD | [e2e_metrics_test.go](../../e2e/e2e_metrics_test.go) |
+| Operator | TBD | [e2e_operator_test.go](../../e2e/e2e_operator_test.go) |
+| Preemption | TBD | [e2e_preemption_test.go](../../e2e/e2e_preemption_test.go) |
+| Scheduling Gate | TBD | [e2e_scheduling_gate_test.go](../../e2e/e2e_scheduling_gate_test.go) |
+| TLS Profile | [e2e_tls_profile.md](../cases/e2e_tls_profile.md) | [e2e_tls_profile_test.go](../../e2e/e2e_tls_profile_test.go) |
+| Visibility On Demand | [e2e_visibility_on_demand.md](../cases/e2e_visibility_on_demand.md) | [e2e_visibility_on_demand_test.go](../../e2e/e2e_visibility_on_demand_test.go) |
+
+## Upgrade Matrix
+
+**OCP Upgrade:** 4.19->4.20, 4.20->4.21, 4.21->4.22, 4.22->4.23
+**Kueue Upgrade:** 1.4->1.5 on OCP 4.23 (operator-only + full uninstall)
+
+## DAST APIs
+
+| API Group | Version | Notes |
+|-----------|---------|-------|
+| kueue.openshift.io | v1 | |
+| kueue.x-k8s.io | v1beta1 | May be removed |
+| kueue.x-k8s.io | v1beta2 | |
+| visibility.kueue.x-k8s.io | v1beta1 | May be removed |
+| visibility.kueue.x-k8s.io | v1beta2 | |
+
+## Bugs
+
+- TBD (label: `Kueue-1.5`)
+
+## Risks
+
+- [ ] TBD
+
+## Exit Criteria
+
+- [ ] All in-scope features verified
+- [ ] No release-blocking regressions
+- [ ] All test activities complete
+- [ ] All risks resolved or accepted

--- a/test/e2e/e2e_dra_er_alpha2_test.go
+++ b/test/e2e/e2e_dra_er_alpha2_test.go
@@ -1,0 +1,363 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	ssv1 "github.com/openshift/kueue-operator/pkg/apis/kueueoperator/v1"
+	"github.com/openshift/kueue-operator/test/e2e/testutils"
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	kueuev1beta2 "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+)
+
+const (
+	erAlpha2NamespacePrefix = "kueue-dra-er-alpha2-"
+	erAlpha2QueueName       = "er-alpha2-queue"
+)
+
+var _ = Describe("DRA Extended Resources Alpha-2 DeviceClass Lifecycle", Label("operator", "dra", "dra-extended-resources"), Ordered, func() {
+	var (
+		originalDeviceClass *resourcev1.DeviceClass
+		initialKueueConfig  *ssv1.KueueConfiguration
+	)
+
+	JustAfterEach(func(ctx context.Context) {
+		testutils.DumpKueueControllerManagerLogs(ctx, kubeClient, 500)
+	})
+
+	BeforeAll(func(ctx context.Context) {
+		By("Checking DRA APIs are available")
+		draSupported := false
+		apiResourceLists, err := kubeClient.Discovery().ServerResourcesForGroupVersion("resource.k8s.io/v1")
+		if err == nil {
+			for _, apiResource := range apiResourceLists.APIResources {
+				if apiResource.Kind == testutils.DeviceClassKind {
+					draSupported = true
+					break
+				}
+			}
+		}
+		if !draSupported {
+			Skip("DRA APIs (resource.k8s.io/v1) not available on this cluster")
+		}
+
+		By("Checking ResourceSlices exist for NVIDIA DRA driver")
+		slices, err := kubeClient.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred(), "Failed to list ResourceSlices")
+		hasDriverSlices := false
+		for _, s := range slices.Items {
+			if s.Spec.Driver == draDeviceClassName {
+				hasDriverSlices = true
+				break
+			}
+		}
+		if !hasDriverSlices {
+			Skip("No ResourceSlices found for driver gpu.nvidia.com - NVIDIA DRA driver not running")
+		}
+
+		By("Checking DeviceClass has extendedResourceName (DRAExtendedResource feature gate)")
+		dc, err := kubeClient.ResourceV1().DeviceClasses().Get(ctx, draDeviceClassName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred(), "Failed to get DeviceClass")
+		if dc.Spec.ExtendedResourceName == nil || *dc.Spec.ExtendedResourceName == "" {
+			Skip("DeviceClass gpu.nvidia.com does not have extendedResourceName set - DRAExtendedResource feature gate not enabled")
+		}
+		originalDeviceClass = dc.DeepCopy()
+
+		By("Saving Kueue config and clearing deviceClassMappings")
+		kueueInstance, err := clients.KueueClient.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred(), "Failed to fetch Kueue instance")
+		initialKueueConfig = kueueInstance.Spec.Config.DeepCopy()
+		DeferCleanup(func(ctx context.Context) {
+			By("Restoring Kueue config")
+			if initialKueueConfig != nil {
+				restoreKueueConfig(ctx, *initialKueueConfig, kubeClient)
+			}
+		})
+
+		kueueInstance.Spec.Config.Resources.DeviceClassMappings = nil
+		applyKueueConfig(ctx, kueueInstance.Spec.Config, kubeClient)
+
+		By("Waiting for config to be reconciled")
+		Eventually(func() error {
+			configMap, err := kubeClient.CoreV1().ConfigMaps(testutils.OperatorNamespace).Get(ctx, "kueue-manager-config", metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			configData := configMap.Data["controller_manager_config.yaml"]
+			if !strings.Contains(configData, "KueueDRAIntegrationExtendedResource: true") {
+				return fmt.Errorf("KueueDRAIntegrationExtendedResource not enabled yet")
+			}
+			if strings.Contains(configData, draLogicalResource) {
+				return fmt.Errorf("deviceClassMappings still contains %s, waiting for config reconciliation", draLogicalResource)
+			}
+			return nil
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(),
+			"Config should be reconciled with deviceClassMappings cleared")
+	})
+
+	AfterAll(func(ctx context.Context) {
+		if originalDeviceClass != nil {
+			By("Restoring DeviceClass to original state")
+			dc, err := kubeClient.ResourceV1().DeviceClasses().Get(ctx, draDeviceClassName, metav1.GetOptions{})
+			if err != nil {
+				recreated := originalDeviceClass.DeepCopy()
+				recreated.ResourceVersion = ""
+				_, _ = kubeClient.ResourceV1().DeviceClasses().Create(ctx, recreated, metav1.CreateOptions{})
+			} else {
+				dc.Spec.ExtendedResourceName = originalDeviceClass.Spec.ExtendedResourceName
+				dc.Spec.Selectors = originalDeviceClass.Spec.Selectors
+				_, _ = kubeClient.ResourceV1().DeviceClasses().Update(ctx, dc, metav1.UpdateOptions{})
+			}
+		}
+	})
+
+	When("no DeviceClass with extendedResourceName exists", func() {
+		It("should admit workload via non-DRA extended resource path but leave pod pending", func(ctx context.Context) {
+			var err error
+
+			By("Deleting DeviceClass so no extendedResourceName mapping exists")
+			err = kubeClient.ResourceV1().DeviceClasses().Delete(ctx, draDeviceClassName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to delete DeviceClass")
+
+			By("Verifying DeviceClass is deleted")
+			Eventually(func() error {
+				_, err := kubeClient.ResourceV1().DeviceClasses().Get(ctx, draDeviceClassName, metav1.GetOptions{})
+				if err != nil {
+					return nil
+				}
+				return fmt.Errorf("DeviceClass %s still exists", draDeviceClassName)
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(),
+				"DeviceClass should be fully deleted")
+
+			By("Creating ResourceFlavor")
+			resourceFlavor, cleanupRF, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, clients.UpstreamKueueClient)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create resource flavor")
+			DeferCleanup(cleanupRF)
+
+			By("Creating ClusterQueue with extended resource quota")
+			cq, cleanupCQ, err := testutils.NewClusterQueue().WithGenerateName().WithFlavorName(resourceFlavor.Name).
+				WithDRAResource(extendedResourceName, "2").
+				CreateWithObject(ctx, clients.UpstreamKueueClient)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create cluster queue")
+			DeferCleanup(cleanupCQ)
+
+			By("Creating namespace")
+			ns, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: erAlpha2NamespacePrefix,
+					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
+			DeferCleanup(func(ctx context.Context) {
+				By(fmt.Sprintf("Deleting namespace %s", ns.Name))
+				err := kubeClient.CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred(), "Failed to delete namespace")
+				testutils.WaitForAllPodsInNamespaceDeleted(ctx, clients.GenericClient, ns)
+			})
+
+			By("Creating LocalQueue")
+			_, cleanupLQ, err := testutils.NewLocalQueue(ns.Name, erAlpha2QueueName).WithClusterQueue(cq.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create local queue")
+			DeferCleanup(cleanupLQ)
+
+			By("Creating Job requesting nvidia.com/gpu via extended resource")
+			builder := testutils.NewTestResourceBuilder(ns.Name, erAlpha2QueueName)
+			job := builder.NewJob()
+			setDRAJobCPU(job)
+			job.Name = "s1-no-deviceclass"
+			job.Labels[testutils.QueueLabel] = erAlpha2QueueName
+			job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
+			job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+				corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
+			}
+			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to create job")
+			DeferCleanup(func(ctx context.Context) {
+				By(fmt.Sprintf("Deleting job %s", createdJob.Name))
+				err := kubeClient.BatchV1().Jobs(ns.Name).Delete(ctx, createdJob.Name, metav1.DeleteOptions{
+					PropagationPolicy: ptr.To(metav1.DeletePropagationBackground),
+				})
+				Expect(err).NotTo(HaveOccurred(), "Failed to delete job")
+			})
+
+			By("Verifying workload is admitted via non-DRA extended resource path")
+			checkWorkloadCondition(ctx, ns.Name, string(createdJob.UID), kueuev1beta2.WorkloadAdmitted, "s1-no-deviceclass")
+
+			By("Verifying job is unsuspended")
+			Eventually(func() bool {
+				return !testutils.IsJobSuspended(ctx, kubeClient, ns.Name, createdJob.Name)
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue(),
+				"Job should be unsuspended (admitted via non-DRA ER path)")
+
+			By("Verifying pod is created but stays Pending")
+			Consistently(func(g Gomega) {
+				pods, err := kubeClient.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("batch.kubernetes.io/job-name=%s", createdJob.Name),
+				})
+				g.Expect(err).NotTo(HaveOccurred(), "Failed to list pods")
+				g.Expect(pods.Items).NotTo(BeEmpty(), "Job pod should exist")
+				g.Expect(pods.Items[0].Status.Phase).To(Equal(corev1.PodPending),
+					"Pod should stay Pending when no DeviceClass provides DRA path for nvidia.com/gpu")
+			}, testutils.ConsistentlyLongTimeout, testutils.ConsistentlyLongPoll).Should(Succeed())
+
+			By("Verifying no ResourceClaim was created")
+			Consistently(func(g Gomega) {
+				claims, err := kubeClient.ResourceV1().ResourceClaims(ns.Name).List(ctx, metav1.ListOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Failed to list ResourceClaims")
+				g.Expect(claims.Items).To(BeEmpty(), "No ResourceClaim should be created without DeviceClass")
+			}, testutils.ConsistentlyLongTimeout, testutils.ConsistentlyLongPoll).Should(Succeed())
+
+			By("Verifying ClusterQueue shows extended resource quota consumed")
+			verifyClusterQueueReservation(ctx, clients.UpstreamKueueClient, cq.Name, extendedResourceName, "1")
+		})
+	})
+
+	When("DeviceClass is created after workload submission", func() {
+		It("should transition pod to running via scheduler-level DRA activation", func(ctx context.Context) {
+			var err error
+
+			By("Deleting DeviceClass so no extendedResourceName mapping exists")
+			_ = kubeClient.ResourceV1().DeviceClasses().Delete(ctx, draDeviceClassName, metav1.DeleteOptions{})
+			Eventually(func() error {
+				_, err := kubeClient.ResourceV1().DeviceClasses().Get(ctx, draDeviceClassName, metav1.GetOptions{})
+				if err != nil {
+					return nil
+				}
+				return fmt.Errorf("DeviceClass %s still exists", draDeviceClassName)
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(),
+				"DeviceClass should be fully deleted")
+
+			By("Creating ResourceFlavor")
+			resourceFlavor, cleanupRF, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, clients.UpstreamKueueClient)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create resource flavor")
+			DeferCleanup(cleanupRF)
+
+			By("Creating ClusterQueue with extended resource quota")
+			cq, cleanupCQ, err := testutils.NewClusterQueue().WithGenerateName().WithFlavorName(resourceFlavor.Name).
+				WithDRAResource(extendedResourceName, "2").
+				CreateWithObject(ctx, clients.UpstreamKueueClient)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create cluster queue")
+			DeferCleanup(cleanupCQ)
+
+			By("Creating namespace")
+			ns, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: erAlpha2NamespacePrefix,
+					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
+			DeferCleanup(func(ctx context.Context) {
+				By(fmt.Sprintf("Deleting namespace %s", ns.Name))
+				err := kubeClient.CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred(), "Failed to delete namespace")
+				testutils.WaitForAllPodsInNamespaceDeleted(ctx, clients.GenericClient, ns)
+			})
+
+			By("Creating LocalQueue")
+			_, cleanupLQ, err := testutils.NewLocalQueue(ns.Name, erAlpha2QueueName).WithClusterQueue(cq.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create local queue")
+			DeferCleanup(cleanupLQ)
+
+			By("Creating Job requesting nvidia.com/gpu via extended resource")
+			builder := testutils.NewTestResourceBuilder(ns.Name, erAlpha2QueueName)
+			job := builder.NewJob()
+			setDRAJobCPU(job)
+			job.Name = "s2-late-deviceclass"
+			job.Labels[testutils.QueueLabel] = erAlpha2QueueName
+			job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
+			job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+				corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
+			}
+			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to create job")
+			DeferCleanup(func(ctx context.Context) {
+				By(fmt.Sprintf("Deleting job %s", createdJob.Name))
+				err := kubeClient.BatchV1().Jobs(ns.Name).Delete(ctx, createdJob.Name, metav1.DeleteOptions{
+					PropagationPolicy: ptr.To(metav1.DeletePropagationBackground),
+				})
+				Expect(err).NotTo(HaveOccurred(), "Failed to delete job")
+			})
+
+			By("Verifying workload is admitted via non-DRA extended resource path")
+			checkWorkloadCondition(ctx, ns.Name, string(createdJob.UID), kueuev1beta2.WorkloadAdmitted, "s2-late-deviceclass")
+
+			By("Verifying pod is Pending before DeviceClass creation")
+			Consistently(func(g Gomega) {
+				pods, err := kubeClient.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("batch.kubernetes.io/job-name=%s", createdJob.Name),
+				})
+				g.Expect(err).NotTo(HaveOccurred(), "Failed to list pods")
+				g.Expect(pods.Items).NotTo(BeEmpty(), "Job pod should exist")
+				g.Expect(pods.Items[0].Status.Phase).To(Equal(corev1.PodPending),
+					"Pod should be Pending before DeviceClass is created")
+			}, testutils.ConsistentlyTimeout, testutils.ConsistentlyPoll).Should(Succeed())
+
+			By("Creating DeviceClass with extendedResourceName")
+			newDC := &resourcev1.DeviceClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: draDeviceClassName,
+				},
+				Spec: resourcev1.DeviceClassSpec{
+					ExtendedResourceName: originalDeviceClass.Spec.ExtendedResourceName,
+					Selectors:            originalDeviceClass.Spec.Selectors,
+				},
+			}
+			_, err = kubeClient.ResourceV1().DeviceClasses().Create(ctx, newDC, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to create DeviceClass")
+
+			By("Verifying DeviceClass was created with extendedResourceName")
+			Eventually(func(g Gomega) {
+				dc, err := kubeClient.ResourceV1().DeviceClasses().Get(ctx, draDeviceClassName, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Failed to get DeviceClass")
+				g.Expect(dc.Spec.ExtendedResourceName).NotTo(BeNil(), "extendedResourceName should be set")
+				g.Expect(*dc.Spec.ExtendedResourceName).To(Equal(extendedResourceName),
+					"extendedResourceName should match")
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
+
+			By("Verifying pod transitions to Running via scheduler-level DRA activation")
+			Eventually(func() bool {
+				return testutils.IsJobPodRunning(ctx, kubeClient, ns.Name, createdJob.Name)
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue(),
+				"Pod should transition to Running after DeviceClass creation")
+
+			By("Verifying ResourceClaim was created by scheduler")
+			Eventually(func(g Gomega) {
+				claims, err := kubeClient.ResourceV1().ResourceClaims(ns.Name).List(ctx, metav1.ListOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Failed to list ResourceClaims")
+				g.Expect(claims.Items).NotTo(BeEmpty(), "ResourceClaim should be created after DeviceClass creation")
+
+				claim := claims.Items[0]
+				g.Expect(claim.Status.Allocation).NotTo(BeNil(), "ResourceClaim should be allocated")
+				g.Expect(claim.Status.ReservedFor).NotTo(BeEmpty(), "ResourceClaim should be reserved")
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
+
+			By("Verifying ClusterQueue still shows extended resource quota consumed")
+			verifyClusterQueueReservation(ctx, clients.UpstreamKueueClient, cq.Name, extendedResourceName, "1")
+		})
+	})
+})


### PR DESCRIPTION
**POC for QE team**

Add three Claude Code skills:
- create-release-plan: generates release testing plans (full/light formats) from repo state, with OCP upgrade matrix, CI job derivation, DAST API list, and test case traceability
- create-test-case: generates manual test case docs from Ginkgo e2e test files, mapping By() steps to action/verification with oc commands
- create-test-code: generates e2e test code from manual test case documentation

Add documentation models used by the skills:
- Release test plans for Kueue 1.4 and 1.5 (full and light formats) serving as templates for future releases
- Test case docs for admission fair sharing, TLS profile, and visibility on demand serving as reference examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed release testing plans and strategies for Kueue 1.4 and 1.5 releases
  * Added test case documentation for admission fair sharing, DRA extended resources, TLS profiles, and visibility API features
  * Added command guides for automated test documentation and release plan generation

* **Tests**
  * Expanded end-to-end test coverage with new test suite validating extended resource lifecycle and behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->