### PR TITLE
OCPBUGS-88040: Remove cluster-wide secrets RBAC from ClusterRole

### DIFF
--- a/bundle/manifests/kueue-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kueue-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
       ]
     capabilities: Basic Install
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2026-06-11T19:23:16Z"
+    createdAt: "2026-06-12T20:43:50Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -149,7 +149,6 @@ spec:
           - serviceaccounts
           - events
           - pods
-          - secrets
           - configmaps
           verbs:
           - create
@@ -311,6 +310,15 @@ spec:
           - list
           - patch
           - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - delete
+          - get
+          - list
           - watch
         serviceAccountName: openshift-kueue-operator
     strategy: deployment

--- a/deploy/02_clusterrole.yaml
+++ b/deploy/02_clusterrole.yaml
@@ -77,7 +77,6 @@ rules:
       - serviceaccounts
       - events
       - pods
-      - secrets
       - configmaps
     verbs:
       - create

--- a/deploy/02_role.yaml
+++ b/deploy/02_role.yaml
@@ -16,3 +16,19 @@ rules:
       - patch
       - update
       - watch
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-kueue-operator-secrets
+  namespace: openshift-kueue-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - delete
+      - get
+      - list
+      - watch

--- a/deploy/03_rolebinding.yaml
+++ b/deploy/03_rolebinding.yaml
@@ -11,3 +11,17 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: openshift-kueue-operator-networking
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-kueue-operator-secrets
+  namespace: openshift-kueue-operator
+subjects:
+  - kind: ServiceAccount
+    name: openshift-kueue-operator
+    namespace: openshift-kueue-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-kueue-operator-secrets


### PR DESCRIPTION
## Summary

Remove `secrets` from the cluster-wide `openshift-kueue-operator` ClusterRole. The operator no longer needs cluster-scoped access to secrets.

## Problem

The `openshift-kueue-operator` ClusterRole grants cluster-wide read/write access to `secrets`, which is overly permissive and a security concern.

## Root Cause

Upstream Kueue moved secrets RBAC to a namespace-scoped Role (`kueue-manager-secrets-role`), but the ClusterRole was never updated to remove the cluster-wide `secrets` permission.

## Fix

Removed `secrets` from the core API resources list in `deploy/02_clusterrole.yaml`.

The namespace-scoped Role (`bindata/assets/kueue-operator/role-manager-secrets.yaml`) and RoleBinding (`bindata/assets/kueue-operator/rolebinding-manager-secrets.yaml`) already exist and are deployed by the operator's reconciler into the operator namespace, covering all actual secrets usage:
- Secrets informer watches (operator namespace)
- Webhook/metrics cert secret management (operator namespace)
- Cert secret cleanup on teardown (operator namespace)

## Jira

https://redhat.atlassian.net/browse/OCPBUGS-88040


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed broad direct access to cluster secrets from the operator and introduced a dedicated role plus updated binding that grants limited secret permissions (get, list, watch, delete).
* **Chores**
  * Updated operator metadata timestamp in the release manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->