### PR TITLE
Add gpu-late-dc DeviceClass mapping for upstream DRA e2e tests

### DIFF
--- a/test/e2e/bindata/assets/08_kueue_default.yaml
+++ b/test/e2e/bindata/assets/08_kueue_default.yaml
@@ -16,6 +16,9 @@ spec:
       - name: gpu
         deviceClassNames:
         - gpu.example.com
+      - name: gpu-late-dc
+        deviceClassNames:
+        - gpu-late-dc.example.com
     integrations:
       frameworks:
       - BatchJob


### PR DESCRIPTION
The upstream baseline DRA test "Should admit job after DeviceClass is created" creates a DeviceClass gpu-late-dc.example.com at runtime and expects kueue to translate it to the logical name gpu-late-dc. Without this mapping in the default Kueue CR, the workload is never admitted on OpenShift because the operator controls the kueue config.