### PR TITLE
update submodule june 13

### DIFF
--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-manager-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-manager-role.yaml
@@ -225,15 +225,11 @@ rules:
   resources:
   - admissionchecks
   - clusterqueues
-  - cohorts
-  - localqueues
-  - workloads
+  - resourceflavors
+  - topologies
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -241,7 +237,6 @@ rules:
   resources:
   - admissionchecks/finalizers
   - clusterqueues/finalizers
-  - localqueues/finalizers
   - resourceflavors/finalizers
   - topologies/finalizers
   - workloads/finalizers
@@ -263,6 +258,8 @@ rules:
 - apiGroups:
   - kueue.x-k8s.io
   resources:
+  - cohorts
+  - localqueues
   - multikueueclusters
   - multikueueconfigs
   - provisioningrequestconfigs
@@ -274,20 +271,13 @@ rules:
 - apiGroups:
   - kueue.x-k8s.io
   resources:
-  - resourceflavors
+  - workloads
   verbs:
+  - create
   - delete
   - get
   - list
-  - update
-  - watch
-- apiGroups:
-  - kueue.x-k8s.io
-  resources:
-  - topologies
-  verbs:
-  - get
-  - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/bindata/assets/kueue-operator/crds/crd-localqueues.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-localqueues.kueue.x-k8s.io-v1beta2.yaml
@@ -267,7 +267,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-map-keys:
                       - name
@@ -276,7 +276,7 @@ spec:
                   - name
                   - resources
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -345,7 +345,7 @@ spec:
                         description: ResourceName is the name identifying various
                           resources in a ResourceList.
                         type: string
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-type: set
                     topology:
@@ -375,7 +375,7 @@ spec:
                   required:
                   - name
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -409,7 +409,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-map-keys:
                       - name
@@ -418,7 +418,7 @@ spec:
                   - name
                   - resources
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -675,7 +675,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-map-keys:
                       - name
@@ -684,7 +684,7 @@ spec:
                   - name
                   - resources
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -718,7 +718,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-map-keys:
                       - name
@@ -727,7 +727,7 @@ spec:
                   - name
                   - resources
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name

--- a/bindata/assets/kueue-operator/crds/crd-workloads.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-workloads.kueue.x-k8s.io-v1beta2.yaml
@@ -2253,7 +2253,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -3843,7 +3842,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -4331,7 +4329,6 @@ spec:
                                 When set to false, a new userns is created for the pod. Setting false is useful for
                                 mitigating container breakout vulnerabilities even allowing users to run their
                                 containers as root without actually having root privileges on the host.
-                                This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                               type: boolean
                             hostname:
                               description: |-
@@ -5514,7 +5511,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -6086,6 +6082,14 @@ spec:
 
                                   It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                                   Containers that need access to the ResourceClaim reference it with this name.
+
+                                  When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                                  belongs to a PodGroup, a PodResourceClaim is matched to a
+                                  PodGroupResourceClaim if all of their fields are equal (Name,
+                                  ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                                  a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                                  the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                                  Pods.
                                 properties:
                                   name:
                                     description: |-
@@ -6110,6 +6114,16 @@ spec:
                                       will also be deleted. The pod name and resource name, along with a
                                       generated component, will be used to form a unique name for the
                                       ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                      When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                      belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                      Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                      ResourceClaim generated for the PodGroup. All pods in the group that
+                                      define an equivalent PodResourceClaim matching the
+                                      PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                      generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                      owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                      instead of any individual pod.
 
                                       This field is immutable and no changes will be made to the
                                       corresponding ResourceClaim by the control plane after creating the
@@ -6237,6 +6251,28 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
+                            schedulingGroup:
+                              description: |-
+                                SchedulingGroup provides a reference to the immediate scheduling runtime
+                                grouping object that this Pod belongs to.
+                                This field is used by the scheduler to identify the group and apply the
+                                correct group scheduling policies. The association with a group also
+                                impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                                of scheduling like preemption, resource attachment, etc. If not specified,
+                                the Pod is treated as a single unit in all of these aspects.
+                                The group object referenced by this field may not exist at the time the
+                                Pod is created.
+                                This field is immutable, but a group object with the same name may be
+                                recreated with different policies. Doing this during pod scheduling
+                                may result in the placement not conforming to the expected policies.
+                              properties:
+                                podGroupName:
+                                  description: |-
+                                    PodGroupName specifies the name of the standalone PodGroup object
+                                    that represents the runtime instance of this group.
+                                    Must be a DNS subdomain.
+                                  type: string
+                              type: object
                             securityContext:
                               description: |-
                                 SecurityContext holds pod-level security attributes and common container settings.
@@ -7693,7 +7729,7 @@ spec:
                                       A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                       The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                       The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                      The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                      The volume will be mounted read-only (ro).
                                       Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                       The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                     properties:
@@ -7867,8 +7903,7 @@ spec:
                                     description: |-
                                       portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                       Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                      are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                      is on.
+                                      are redirected to the pxd.portworx.com CSI driver.
                                     properties:
                                       fsType:
                                         description: |-
@@ -8705,42 +8740,6 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
-                            workloadRef:
-                              description: |-
-                                WorkloadRef provides a reference to the Workload object that this Pod belongs to.
-                                This field is used by the scheduler to identify the PodGroup and apply the
-                                correct group scheduling policies. The Workload object referenced
-                                by this field may not exist at the time the Pod is created.
-                                This field is immutable, but a Workload object with the same name
-                                may be recreated with different policies. Doing this during pod scheduling
-                                may result in the placement not conforming to the expected policies.
-                              properties:
-                                name:
-                                  description: |-
-                                    Name defines the name of the Workload object this Pod belongs to.
-                                    Workload must be in the same namespace as the Pod.
-                                    If it doesn't match any existing Workload, the Pod will remain unschedulable
-                                    until a Workload object is created and observed by the kube-scheduler.
-                                    It must be a DNS subdomain.
-                                  type: string
-                                podGroup:
-                                  description: |-
-                                    PodGroup is the name of the PodGroup within the Workload that this Pod
-                                    belongs to. If it doesn't match any existing PodGroup within the Workload,
-                                    the Pod will remain unschedulable until the Workload object is recreated
-                                    and observed by the kube-scheduler. It must be a DNS label.
-                                  type: string
-                                podGroupReplicaKey:
-                                  description: |-
-                                    PodGroupReplicaKey specifies the replica key of the PodGroup to which this
-                                    Pod belongs. It is used to distinguish pods belonging to different replicas
-                                    of the same pod group. The pod group policy is applied separately to each replica.
-                                    When set, it must be a DNS label.
-                                  type: string
-                              required:
-                              - name
-                              - podGroup
-                              type: object
                           required:
                           - containers
                           type: object
@@ -11689,7 +11688,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -13279,7 +13277,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -13767,7 +13764,6 @@ spec:
                                 When set to false, a new userns is created for the pod. Setting false is useful for
                                 mitigating container breakout vulnerabilities even allowing users to run their
                                 containers as root without actually having root privileges on the host.
-                                This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                               type: boolean
                             hostname:
                               description: |-
@@ -14950,7 +14946,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -15522,6 +15517,14 @@ spec:
 
                                   It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                                   Containers that need access to the ResourceClaim reference it with this name.
+
+                                  When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                                  belongs to a PodGroup, a PodResourceClaim is matched to a
+                                  PodGroupResourceClaim if all of their fields are equal (Name,
+                                  ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                                  a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                                  the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                                  Pods.
                                 properties:
                                   name:
                                     description: |-
@@ -15546,6 +15549,16 @@ spec:
                                       will also be deleted. The pod name and resource name, along with a
                                       generated component, will be used to form a unique name for the
                                       ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                      When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                      belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                      Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                      ResourceClaim generated for the PodGroup. All pods in the group that
+                                      define an equivalent PodResourceClaim matching the
+                                      PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                      generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                      owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                      instead of any individual pod.
 
                                       This field is immutable and no changes will be made to the
                                       corresponding ResourceClaim by the control plane after creating the
@@ -15673,6 +15686,28 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
+                            schedulingGroup:
+                              description: |-
+                                SchedulingGroup provides a reference to the immediate scheduling runtime
+                                grouping object that this Pod belongs to.
+                                This field is used by the scheduler to identify the group and apply the
+                                correct group scheduling policies. The association with a group also
+                                impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                                of scheduling like preemption, resource attachment, etc. If not specified,
+                                the Pod is treated as a single unit in all of these aspects.
+                                The group object referenced by this field may not exist at the time the
+                                Pod is created.
+                                This field is immutable, but a group object with the same name may be
+                                recreated with different policies. Doing this during pod scheduling
+                                may result in the placement not conforming to the expected policies.
+                              properties:
+                                podGroupName:
+                                  description: |-
+                                    PodGroupName specifies the name of the standalone PodGroup object
+                                    that represents the runtime instance of this group.
+                                    Must be a DNS subdomain.
+                                  type: string
+                              type: object
                             securityContext:
                               description: |-
                                 SecurityContext holds pod-level security attributes and common container settings.
@@ -17129,7 +17164,7 @@ spec:
                                       A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                       The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                       The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                      The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                      The volume will be mounted read-only (ro).
                                       Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                       The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                     properties:
@@ -17303,8 +17338,7 @@ spec:
                                     description: |-
                                       portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                       Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                      are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                      is on.
+                                      are redirected to the pxd.portworx.com CSI driver.
                                     properties:
                                       fsType:
                                         description: |-
@@ -18141,42 +18175,6 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
-                            workloadRef:
-                              description: |-
-                                WorkloadRef provides a reference to the Workload object that this Pod belongs to.
-                                This field is used by the scheduler to identify the PodGroup and apply the
-                                correct group scheduling policies. The Workload object referenced
-                                by this field may not exist at the time the Pod is created.
-                                This field is immutable, but a Workload object with the same name
-                                may be recreated with different policies. Doing this during pod scheduling
-                                may result in the placement not conforming to the expected policies.
-                              properties:
-                                name:
-                                  description: |-
-                                    Name defines the name of the Workload object this Pod belongs to.
-                                    Workload must be in the same namespace as the Pod.
-                                    If it doesn't match any existing Workload, the Pod will remain unschedulable
-                                    until a Workload object is created and observed by the kube-scheduler.
-                                    It must be a DNS subdomain.
-                                  type: string
-                                podGroup:
-                                  description: |-
-                                    PodGroup is the name of the PodGroup within the Workload that this Pod
-                                    belongs to. If it doesn't match any existing PodGroup within the Workload,
-                                    the Pod will remain unschedulable until the Workload object is recreated
-                                    and observed by the kube-scheduler. It must be a DNS label.
-                                  type: string
-                                podGroupReplicaKey:
-                                  description: |-
-                                    PodGroupReplicaKey specifies the replica key of the PodGroup to which this
-                                    Pod belongs. It is used to distinguish pods belonging to different replicas
-                                    of the same pod group. The pod group policy is applied separately to each replica.
-                                    When set, it must be a DNS label.
-                                  type: string
-                              required:
-                              - name
-                              - podGroup
-                              type: object
                           required:
                           - containers
                           type: object

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.24.0
 	sigs.k8s.io/controller-tools v0.19.0
 	sigs.k8s.io/jobset v0.12.0
-	sigs.k8s.io/kueue v0.18.0
+	sigs.k8s.io/kueue v0.18.1
 	sigs.k8s.io/lws v0.8.0
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
 	sigs.k8s.io/yaml v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -428,8 +428,8 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kube-storage-version-migrator v0.0.6-0.20230721195810-5c8923c5ff96 h1:PFWFSkpArPNJxFX4ZKWAk9NSeRoZaXschn+ULa4xVek=
 sigs.k8s.io/kube-storage-version-migrator v0.0.6-0.20230721195810-5c8923c5ff96/go.mod h1:EOBQyBowOUsd7U4CJnMHNE0ri+zCXyouGdLwC/jZU+I=
-sigs.k8s.io/kueue v0.18.0 h1:erVuAM8ziFMS9IaX6LznSNK+OAe6Kg9ixQLGFw27wqw=
-sigs.k8s.io/kueue v0.18.0/go.mod h1:ZZ/oo38C7WAa6rCqK9FL7NdrDXMiRq4Rrjey0iHAEqU=
+sigs.k8s.io/kueue v0.18.1 h1:XHPgRGhYYMTzsUHAKfZQ8V70jtXBKkIC18QbFLD72t8=
+sigs.k8s.io/kueue v0.18.1/go.mod h1:Pxmlj5cBKfZTzKNK7LKlyb/tB4HFErf6JM8qmklpFV8=
 sigs.k8s.io/lws v0.8.0 h1:DdhJ8QabwTfWgbgaHH2gdf8twliioHaoSfmDXRYEVU0=
 sigs.k8s.io/lws v0.8.0/go.mod h1:NEZk0ujEAzmDMys8HBh6aRVVK3tOIay/gv2qlU6HJdQ=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/upstream/kueue/patch/e2e.patch
+++ b/upstream/kueue/patch/e2e.patch
@@ -15,7 +15,7 @@ index 192fc8916..2b8708ca0 100644
  		util.MustCreate(ctx, k8sClient, ns)
  
 diff --git a/test/e2e/certmanager/metrics_test.go b/test/e2e/certmanager/metrics_test.go
-index 1ec80185e..63c816124 100644
+index 0cc393c98..eabe91047 100644
 --- a/test/e2e/certmanager/metrics_test.go
 +++ b/test/e2e/certmanager/metrics_test.go
 @@ -40,7 +40,7 @@ const (
@@ -28,7 +28,7 @@ index 1ec80185e..63c816124 100644
  )
  
 diff --git a/test/e2e/sequential/baseline/admission_fair_sharing_test.go b/test/e2e/sequential/baseline/admission_fair_sharing_test.go
-index 0cc1e5d47..3215c2f9a 100644
+index 1cd6a7126..7757f919f 100644
 --- a/test/e2e/sequential/baseline/admission_fair_sharing_test.go
 +++ b/test/e2e/sequential/baseline/admission_fair_sharing_test.go
 @@ -17,8 +17,6 @@ limitations under the License.
@@ -68,36 +68,21 @@ index 0cc1e5d47..3215c2f9a 100644
  
  		rf = utiltestingapi.MakeResourceFlavor("afs-rf").Obj()
  		util.MustCreate(ctx, k8sClient, rf)
-diff --git a/test/e2e/sequential/baseline/suite_test.go b/test/e2e/sequential/baseline/suite_test.go
-index 13c60383a..bd787db80 100644
---- a/test/e2e/sequential/baseline/suite_test.go
-+++ b/test/e2e/sequential/baseline/suite_test.go
-@@ -68,6 +68,7 @@ var _ = ginkgo.BeforeSuite(func() {
- 	defaultKueueCfg = util.GetKueueConfiguration(ctx, k8sClient)
- })
- 
--var _ = ginkgo.AfterSuite(func() {
--	util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
--})
-+// On OCP, kueue configuration is managed via the Kueue CR, not direct config updates.
-+// var _ = ginkgo.AfterSuite(func() {
-+// 	util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
-+// })
 diff --git a/test/e2e/singlecluster/extended/suite_test.go b/test/e2e/singlecluster/extended/suite_test.go
-index 78be86a76..55d24706a 100644
+index 4bbee0840..201c01148 100644
 --- a/test/e2e/singlecluster/extended/suite_test.go
 +++ b/test/e2e/singlecluster/extended/suite_test.go
 @@ -54,12 +54,12 @@ var _ = ginkgo.BeforeSuite(func() {
  	waitForAvailableStart := time.Now()
  	util.WaitForKueueAvailability(ctx, k8sClient)
  	labelFilter := ginkgo.GinkgoLabelFilter()
--	if ginkgo.Label("feature:jobset", "feature:tas", "feature:trainjob").MatchesLabelFilter(labelFilter) {
+-	if ginkgo.Label("feature:jobset", "feature:trainjob").MatchesLabelFilter(labelFilter) {
 -		util.WaitForJobSetAvailability(ctx, k8sClient)
 -	}
 -	if ginkgo.Label("feature:leaderworkerset").MatchesLabelFilter(labelFilter) {
 -		util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
 -	}
-+	// if ginkgo.Label("feature:jobset", "feature:tas", "feature:trainjob").MatchesLabelFilter(labelFilter) {
++	// if ginkgo.Label("feature:jobset", "feature:trainjob").MatchesLabelFilter(labelFilter) {
 +	// 	util.WaitForJobSetAvailability(ctx, k8sClient)
 +	// }
 +	// if ginkgo.Label("feature:leaderworkerset").MatchesLabelFilter(labelFilter) {

--- a/upstream/kueue/utils.sh
+++ b/upstream/kueue/utils.sh
@@ -4,16 +4,16 @@
 apply_patches() {
   for patch in patch/*.patch; do
     pushd src >/dev/null
-    # Check if patch can be applied (not already applied)
-    if git apply --check ../"$patch" 2>/dev/null; then
+    # Check if patch is already applied (reverse-apply succeeds)
+    if git apply --check --reverse ../"$patch" 2>/dev/null; then
+      echo "Skipping $patch (already applied)"
+    else
       echo "Applying $patch"
       git apply ../"$patch" || {
-        echo "Error: Failed to apply $patch"
+        echo "Error: Failed to apply $patch — patch may need updating after a submodule sync"
         popd >/dev/null
         return 1
       }
-    else
-      echo "Skipping $patch (already applied or conflicts)"
     fi
     popd >/dev/null
   done

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1710,7 +1710,7 @@ sigs.k8s.io/kube-storage-version-migrator/pkg/apis/migration/v1alpha1
 sigs.k8s.io/kube-storage-version-migrator/pkg/clients/clientset
 sigs.k8s.io/kube-storage-version-migrator/pkg/clients/clientset/scheme
 sigs.k8s.io/kube-storage-version-migrator/pkg/clients/clientset/typed/migration/v1alpha1
-# sigs.k8s.io/kueue v0.18.0
+# sigs.k8s.io/kueue v0.18.1
 ## explicit; go 1.26.0
 sigs.k8s.io/kueue/apis/config/v1beta2
 sigs.k8s.io/kueue/apis/kueue/v1alpha1

--- a/vendor/sigs.k8s.io/kueue/apis/kueue/v1beta1/localqueue_types.go
+++ b/vendor/sigs.k8s.io/kueue/apis/kueue/v1beta1/localqueue_types.go
@@ -65,7 +65,7 @@ type LocalQueueFlavorStatus struct {
 
 	// resources used in the flavor.
 	// +listType=set
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	// +optional
 	Resources []corev1.ResourceName `json:"resources,omitempty"`
 
@@ -138,7 +138,7 @@ type LocalQueueStatus struct {
 	// workloads assigned to this LocalQueue.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	// +optional
 	FlavorsReservation []LocalQueueFlavorUsage `json:"flavorsReservation"`
 
@@ -146,14 +146,14 @@ type LocalQueueStatus struct {
 	// workloads assigned to this LocalQueue.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	// +optional
 	FlavorUsage []LocalQueueFlavorUsage `json:"flavorUsage"`
 
 	// flavors lists all currently available ResourceFlavors in specified ClusterQueue.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	// +optional
 	//
 	// Deprecated: Flavors is deprecated and marked for removal in v1beta2.
@@ -177,7 +177,7 @@ type LocalQueueFlavorUsage struct {
 	// resources lists the quota usage for the resources in this flavor.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	Resources []LocalQueueResourceUsage `json:"resources"`
 }
 

--- a/vendor/sigs.k8s.io/kueue/apis/kueue/v1beta2/localqueue_types.go
+++ b/vendor/sigs.k8s.io/kueue/apis/kueue/v1beta2/localqueue_types.go
@@ -104,7 +104,7 @@ type LocalQueueStatus struct {
 	// workloads assigned to this LocalQueue.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	// +optional
 	FlavorsReservation []LocalQueueFlavorUsage `json:"flavorsReservation,omitempty"`
 
@@ -112,7 +112,7 @@ type LocalQueueStatus struct {
 	// workloads assigned to this LocalQueue.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	// +optional
 	FlavorsUsage []LocalQueueFlavorUsage `json:"flavorsUsage,omitempty"`
 
@@ -164,7 +164,7 @@ type LocalQueueFlavorUsage struct {
 	// resources lists the quota usage for the resources in this flavor.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	// +required
 	Resources []LocalQueueResourceUsage `json:"resources,omitempty"`
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased CRD validation capacity for local queue flavor quota/status lists (maxItems 16 → 64).

* **Bug Fixes**
  * Updated controller RBAC to better match required permissions, including flavor/topology and cohort/local queue access changes.

* **Documentation**
  * Refreshed and clarified CRD schema text, field behavior notes, and PodResourceClaim documentation.

* **Tests**
  * Updated E2E test setup and expectations to align with the target platform’s cert-manager and configuration behavior.

* **Chores**
  * Bumped the upstream dependency and improved patch-application handling to better support submodule syncs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->