### PR TITLE
sync tekton with release-1.3

### DIFF
--- a/.opencode/skills/sync-tekton-release/SKILL.md
+++ b/.opencode/skills/sync-tekton-release/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: sync-tekton-release
+description: Use when the user asks to sync, create, or update .tekton/ pipeline YAML files for a new release branch (e.g., release-1.4, release-1.5). Covers syncing Tekton Konflux PipelineRun files from one release version to another while preserving newer task digests and pipeline improvements.
+---
+
+# Sync Tekton Release Files
+
+This skill generates `.tekton/*-<NEW_VERSION>-*.yaml` files for a new release branch by taking the corresponding files from a source release branch as the structural template, then applying version substitutions and preserving newer task digests/pipeline improvements.
+
+## When to use
+
+- User asks to sync/create/update Tekton files for a new release
+- User asks to create `.tekton/` pipeline files for `release-X.Y` based on `release-A.B`
+- User references "tekton files" and a release branch version
+
+## Components
+
+There are 4 components, each with a pull-request and push variant (8 files total):
+
+| Component       | Build type          | Dockerfile          | CEL path filter (push)                  |
+|-----------------|---------------------|---------------------|-----------------------------------------|
+| kueue-operator  | buildah-remote-oci-ta | Dockerfile         | Negative match (excludes bundle/must-gather paths) |
+| kueue-operand   | buildah-remote-oci-ta | Dockerfile.kueue   | Negative match (excludes bundle/must-gather paths) |
+| kueue-must-gather | buildah-remote-oci-ta | must-gather/Dockerfile | Positive match (must-gather paths only) |
+| kueue-bundle    | buildah-oci-ta (NOT remote) | bundle.Dockerfile | Positive match (bundle paths only) |
+
+## Workflow
+
+### Step 1: Extract source files
+
+Extract the versioned tekton files from the source branch:
+
+```bash
+# Example: source is release-1.3, files are *-1-3-*.yaml
+git show release-<SOURCE>:.tekton/<component>-<SRC_VER>-pull-request.yaml
+git show release-<SOURCE>:.tekton/<component>-<SRC_VER>-push.yaml
+```
+
+The version in filenames uses dashes not dots (e.g., `1-3` not `1.3`).
+
+### Step 2: Version substitution
+
+Replace all occurrences:
+- `<SRC_VER>` -> `<NEW_VER>` (e.g., `1-3` -> `1-4`) in names, labels, image refs, CEL expressions
+- `release-<SOURCE>` -> `release-<TARGET>` (e.g., `release-1.3` -> `release-1.4`) in target branch references
+
+### Step 3: Update task digests
+
+If the user wants to keep newer task digests (from existing files on the target branch or from a reference), replace the old task references with the new ones. The task references follow this pattern:
+
+```yaml
+value: quay.io/konflux-ci/tekton-catalog/<task-name>:<version>@sha256:<digest>
+```
+
+Common tasks that get updated:
+- `task-init`
+- `task-git-clone-oci-ta`
+- `task-prefetch-dependencies-oci-ta`
+- `task-buildah-remote-oci-ta` (operator, operand, must-gather)
+- `task-buildah-oci-ta` (bundle only)
+- `task-build-image-index`
+- `task-source-build-oci-ta`
+- `task-deprecated-image-check`
+- `task-clair-scan`
+- `task-ecosystem-cert-preflight-checks`
+- `task-sast-snyk-check-oci-ta`
+- `task-clamav-scan`
+- `task-sast-shell-check-oci-ta`
+- `task-sast-unicode-check-oci-ta`
+- `task-apply-tags`
+- `task-push-dockerfile-oci-ta`
+- `task-rpms-signature-scan`
+
+### Step 4: Set spec.params for hermetic builds (operator and operand only)
+
+The operator and operand pipelines MUST have `hermetic`, `prefetch-input`, and `build-source-image` set at the **`spec.params`** level (the PipelineRun inputs), not just in `pipelineSpec.params` defaults. Without these, hermetic builds run with network isolation but no prefetched RPMs, causing `microdnf install` / `dnf install` to fail.
+
+Add these under `spec.params` (after `dockerfile`) for **operator and operand** pipelines only:
+
+```yaml
+spec:
+  params:
+  # ... git-url, revision, output-image, image-expires-after, build-platforms, dockerfile ...
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "rpm", "path": "konflux"}'
+  - name: build-source-image
+    value: "true"
+  pipelineSpec:
+```
+
+**Bundle and must-gather do NOT get these params** — they match the main branch pattern where these are omitted.
+
+Always cross-reference with the corresponding `main` pipeline files to confirm which components need `spec.params` set.
+
+### Step 5: Apply pipeline improvements
+
+If newer pipeline template features exist, apply them. Common changes include:
+
+1. **New pipeline params** (e.g., `enable-package-registry-proxy`, `sast-target-dirs`) - add to `pipelineSpec.params` section
+2. **New task params** - wire new pipeline params into specific tasks (e.g., `enable-package-registry-proxy` into `prefetch-dependencies`, `TARGET_DIRS` into sast tasks)
+3. **Removed task params** - when a task version bumps, some params may be removed (e.g., `COMMIT_SHA` and `IMAGE_EXPIRES_AFTER` were removed from `build-image-index` 0.3)
+4. **Default value changes** - For release branches, `hermetic` and `build-source-image` defaults in `pipelineSpec.params` MUST be set to `"true"` (they default to `"false"` in main/template pipelines). Always verify and update these after generating files.
+5. **Bundle-specific changes** - `prefetch-input` default may differ for bundle components
+
+### Step 6: Preserve structural elements from source
+
+These elements should match the source release structure:
+
+- **CEL expressions**: Complex `on-cel-expression` with `files.all.exists(...)` path filters
+  - Operator pull-request and push: both use `files.all.exists(...)` with negative path matching (triggers on everything EXCEPT bundle/must-gather paths)
+  - Operand/must-gather pull-request: simple `event == "pull_request" && target_branch == "release-X.Y"` (no path filter)
+  - Operand/must-gather push: include `files.all.exists(...)` with path filters
+  - Bundle pull-request and push: both use `files.all.exists(...)` with positive path matching
+- **`creationTimestamp:`** field in metadata
+- **Multi-arch platforms**: `linux/x86_64`, `linux/s390x`, `linux/arm64`, `linux/ppc64le`
+- **Single-line description strings** (not wrapped)
+
+## Key structural patterns
+
+### CEL expression patterns
+
+**operator/operand push** (negative match - triggers on everything EXCEPT bundle/must-gather):
+```yaml
+pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-X.Y" && files.all.exists(path, !path.matches('upstream/kueue/src|bundle/|bundle.Dockerfile|.tekton/kueue-bundle-*|bundle.developer.Dockerfile|must-gather/|.tekton/kueue-must-gather-*|related_images.json|related_images.developer.json|bundle/manifests/kueue-operator.clusterserviceversion.yaml'))
+```
+
+**must-gather push** (positive match):
+```yaml
+pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-X.Y" && files.all.exists(path, path.matches('must-gather/|must-gather/Dockerfile|.tekton/kueue-must-gather-<VER>-*'))
+```
+
+**bundle pull-request** (positive match):
+```yaml
+pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-X.Y" && files.all.exists(path, path.matches('bundle/|bundle.Dockerfile|.tekton/kueue-bundle-<VER>-*|related_images.json'))
+```
+
+**bundle push** (positive match):
+```yaml
+pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-X.Y" && files.all.exists(path, path.matches('bundle/|bundle.Dockerfile|.tekton/kueue-bundle-<VER>-*|related_images.json'))
+```
+
+**operator pull-request** (negative match - same pattern as push):
+```yaml
+pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-X.Y" && files.all.exists(path, !path.matches('upstream/kueue/src|bundle/|bundle.Dockerfile|bundle.developer.Dockerfile|.tekton/kueue-bundle-*|must-gather/|.tekton/kueue-must-gather-*|related_images.json|related_images.developer.json|bundle/manifests/kueue-operator.clusterserviceversion.yaml'))
+```
+
+### Service account naming
+
+```yaml
+taskRunTemplate:
+  serviceAccountName: build-pipeline-<component>-<VER>
+```
+
+### Labels
+
+```yaml
+labels:
+  appstudio.openshift.io/application: kueue-operator-<VER>
+  appstudio.openshift.io/component: <component>-<VER>
+```
+
+### Output image
+
+```yaml
+# Pull request:
+output-image: quay.io/redhat-user-workloads/kueue-operator-tenant/<component>-<VER>:on-pr-{{revision}}
+# Push:
+output-image: quay.io/redhat-user-workloads/kueue-operator-tenant/<component>-<VER>:{{revision}}
+```
+
+## Verification
+
+After generating files, verify:
+
+1. Each file has the correct CEL expression pattern
+2. `creationTimestamp:` is present
+3. Multi-arch platforms are listed
+4. Task digests are updated (if newer versions were requested)
+5. New pipeline params are properly wired into tasks
+6. Removed task params are gone
+7. Bundle files use `buildah-oci-ta` (not `buildah-remote-oci-ta`)
+8. Service account names, labels, and output images use the correct version
+9. `hermetic` default is `"true"` (not `"false"`)
+10. `build-source-image` default is `"true"` (not `"false"`)
+11. **Operator and operand** files have `hermetic`, `prefetch-input`, and `build-source-image` in `spec.params` (not just `pipelineSpec.params`)
+
+```bash
+# Quick validation across all files
+for f in .tekton/kueue-*-<VER>-*.yaml; do
+    name=$(basename "$f")
+    proxy_count=$(grep -c 'enable-package-registry-proxy' "$f" 2>/dev/null)
+    target_dirs=$(grep -c 'TARGET_DIRS' "$f" 2>/dev/null)
+    cel=$(grep 'on-cel-expression' "$f")
+    creation=$(grep -c 'creationTimestamp' "$f")
+    hermetic=$(grep -A2 'name: hermetic' "$f" | grep -oP 'default: "\K[^"]+' | head -1)
+    source_image=$(grep -A2 'name: build-source-image' "$f" | grep -oP 'default: "\K[^"]+' | head -1)
+    echo "$name: proxy=$proxy_count target_dirs=$target_dirs creation=$creation hermetic=$hermetic build-source-image=$source_image"
+    echo "  CEL: $cel"
+done
+```

--- a/.tekton/kueue-bundle-1-4-pull-request.yaml
+++ b/.tekton/kueue-bundle-1-4-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-1.4"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.4" && files.all.exists(path, path.matches('bundle/|bundle.Dockerfile|.tekton/kueue-bundle-1-4-*|related_images.json'))
+  creationTimestamp:
   labels:
     appstudio.openshift.io/application: kueue-operator-1-4
     appstudio.openshift.io/component: kueue-bundle-1-4
@@ -46,33 +46,30 @@ spec:
       name: output-image
       type: string
     - default: .
-      description: Path to the source code of an application's component from where
-        to build image.
+      description: Path to the source code of an application's component from where to build image.
       name: path-context
       type: string
     - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
-        path-context
+      description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
       type: string
     - default: "false"
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
-      description: Build dependencies to be prefetched
+    - default: '{"type": "rpm", "path": "./konflux"}'
+      description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string
     - default: ""
-      description: Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       type: string
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string
@@ -81,8 +78,7 @@ spec:
       name: build-image-index
       type: string
     - default: docker
-      description: The format for the resulting image's mediaType. Valid values are
-        oci or docker.
+      description: The format for the resulting image's mediaType. Valid values are oci or docker.
       name: buildah-format
       type: string
     - default: "false"
@@ -92,8 +88,7 @@ spec:
       description: Use the package registry proxy when prefetching dependencies
       name: enable-package-registry-proxy
     - default: .
-      description: Target directories in component's source code to scan with SAST
-        tools. Multiple values should be separated with commas.
+      description: Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.
       name: sast-target-dirs
       type: string
     - default: []
@@ -105,8 +100,7 @@ spec:
       name: build-args-file
       type: string
     - default: "false"
-      description: Whether to enable privileged mode, should be used only with remote
-        VMs
+      description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
     results:
@@ -352,12 +346,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:
@@ -402,12 +396,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:
@@ -430,12 +424,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/kueue-bundle-1-4-push.yaml
+++ b/.tekton/kueue-bundle-1-4-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-1.4"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.4" && files.all.exists(path, path.matches('bundle/|bundle.Dockerfile|.tekton/kueue-bundle-1-4-*|related_images.json'))
+  creationTimestamp:
   labels:
     appstudio.openshift.io/application: kueue-operator-1-4
     appstudio.openshift.io/component: kueue-bundle-1-4
@@ -43,33 +43,30 @@ spec:
       name: output-image
       type: string
     - default: .
-      description: Path to the source code of an application's component from where
-        to build image.
+      description: Path to the source code of an application's component from where to build image.
       name: path-context
       type: string
     - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
-        path-context
+      description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
       type: string
     - default: "false"
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
-      description: Build dependencies to be prefetched
+    - default: '{"type": "rpm", "path": "./konflux"}'
+      description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string
     - default: ""
-      description: Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       type: string
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string
@@ -78,8 +75,7 @@ spec:
       name: build-image-index
       type: string
     - default: docker
-      description: The format for the resulting image's mediaType. Valid values are
-        oci or docker.
+      description: The format for the resulting image's mediaType. Valid values are oci or docker.
       name: buildah-format
       type: string
     - default: "false"
@@ -89,8 +85,7 @@ spec:
       description: Use the package registry proxy when prefetching dependencies
       name: enable-package-registry-proxy
     - default: .
-      description: Target directories in component's source code to scan with SAST
-        tools. Multiple values should be separated with commas.
+      description: Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.
       name: sast-target-dirs
       type: string
     - default: []
@@ -102,8 +97,7 @@ spec:
       name: build-args-file
       type: string
     - default: "false"
-      description: Whether to enable privileged mode, should be used only with remote
-        VMs
+      description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
     results:
@@ -349,12 +343,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:
@@ -399,12 +393,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:
@@ -427,12 +421,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/kueue-must-gather-1-4-pull-request.yaml
+++ b/.tekton/kueue-must-gather-1-4-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-1.4"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.4"
+  creationTimestamp:
   labels:
     appstudio.openshift.io/application: kueue-operator-1-4
     appstudio.openshift.io/component: kueue-must-gather-1-4
@@ -29,6 +29,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/s390x
+    - linux/arm64
+    - linux/ppc64le
   - name: dockerfile
     value: must-gather/Dockerfile
   pipelineSpec:
@@ -49,20 +52,18 @@ spec:
       name: output-image
       type: string
     - default: .
-      description: Path to the source code of an application's component from where
-        to build image.
+      description: Path to the source code of an application's component from where to build image.
       name: path-context
       type: string
     - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
-        path-context
+      description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
       type: string
     - default: "false"
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -71,11 +72,10 @@ spec:
       name: prefetch-input
       type: string
     - default: ""
-      description: Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       type: string
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string
@@ -84,8 +84,7 @@ spec:
       name: build-image-index
       type: string
     - default: docker
-      description: The format for the resulting image's mediaType. Valid values are
-        oci or docker.
+      description: The format for the resulting image's mediaType. Valid values are oci or docker.
       name: buildah-format
       type: string
     - default: "false"
@@ -95,8 +94,7 @@ spec:
       description: Use the package registry proxy when prefetching dependencies
       name: enable-package-registry-proxy
     - default: .
-      description: Target directories in component's source code to scan with SAST
-        tools. Multiple values should be separated with commas.
+      description: Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.
       name: sast-target-dirs
       type: string
     - default: []
@@ -108,14 +106,12 @@ spec:
       name: build-args-file
       type: string
     - default: "false"
-      description: Whether to enable privileged mode, should be used only with remote
-        VMs
+      description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
     - default:
       - linux/x86_64
-      description: List of platforms to build the container images on. The available
-        set of values is determined by the configuration of the multi-platform-controller.
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
     results:
@@ -378,12 +374,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:
@@ -433,12 +429,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:
@@ -461,12 +457,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/kueue-must-gather-1-4-push.yaml
+++ b/.tekton/kueue-must-gather-1-4-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-1.4"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.4" && files.all.exists(path, path.matches('must-gather/|must-gather/Dockerfile|.tekton/kueue-must-gather-1-4-*'))
+  creationTimestamp:
   labels:
     appstudio.openshift.io/application: kueue-operator-1-4
     appstudio.openshift.io/component: kueue-must-gather-1-4
@@ -26,6 +26,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/s390x
+    - linux/arm64
+    - linux/ppc64le
   - name: dockerfile
     value: must-gather/Dockerfile
   pipelineSpec:
@@ -46,20 +49,18 @@ spec:
       name: output-image
       type: string
     - default: .
-      description: Path to the source code of an application's component from where
-        to build image.
+      description: Path to the source code of an application's component from where to build image.
       name: path-context
       type: string
     - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
-        path-context
+      description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
       type: string
     - default: "false"
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -68,11 +69,10 @@ spec:
       name: prefetch-input
       type: string
     - default: ""
-      description: Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       type: string
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string
@@ -81,8 +81,7 @@ spec:
       name: build-image-index
       type: string
     - default: docker
-      description: The format for the resulting image's mediaType. Valid values are
-        oci or docker.
+      description: The format for the resulting image's mediaType. Valid values are oci or docker.
       name: buildah-format
       type: string
     - default: "false"
@@ -92,8 +91,7 @@ spec:
       description: Use the package registry proxy when prefetching dependencies
       name: enable-package-registry-proxy
     - default: .
-      description: Target directories in component's source code to scan with SAST
-        tools. Multiple values should be separated with commas.
+      description: Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.
       name: sast-target-dirs
       type: string
     - default: []
@@ -105,14 +103,12 @@ spec:
       name: build-args-file
       type: string
     - default: "false"
-      description: Whether to enable privileged mode, should be used only with remote
-        VMs
+      description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
     - default:
       - linux/x86_64
-      description: List of platforms to build the container images on. The available
-        set of values is determined by the configuration of the multi-platform-controller.
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
     results:
@@ -375,12 +371,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:
@@ -430,12 +426,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:
@@ -458,12 +454,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/kueue-operand-1-4-pull-request.yaml
+++ b/.tekton/kueue-operand-1-4-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-1.4"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.4"
+  creationTimestamp:
   labels:
     appstudio.openshift.io/application: kueue-operator-1-4
     appstudio.openshift.io/component: kueue-operand-1-4
@@ -29,8 +29,17 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/s390x
+    - linux/arm64
+    - linux/ppc64le
   - name: dockerfile
     value: Dockerfile.kueue
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "rpm", "path": "konflux"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -49,20 +58,18 @@ spec:
       name: output-image
       type: string
     - default: .
-      description: Path to the source code of an application's component from where
-        to build image.
+      description: Path to the source code of an application's component from where to build image.
       name: path-context
       type: string
     - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
-        path-context
+      description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
       type: string
     - default: "false"
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -71,11 +78,10 @@ spec:
       name: prefetch-input
       type: string
     - default: ""
-      description: Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       type: string
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string
@@ -84,8 +90,7 @@ spec:
       name: build-image-index
       type: string
     - default: docker
-      description: The format for the resulting image's mediaType. Valid values are
-        oci or docker.
+      description: The format for the resulting image's mediaType. Valid values are oci or docker.
       name: buildah-format
       type: string
     - default: "false"
@@ -95,8 +100,7 @@ spec:
       description: Use the package registry proxy when prefetching dependencies
       name: enable-package-registry-proxy
     - default: .
-      description: Target directories in component's source code to scan with SAST
-        tools. Multiple values should be separated with commas.
+      description: Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.
       name: sast-target-dirs
       type: string
     - default: []
@@ -108,14 +112,12 @@ spec:
       name: build-args-file
       type: string
     - default: "false"
-      description: Whether to enable privileged mode, should be used only with remote
-        VMs
+      description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
     - default:
       - linux/x86_64
-      description: List of platforms to build the container images on. The available
-        set of values is determined by the configuration of the multi-platform-controller.
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
     results:
@@ -378,12 +380,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:
@@ -433,12 +435,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:
@@ -461,12 +463,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/kueue-operand-1-4-push.yaml
+++ b/.tekton/kueue-operand-1-4-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-1.4"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.4" && ( "upstream/kueue/***".pathChanged() || "Dockerfile.kueue".pathChanged() || ".tekton/kueue-operand-1-4-push.yaml".pathChanged() )
+  creationTimestamp:
   labels:
     appstudio.openshift.io/application: kueue-operator-1-4
     appstudio.openshift.io/component: kueue-operand-1-4
@@ -26,8 +26,17 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/s390x
+    - linux/arm64
+    - linux/ppc64le
   - name: dockerfile
     value: Dockerfile.kueue
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "rpm", "path": "konflux"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -46,20 +55,18 @@ spec:
       name: output-image
       type: string
     - default: .
-      description: Path to the source code of an application's component from where
-        to build image.
+      description: Path to the source code of an application's component from where to build image.
       name: path-context
       type: string
     - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
-        path-context
+      description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
       type: string
     - default: "false"
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -68,11 +75,10 @@ spec:
       name: prefetch-input
       type: string
     - default: ""
-      description: Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       type: string
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string
@@ -81,8 +87,7 @@ spec:
       name: build-image-index
       type: string
     - default: docker
-      description: The format for the resulting image's mediaType. Valid values are
-        oci or docker.
+      description: The format for the resulting image's mediaType. Valid values are oci or docker.
       name: buildah-format
       type: string
     - default: "false"
@@ -92,8 +97,7 @@ spec:
       description: Use the package registry proxy when prefetching dependencies
       name: enable-package-registry-proxy
     - default: .
-      description: Target directories in component's source code to scan with SAST
-        tools. Multiple values should be separated with commas.
+      description: Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.
       name: sast-target-dirs
       type: string
     - default: []
@@ -105,14 +109,12 @@ spec:
       name: build-args-file
       type: string
     - default: "false"
-      description: Whether to enable privileged mode, should be used only with remote
-        VMs
+      description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
     - default:
       - linux/x86_64
-      description: List of platforms to build the container images on. The available
-        set of values is determined by the configuration of the multi-platform-controller.
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
     results:
@@ -375,12 +377,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:
@@ -430,12 +432,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:
@@ -458,12 +460,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/kueue-operator-1-4-pull-request.yaml
+++ b/.tekton/kueue-operator-1-4-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-1.4"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.4" && files.all.exists(path, !path.matches('upstream/kueue/src|bundle/|bundle.Dockerfile|bundle.developer.Dockerfile|.tekton/kueue-bundle-*|must-gather/|.tekton/kueue-must-gather-*|related_images.json|related_images.developer.json|bundle/manifests/kueue-operator.clusterserviceversion.yaml'))
+  creationTimestamp:
   labels:
     appstudio.openshift.io/application: kueue-operator-1-4
     appstudio.openshift.io/component: kueue-operator-1-4
@@ -29,8 +29,17 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/s390x
+    - linux/arm64
+    - linux/ppc64le
   - name: dockerfile
     value: Dockerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "rpm", "path": "konflux"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -49,20 +58,18 @@ spec:
       name: output-image
       type: string
     - default: .
-      description: Path to the source code of an application's component from where
-        to build image.
+      description: Path to the source code of an application's component from where to build image.
       name: path-context
       type: string
     - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
-        path-context
+      description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
       type: string
     - default: "false"
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -71,11 +78,10 @@ spec:
       name: prefetch-input
       type: string
     - default: ""
-      description: Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       type: string
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string
@@ -84,8 +90,7 @@ spec:
       name: build-image-index
       type: string
     - default: docker
-      description: The format for the resulting image's mediaType. Valid values are
-        oci or docker.
+      description: The format for the resulting image's mediaType. Valid values are oci or docker.
       name: buildah-format
       type: string
     - default: "false"
@@ -95,8 +100,7 @@ spec:
       description: Use the package registry proxy when prefetching dependencies
       name: enable-package-registry-proxy
     - default: .
-      description: Target directories in component's source code to scan with SAST
-        tools. Multiple values should be separated with commas.
+      description: Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.
       name: sast-target-dirs
       type: string
     - default: []
@@ -108,14 +112,12 @@ spec:
       name: build-args-file
       type: string
     - default: "false"
-      description: Whether to enable privileged mode, should be used only with remote
-        VMs
+      description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
     - default:
       - linux/x86_64
-      description: List of platforms to build the container images on. The available
-        set of values is determined by the configuration of the multi-platform-controller.
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
     results:
@@ -378,12 +380,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:
@@ -433,12 +435,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:
@@ -461,12 +463,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/kueue-operator-1-4-push.yaml
+++ b/.tekton/kueue-operator-1-4-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-1.4"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.4" && files.all.exists(path, !path.matches('upstream/kueue/src|bundle/|bundle.Dockerfile|.tekton/kueue-bundle-*|bundle.developer.Dockerfile|must-gather/|.tekton/kueue-must-gather-*|related_images.json|related_images.developer.json|bundle/manifests/kueue-operator.clusterserviceversion.yaml'))
+  creationTimestamp:
   labels:
     appstudio.openshift.io/application: kueue-operator-1-4
     appstudio.openshift.io/component: kueue-operator-1-4
@@ -26,8 +26,17 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/s390x
+    - linux/arm64
+    - linux/ppc64le
   - name: dockerfile
     value: Dockerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "rpm", "path": "konflux"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -46,20 +55,18 @@ spec:
       name: output-image
       type: string
     - default: .
-      description: Path to the source code of an application's component from where
-        to build image.
+      description: Path to the source code of an application's component from where to build image.
       name: path-context
       type: string
     - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
-        path-context
+      description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
       type: string
     - default: "false"
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -68,11 +75,10 @@ spec:
       name: prefetch-input
       type: string
     - default: ""
-      description: Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       type: string
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string
@@ -81,8 +87,7 @@ spec:
       name: build-image-index
       type: string
     - default: docker
-      description: The format for the resulting image's mediaType. Valid values are
-        oci or docker.
+      description: The format for the resulting image's mediaType. Valid values are oci or docker.
       name: buildah-format
       type: string
     - default: "false"
@@ -92,8 +97,7 @@ spec:
       description: Use the package registry proxy when prefetching dependencies
       name: enable-package-registry-proxy
     - default: .
-      description: Target directories in component's source code to scan with SAST
-        tools. Multiple values should be separated with commas.
+      description: Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.
       name: sast-target-dirs
       type: string
     - default: []
@@ -105,14 +109,12 @@ spec:
       name: build-args-file
       type: string
     - default: "false"
-      description: Whether to enable privileged mode, should be used only with remote
-        VMs
+      description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
     - default:
       - linux/x86_64
-      description: List of platforms to build the container images on. The available
-        set of values is determined by the configuration of the multi-platform-controller.
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
     results:
@@ -375,12 +377,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:
@@ -430,12 +432,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:
@@ -458,12 +460,12 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: TARGET_DIRS
-        value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added docs for a new sync-tekton-release skill: pipeline generation, systematic version substitutions, digest refresh guidance, CEL filter patterns, hermetic-input requirements, and verification checklist.

* **Chores**
  * Reformatted pipeline manifests and collapsed trigger CEL expressions to single-line form.
  * Reordered SAST task parameter listings (no value changes).
  * Expanded multi-arch builds to include s390x, arm64, ppc64le.
  * Refined trigger path matching for bundle and must-gather.
  * Updated defaults: hermetic and image-expires-after true; skip-checks true; prefetch-input defaults to a prefetch JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->