### PR TITLE
Fix API lint: add omitempty to union discriminator Type fields

### DIFF
--- a/pkg/apis/kueueoperator/v1/types.go
+++ b/pkg/apis/kueueoperator/v1/types.go
@@ -469,7 +469,7 @@ type DeviceClassSourceConfig struct {
 	// Counter uses DRA ConsumesCounters data from ResourceSlices to compute quota charges.
 	// +unionDiscriminator
 	// +required
-	Type DeviceClassSourceType `json:"type"`
+	Type DeviceClassSourceType `json:"type,omitempty"`
 
 	// counter configures counter-based quota for partitionable devices.
 	// Maps a DRA driver counter to the parent DeviceClassMapping's Kueue quota resource.
@@ -532,7 +532,7 @@ type DeviceSelector struct {
 	// CEL uses a CEL expression to filter devices by attributes.
 	// +unionDiscriminator
 	// +required
-	Type DeviceSelectorType `json:"type"`
+	Type DeviceSelectorType `json:"type,omitempty"`
 
 	// cel contains a CEL expression for filtering devices.
 	// cel is required when type is CEL, and forbidden otherwise.


### PR DESCRIPTION
Signed-off-by: Pannaga Rao Bhoja Ramamanohara

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* API responses now exclude unset discriminator fields from JSON output, resulting in cleaner and more compact responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->