### PR TITLE
update submodule to latest 0.18 and fix upstream patch failures

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "upstream/kueue/src"]
 	path = upstream/kueue/src
 	url = https://github.com/kubernetes-sigs/kueue.git
-	branch = main
+	branch = release-0.18

--- a/bindata/assets/kueue-operator/crds/crd-localqueues.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-localqueues.kueue.x-k8s.io-v1beta2.yaml
@@ -267,7 +267,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-map-keys:
                       - name
@@ -276,7 +276,7 @@ spec:
                   - name
                   - resources
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -345,7 +345,7 @@ spec:
                         description: ResourceName is the name identifying various
                           resources in a ResourceList.
                         type: string
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-type: set
                     topology:
@@ -375,7 +375,7 @@ spec:
                   required:
                   - name
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -409,7 +409,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-map-keys:
                       - name
@@ -418,7 +418,7 @@ spec:
                   - name
                   - resources
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -675,7 +675,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-map-keys:
                       - name
@@ -684,7 +684,7 @@ spec:
                   - name
                   - resources
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -718,7 +718,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-map-keys:
                       - name
@@ -727,7 +727,7 @@ spec:
                   - name
                   - resources
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name

--- a/bindata/assets/kueue-operator/crds/crd-workloads.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-workloads.kueue.x-k8s.io-v1beta2.yaml
@@ -2253,7 +2253,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -3843,7 +3842,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -4331,7 +4329,6 @@ spec:
                                 When set to false, a new userns is created for the pod. Setting false is useful for
                                 mitigating container breakout vulnerabilities even allowing users to run their
                                 containers as root without actually having root privileges on the host.
-                                This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                               type: boolean
                             hostname:
                               description: |-
@@ -5514,7 +5511,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -6086,6 +6082,14 @@ spec:
 
                                   It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                                   Containers that need access to the ResourceClaim reference it with this name.
+
+                                  When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                                  belongs to a PodGroup, a PodResourceClaim is matched to a
+                                  PodGroupResourceClaim if all of their fields are equal (Name,
+                                  ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                                  a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                                  the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                                  Pods.
                                 properties:
                                   name:
                                     description: |-
@@ -6110,6 +6114,16 @@ spec:
                                       will also be deleted. The pod name and resource name, along with a
                                       generated component, will be used to form a unique name for the
                                       ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                      When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                      belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                      Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                      ResourceClaim generated for the PodGroup. All pods in the group that
+                                      define an equivalent PodResourceClaim matching the
+                                      PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                      generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                      owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                      instead of any individual pod.
 
                                       This field is immutable and no changes will be made to the
                                       corresponding ResourceClaim by the control plane after creating the
@@ -6237,6 +6251,28 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
+                            schedulingGroup:
+                              description: |-
+                                SchedulingGroup provides a reference to the immediate scheduling runtime
+                                grouping object that this Pod belongs to.
+                                This field is used by the scheduler to identify the group and apply the
+                                correct group scheduling policies. The association with a group also
+                                impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                                of scheduling like preemption, resource attachment, etc. If not specified,
+                                the Pod is treated as a single unit in all of these aspects.
+                                The group object referenced by this field may not exist at the time the
+                                Pod is created.
+                                This field is immutable, but a group object with the same name may be
+                                recreated with different policies. Doing this during pod scheduling
+                                may result in the placement not conforming to the expected policies.
+                              properties:
+                                podGroupName:
+                                  description: |-
+                                    PodGroupName specifies the name of the standalone PodGroup object
+                                    that represents the runtime instance of this group.
+                                    Must be a DNS subdomain.
+                                  type: string
+                              type: object
                             securityContext:
                               description: |-
                                 SecurityContext holds pod-level security attributes and common container settings.
@@ -7693,7 +7729,7 @@ spec:
                                       A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                       The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                       The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                      The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                      The volume will be mounted read-only (ro).
                                       Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                       The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                     properties:
@@ -7867,8 +7903,7 @@ spec:
                                     description: |-
                                       portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                       Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                      are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                      is on.
+                                      are redirected to the pxd.portworx.com CSI driver.
                                     properties:
                                       fsType:
                                         description: |-
@@ -8705,42 +8740,6 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
-                            workloadRef:
-                              description: |-
-                                WorkloadRef provides a reference to the Workload object that this Pod belongs to.
-                                This field is used by the scheduler to identify the PodGroup and apply the
-                                correct group scheduling policies. The Workload object referenced
-                                by this field may not exist at the time the Pod is created.
-                                This field is immutable, but a Workload object with the same name
-                                may be recreated with different policies. Doing this during pod scheduling
-                                may result in the placement not conforming to the expected policies.
-                              properties:
-                                name:
-                                  description: |-
-                                    Name defines the name of the Workload object this Pod belongs to.
-                                    Workload must be in the same namespace as the Pod.
-                                    If it doesn't match any existing Workload, the Pod will remain unschedulable
-                                    until a Workload object is created and observed by the kube-scheduler.
-                                    It must be a DNS subdomain.
-                                  type: string
-                                podGroup:
-                                  description: |-
-                                    PodGroup is the name of the PodGroup within the Workload that this Pod
-                                    belongs to. If it doesn't match any existing PodGroup within the Workload,
-                                    the Pod will remain unschedulable until the Workload object is recreated
-                                    and observed by the kube-scheduler. It must be a DNS label.
-                                  type: string
-                                podGroupReplicaKey:
-                                  description: |-
-                                    PodGroupReplicaKey specifies the replica key of the PodGroup to which this
-                                    Pod belongs. It is used to distinguish pods belonging to different replicas
-                                    of the same pod group. The pod group policy is applied separately to each replica.
-                                    When set, it must be a DNS label.
-                                  type: string
-                              required:
-                              - name
-                              - podGroup
-                              type: object
                           required:
                           - containers
                           type: object
@@ -11689,7 +11688,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -13279,7 +13277,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -13767,7 +13764,6 @@ spec:
                                 When set to false, a new userns is created for the pod. Setting false is useful for
                                 mitigating container breakout vulnerabilities even allowing users to run their
                                 containers as root without actually having root privileges on the host.
-                                This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                               type: boolean
                             hostname:
                               description: |-
@@ -14950,7 +14946,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -15522,6 +15517,14 @@ spec:
 
                                   It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                                   Containers that need access to the ResourceClaim reference it with this name.
+
+                                  When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                                  belongs to a PodGroup, a PodResourceClaim is matched to a
+                                  PodGroupResourceClaim if all of their fields are equal (Name,
+                                  ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                                  a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                                  the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                                  Pods.
                                 properties:
                                   name:
                                     description: |-
@@ -15546,6 +15549,16 @@ spec:
                                       will also be deleted. The pod name and resource name, along with a
                                       generated component, will be used to form a unique name for the
                                       ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                      When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                      belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                      Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                      ResourceClaim generated for the PodGroup. All pods in the group that
+                                      define an equivalent PodResourceClaim matching the
+                                      PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                      generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                      owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                      instead of any individual pod.
 
                                       This field is immutable and no changes will be made to the
                                       corresponding ResourceClaim by the control plane after creating the
@@ -15673,6 +15686,28 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
+                            schedulingGroup:
+                              description: |-
+                                SchedulingGroup provides a reference to the immediate scheduling runtime
+                                grouping object that this Pod belongs to.
+                                This field is used by the scheduler to identify the group and apply the
+                                correct group scheduling policies. The association with a group also
+                                impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                                of scheduling like preemption, resource attachment, etc. If not specified,
+                                the Pod is treated as a single unit in all of these aspects.
+                                The group object referenced by this field may not exist at the time the
+                                Pod is created.
+                                This field is immutable, but a group object with the same name may be
+                                recreated with different policies. Doing this during pod scheduling
+                                may result in the placement not conforming to the expected policies.
+                              properties:
+                                podGroupName:
+                                  description: |-
+                                    PodGroupName specifies the name of the standalone PodGroup object
+                                    that represents the runtime instance of this group.
+                                    Must be a DNS subdomain.
+                                  type: string
+                              type: object
                             securityContext:
                               description: |-
                                 SecurityContext holds pod-level security attributes and common container settings.
@@ -17129,7 +17164,7 @@ spec:
                                       A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                       The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                       The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                      The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                      The volume will be mounted read-only (ro).
                                       Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                       The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                     properties:
@@ -17303,8 +17338,7 @@ spec:
                                     description: |-
                                       portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                       Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                      are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                      is on.
+                                      are redirected to the pxd.portworx.com CSI driver.
                                     properties:
                                       fsType:
                                         description: |-
@@ -18141,42 +18175,6 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
-                            workloadRef:
-                              description: |-
-                                WorkloadRef provides a reference to the Workload object that this Pod belongs to.
-                                This field is used by the scheduler to identify the PodGroup and apply the
-                                correct group scheduling policies. The Workload object referenced
-                                by this field may not exist at the time the Pod is created.
-                                This field is immutable, but a Workload object with the same name
-                                may be recreated with different policies. Doing this during pod scheduling
-                                may result in the placement not conforming to the expected policies.
-                              properties:
-                                name:
-                                  description: |-
-                                    Name defines the name of the Workload object this Pod belongs to.
-                                    Workload must be in the same namespace as the Pod.
-                                    If it doesn't match any existing Workload, the Pod will remain unschedulable
-                                    until a Workload object is created and observed by the kube-scheduler.
-                                    It must be a DNS subdomain.
-                                  type: string
-                                podGroup:
-                                  description: |-
-                                    PodGroup is the name of the PodGroup within the Workload that this Pod
-                                    belongs to. If it doesn't match any existing PodGroup within the Workload,
-                                    the Pod will remain unschedulable until the Workload object is recreated
-                                    and observed by the kube-scheduler. It must be a DNS label.
-                                  type: string
-                                podGroupReplicaKey:
-                                  description: |-
-                                    PodGroupReplicaKey specifies the replica key of the PodGroup to which this
-                                    Pod belongs. It is used to distinguish pods belonging to different replicas
-                                    of the same pod group. The pod group policy is applied separately to each replica.
-                                    When set, it must be a DNS label.
-                                  type: string
-                              required:
-                              - name
-                              - podGroup
-                              type: object
                           required:
                           - containers
                           type: object

--- a/upstream/kueue/patch/e2e.patch
+++ b/upstream/kueue/patch/e2e.patch
@@ -3,7 +3,7 @@ index 192fc8916..2b8708ca0 100644
 --- a/test/e2e/certmanager/certmanager_test.go
 +++ b/test/e2e/certmanager/certmanager_test.go
 @@ -40,7 +40,10 @@ var _ = ginkgo.Describe("CertManager", ginkgo.Ordered, func() {
- 
+
  	ginkgo.BeforeEach(func() {
  		ns = &corev1.Namespace{
 -			ObjectMeta: metav1.ObjectMeta{GenerateName: "e2e-cert-manager-"},
@@ -13,9 +13,9 @@ index 192fc8916..2b8708ca0 100644
 +			},
  		}
  		util.MustCreate(ctx, k8sClient, ns)
- 
+
 diff --git a/test/e2e/certmanager/metrics_test.go b/test/e2e/certmanager/metrics_test.go
-index 1ec80185e..63c816124 100644
+index 0cc393c98..eabe91047 100644
 --- a/test/e2e/certmanager/metrics_test.go
 +++ b/test/e2e/certmanager/metrics_test.go
 @@ -40,7 +40,7 @@ const (
@@ -26,14 +26,14 @@ index 1ec80185e..63c816124 100644
 +	certSecretName               = "metrics-server-cert"
  	certMountPath                = "/etc/kueue/metrics/certs"
  )
- 
+
 diff --git a/test/e2e/sequential/baseline/admission_fair_sharing_test.go b/test/e2e/sequential/baseline/admission_fair_sharing_test.go
-index 0cc1e5d47..3215c2f9a 100644
+index 1cd6a7126..7757f919f 100644
 --- a/test/e2e/sequential/baseline/admission_fair_sharing_test.go
 +++ b/test/e2e/sequential/baseline/admission_fair_sharing_test.go
 @@ -17,8 +17,6 @@ limitations under the License.
  package baseline
- 
+
  import (
 -	"time"
 -
@@ -43,14 +43,14 @@ index 0cc1e5d47..3215c2f9a 100644
 @@ -27,7 +25,6 @@ import (
  	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
  	"sigs.k8s.io/controller-runtime/pkg/client"
- 
+
 -	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
  	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
  	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
  	jobtesting "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 @@ -41,12 +38,13 @@ var _ = ginkgo.Describe("Admission Fair Sharing", ginkgo.Label("feature:admissio
  	)
- 
+
  	ginkgo.BeforeAll(func() {
 -		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
 -			cfg.AdmissionFairSharing = &configapi.AdmissionFairSharing{
@@ -65,39 +65,24 @@ index 0cc1e5d47..3215c2f9a 100644
 +		// 		UsageSamplingInterval: metav1.Duration{Duration: 1 * time.Second},
 +		// 	}
 +		// })
- 
+
  		rf = utiltestingapi.MakeResourceFlavor("afs-rf").Obj()
  		util.MustCreate(ctx, k8sClient, rf)
-diff --git a/test/e2e/sequential/baseline/suite_test.go b/test/e2e/sequential/baseline/suite_test.go
-index 13c60383a..bd787db80 100644
---- a/test/e2e/sequential/baseline/suite_test.go
-+++ b/test/e2e/sequential/baseline/suite_test.go
-@@ -68,6 +68,7 @@ var _ = ginkgo.BeforeSuite(func() {
- 	defaultKueueCfg = util.GetKueueConfiguration(ctx, k8sClient)
- })
- 
--var _ = ginkgo.AfterSuite(func() {
--	util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
--})
-+// On OCP, kueue configuration is managed via the Kueue CR, not direct config updates.
-+// var _ = ginkgo.AfterSuite(func() {
-+// 	util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
-+// })
 diff --git a/test/e2e/singlecluster/extended/suite_test.go b/test/e2e/singlecluster/extended/suite_test.go
-index 78be86a76..55d24706a 100644
+index 4bbee0840..201c01148 100644
 --- a/test/e2e/singlecluster/extended/suite_test.go
 +++ b/test/e2e/singlecluster/extended/suite_test.go
 @@ -54,12 +54,12 @@ var _ = ginkgo.BeforeSuite(func() {
  	waitForAvailableStart := time.Now()
  	util.WaitForKueueAvailability(ctx, k8sClient)
  	labelFilter := ginkgo.GinkgoLabelFilter()
--	if ginkgo.Label("feature:jobset", "feature:tas", "feature:trainjob").MatchesLabelFilter(labelFilter) {
+-	if ginkgo.Label("feature:jobset", "feature:trainjob").MatchesLabelFilter(labelFilter) {
 -		util.WaitForJobSetAvailability(ctx, k8sClient)
 -	}
 -	if ginkgo.Label("feature:leaderworkerset").MatchesLabelFilter(labelFilter) {
 -		util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
 -	}
-+	// if ginkgo.Label("feature:jobset", "feature:tas", "feature:trainjob").MatchesLabelFilter(labelFilter) {
++	// if ginkgo.Label("feature:jobset", "feature:trainjob").MatchesLabelFilter(labelFilter) {
 +	// 	util.WaitForJobSetAvailability(ctx, k8sClient)
 +	// }
 +	// if ginkgo.Label("feature:leaderworkerset").MatchesLabelFilter(labelFilter) {

--- a/upstream/kueue/utils.sh
+++ b/upstream/kueue/utils.sh
@@ -4,16 +4,16 @@
 apply_patches() {
   for patch in patch/*.patch; do
     pushd src >/dev/null
-    # Check if patch can be applied (not already applied)
-    if git apply --check ../"$patch" 2>/dev/null; then
+    # Check if patch is already applied (reverse-apply succeeds)
+    if git apply --check --reverse ../"$patch" 2>/dev/null; then
+      echo "Skipping $patch (already applied)"
+    else
       echo "Applying $patch"
       git apply ../"$patch" || {
-        echo "Error: Failed to apply $patch"
+        echo "Error: Failed to apply $patch — patch may need updating after a submodule sync"
         popd >/dev/null
         return 1
       }
-    else
-      echo "Skipping $patch (already applied or conflicts)"
     fi
     popd >/dev/null
   done


### PR DESCRIPTION
Fix failures in https://github.com/openshift/kueue-operator/pull/2014 but applying changes in https://github.com/openshift/kueue-operator/pull/2016.

Also update branch to point to 0.18 submodule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased maximum items limit in quota structures from 16 to 64.

* **Documentation**
  * Updated CustomResourceDefinition schemas with refined descriptions.

* **Chores**
  * Improved patch detection in build utilities.
  * Updated submodule tracking and test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->