### PR TITLE
OCPKUEUE-655: Refactor e2e test suites to use shared helpers

### DIFF
--- a/test/e2e/e2e_admission_fair_sharing_test.go
+++ b/test/e2e/e2e_admission_fair_sharing_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Admission Fair Sharing", Label("admission-fair-sharing"), Orde
 		labelValue                         = trueLabelValue
 		usageHalfLifeTimeSeconds     int32 = 60
 		usageSamplingIntervalSeconds int32 = 5
+		afsSamplingLQName                  = "lq-sampling"
 	)
 
 	JustAfterEach(func(ctx context.Context) {
@@ -187,48 +188,15 @@ var _ = Describe("Admission Fair Sharing", Label("admission-fair-sharing"), Orde
 		})
 
 		It("should advance lastUpdate timestamps at approximately the configured sampling interval", func(ctx context.Context) {
-			By("Creating Resource Flavor")
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create resource flavor")
-			DeferCleanup(cleanupResourceFlavor)
-
-			By("Creating ClusterQueue with UsageBasedAdmissionFairSharing")
-			clusterQueue, cleanupClusterQueue, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithCPU("1").
-				WithMemory("200Mi").
-				WithFlavorName(resourceFlavor.Name).
-				WithAdmissionScope(kueuev1beta2.UsageBasedAdmissionFairSharing).
-				CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create cluster queue")
-			DeferCleanup(cleanupClusterQueue)
-
-			By("Creating namespace")
-			namespace, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "afs-sampling-",
-					Labels: map[string]string{
-						labelKey: labelValue,
-					},
-				},
-			}, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
-			DeferCleanup(func(ctx context.Context) {
-				By(fmt.Sprintf("Deleting namespace %s", namespace.Name))
-				err := kubeClient.CoreV1().Namespaces().Delete(ctx, namespace.Name, metav1.DeleteOptions{})
-				Expect(err).NotTo(HaveOccurred(), "Failed to delete namespace")
-				testutils.WaitForAllPodsInNamespaceDeleted(ctx, clients.GenericClient, namespace)
-			})
-
-			By("Creating LocalQueue")
-			lq, cleanupLQ, err := testutils.NewLocalQueue(namespace.Name, "lq-sampling").
-				WithClusterQueue(clusterQueue.Name).
-				CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create local queue")
-			DeferCleanup(cleanupLQ)
+			_, namespace := testutils.SetupTestEnv(ctx, kubeClient, clients.UpstreamKueueClient,
+				"afs-sampling-", afsSamplingLQName,
+				func(cq *testutils.ClusterQueueWrapper) {
+					cq.WithCPU("1").WithMemory("200Mi").
+						WithAdmissionScope(kueuev1beta2.UsageBasedAdmissionFairSharing)
+				})
 
 			By("Creating a long-running job to generate usage")
-			job, err := kubeClient.BatchV1().Jobs(namespace.Name).Create(ctx, newLongRunningJob("job-sampling", namespace.Name, lq.Name, "500m", "50Mi"), metav1.CreateOptions{})
+			job, err := kubeClient.BatchV1().Jobs(namespace.Name).Create(ctx, newLongRunningJob("job-sampling", namespace.Name, afsSamplingLQName, "500m", "50Mi"), metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred(), "Failed to create job")
 
 			By("Verifying job workload is admitted")
@@ -242,7 +210,7 @@ var _ = Describe("Admission Fair Sharing", Label("admission-fair-sharing"), Orde
 			By("Waiting for initial lastUpdate to appear on LocalQueue status")
 			var firstUpdate metav1.Time
 			Eventually(func() bool {
-				lqStatus, err := clients.UpstreamKueueClient.KueueV1beta2().LocalQueues(namespace.Name).Get(ctx, lq.Name, metav1.GetOptions{})
+				lqStatus, err := clients.UpstreamKueueClient.KueueV1beta2().LocalQueues(namespace.Name).Get(ctx, afsSamplingLQName, metav1.GetOptions{})
 				if err != nil || lqStatus.Status.FairSharing == nil || lqStatus.Status.FairSharing.AdmissionFairSharingStatus == nil {
 					return false
 				}
@@ -259,7 +227,7 @@ var _ = Describe("Admission Fair Sharing", Label("admission-fair-sharing"), Orde
 				previousUpdate := timestamps[len(timestamps)-1]
 				var nextUpdate metav1.Time
 				Eventually(func(g Gomega) {
-					lqStatus, err := clients.UpstreamKueueClient.KueueV1beta2().LocalQueues(namespace.Name).Get(ctx, lq.Name, metav1.GetOptions{})
+					lqStatus, err := clients.UpstreamKueueClient.KueueV1beta2().LocalQueues(namespace.Name).Get(ctx, afsSamplingLQName, metav1.GetOptions{})
 					g.Expect(err).NotTo(HaveOccurred(), "Failed to get LocalQueue status")
 					g.Expect(lqStatus.Status.FairSharing).NotTo(BeNil(), "FairSharing status should not be nil")
 					g.Expect(lqStatus.Status.FairSharing.AdmissionFairSharingStatus).NotTo(BeNil(), "AdmissionFairSharingStatus should not be nil")
@@ -836,34 +804,13 @@ func enableAdmissionFairSharing(ctx context.Context, afs ssv1.AdmissionFairShari
 }
 
 func newLongRunningJob(name, namespace, queueName, cpu, memory string) *batchv1.Job {
-	return &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels: map[string]string{
-				testutils.QueueLabel: queueName,
-			},
-		},
-		Spec: batchv1.JobSpec{
-			Suspend: ptr.To(true),
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyNever,
-					Containers: []corev1.Container{
-						{
-							Name:    "worker",
-							Image:   testutils.GetContainerImageForWorkloads(),
-							Command: []string{"sh", "-c", "sleep infinity"},
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse(cpu),
-									corev1.ResourceMemory: resource.MustParse(memory),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	builder := testutils.NewTestResourceBuilder(namespace, queueName)
+	job := builder.NewJob()
+	job.Name = name
+	job.Labels[testutils.QueueLabel] = queueName
+	job.Spec.Suspend = ptr.To(true)
+	job.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "sleep infinity"}
+	job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse(cpu)
+	job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory] = resource.MustParse(memory)
+	return job
 }

--- a/test/e2e/e2e_dra_extended_resources_test.go
+++ b/test/e2e/e2e_dra_extended_resources_test.go
@@ -54,18 +54,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 	})
 
 	BeforeAll(func(ctx context.Context) {
-		// Check if DRA APIs are available
-		draSupported := false
-		apiResourceLists, err := kubeClient.Discovery().ServerResourcesForGroupVersion("resource.k8s.io/v1")
-		if err == nil {
-			for _, apiResource := range apiResourceLists.APIResources {
-				if apiResource.Kind == testutils.DeviceClassKind {
-					draSupported = true
-					break
-				}
-			}
-		}
-		if !draSupported {
+		if !testutils.IsDRASupported(kubeClient) {
 			Skip("DRA APIs (resource.k8s.io/v1) not available on this cluster")
 		}
 
@@ -187,14 +176,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 		By("Creating Job with extended resource request nvidia.com/gpu")
 		builder := testutils.NewTestResourceBuilder(ns.Name, erLocalQueueName)
-		job := builder.NewJob()
-		setDRAJobCPU(job)
-		job.Name = "er-basic-job"
-		job.Labels[testutils.QueueLabel] = erLocalQueueName
-		job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
-		job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-			corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
-		}
+		job := builder.NewDRAExtendedResourceJob("er-basic-job", erLocalQueueName, extendedResourceName, 1)
 		createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
@@ -288,15 +270,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 		By(fmt.Sprintf("Creating Job requesting %d GPUs via extended resources (quota is %d)", maxGPUsPerNode+1, maxGPUsPerNode))
 		builder := testutils.NewTestResourceBuilder(ns.Name, erLocalQueueName)
-		job := builder.NewJob()
-		setDRAJobCPU(job)
-		job.Name = "er-exceed-job"
-		job.Labels[testutils.QueueLabel] = erLocalQueueName
-		exceededCount := *resource.NewQuantity(int64(maxGPUsPerNode+1), resource.DecimalSI)
-		job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = exceededCount
-		job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-			corev1.ResourceName(extendedResourceName): exceededCount,
-		}
+		job := builder.NewDRAExtendedResourceJob("er-exceed-job", erLocalQueueName, extendedResourceName, maxGPUsPerNode+1)
 		createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
@@ -345,15 +319,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 		By(fmt.Sprintf("Creating first job requesting all %d GPUs via extended resources (fills quota)", maxGPUsPerNode))
 		builder := testutils.NewTestResourceBuilder(ns.Name, erLocalQueueName)
-		job1 := builder.NewJob()
-		setDRAJobCPU(job1)
-		job1.Name = "er-fill-job-1"
-		job1.Labels[testutils.QueueLabel] = erLocalQueueName
-		fillCount := *resource.NewQuantity(int64(maxGPUsPerNode), resource.DecimalSI)
-		job1.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = fillCount
-		job1.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-			corev1.ResourceName(extendedResourceName): fillCount,
-		}
+		job1 := builder.NewDRAExtendedResourceJob("er-fill-job-1", erLocalQueueName, extendedResourceName, maxGPUsPerNode)
 		createdJob1, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job1, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		defer testutils.CleanUpJob(ctx, kubeClient, createdJob1.Namespace, createdJob1.Name)
@@ -371,14 +337,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 		By("Creating second job requesting 1 GPU via extended resources (quota full, should be suspended)")
-		job2 := builder.NewJob()
-		setDRAJobCPU(job2)
-		job2.Name = "er-fill-job-2"
-		job2.Labels[testutils.QueueLabel] = erLocalQueueName
-		job2.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
-		job2.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-			corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
-		}
+		job2 := builder.NewDRAExtendedResourceJob("er-fill-job-2", erLocalQueueName, extendedResourceName, 1)
 		createdJob2, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job2, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		defer testutils.CleanUpJob(ctx, kubeClient, createdJob2.Namespace, createdJob2.Name)
@@ -442,14 +401,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 		By("Creating Job with 1 GPU via extended resource request")
 		builder := testutils.NewTestResourceBuilder(ns.Name, erLocalQueueName)
-		job := builder.NewJob()
-		setDRAJobCPU(job)
-		job.Name = "er-usage-job"
-		job.Labels[testutils.QueueLabel] = erLocalQueueName
-		job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
-		job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-			corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
-		}
+		job := builder.NewDRAExtendedResourceJob("er-usage-job", erLocalQueueName, extendedResourceName, 1)
 		createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
@@ -723,16 +675,9 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 			By("Submitting low-priority ER job that fills the 1-GPU quota")
 			builder := testutils.NewTestResourceBuilder(ns.Name, preemptLQ.Name)
-			lowJob := builder.NewJob()
-			setDRAJobCPU(lowJob)
-			lowJob.Name = "er-low-prio"
-			lowJob.Labels[testutils.QueueLabel] = preemptLQ.Name
+			lowJob := builder.NewDRAExtendedResourceJob("er-low-prio", preemptLQ.Name, extendedResourceName, 1)
 			lowJob.Spec.Template.Spec.PriorityClassName = lowPC.Name
 			lowJob.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "sleep 60"}
-			lowJob.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
-			lowJob.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-				corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
-			}
 			createdLowJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, lowJob, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			defer testutils.CleanUpJob(ctx, kubeClient, createdLowJob.Namespace, createdLowJob.Name)
@@ -777,16 +722,9 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Submitting high-priority ER job that triggers preemption")
-			highJob := builder.NewJob()
-			setDRAJobCPU(highJob)
-			highJob.Name = "er-high-prio"
-			highJob.Labels[testutils.QueueLabel] = preemptLQ.Name
+			highJob := builder.NewDRAExtendedResourceJob("er-high-prio", preemptLQ.Name, extendedResourceName, 1)
 			highJob.Spec.Template.Spec.PriorityClassName = highPC.Name
 			highJob.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "sleep 10"}
-			highJob.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
-			highJob.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-				corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
-			}
 			createdHighJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, highJob, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			defer testutils.CleanUpJob(ctx, kubeClient, createdHighJob.Namespace, createdHighJob.Name)
@@ -934,15 +872,8 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 			By("Submitting single-pod ER job that fills 1 of 2 GPUs")
 			builder := testutils.NewTestResourceBuilder(ns.Name, gangLQ.Name)
-			singleJob := builder.NewJob()
-			setDRAJobCPU(singleJob)
-			singleJob.Name = "er-single-gpu"
-			singleJob.Labels[testutils.QueueLabel] = gangLQ.Name
+			singleJob := builder.NewDRAExtendedResourceJob("er-single-gpu", gangLQ.Name, extendedResourceName, 1)
 			singleJob.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "sleep 60"}
-			singleJob.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
-			singleJob.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-				corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
-			}
 			createdSingleJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, singleJob, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			defer testutils.CleanUpJob(ctx, kubeClient, createdSingleJob.Namespace, createdSingleJob.Name)
@@ -955,17 +886,10 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Submitting gang ER job (parallelism=2, needs 2 GPUs, only 1 free)")
-			gangJob := builder.NewJob()
-			setDRAJobCPU(gangJob)
-			gangJob.Name = "er-gang-job"
-			gangJob.Labels[testutils.QueueLabel] = gangLQ.Name
+			gangJob := builder.NewDRAExtendedResourceJob("er-gang-job", gangLQ.Name, extendedResourceName, 1)
 			gangJob.Spec.Parallelism = ptr.To(int32(2))
 			gangJob.Spec.Completions = ptr.To(int32(2))
 			gangJob.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "sleep 60"}
-			gangJob.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
-			gangJob.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-				corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
-			}
 			createdGangJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, gangJob, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			defer testutils.CleanUpJob(ctx, kubeClient, createdGangJob.Namespace, createdGangJob.Name)
@@ -1100,15 +1024,8 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 			By("Submitting ER job requesting 1 GPU")
 			builder := testutils.NewTestResourceBuilder(ns.Name, erLocalQueueName)
-			job := builder.NewJob()
-			setDRAJobCPU(job)
-			job.Name = "er-cel-invalid-test"
-			job.Labels[testutils.QueueLabel] = erLocalQueueName
+			job := builder.NewDRAExtendedResourceJob("er-cel-invalid-test", erLocalQueueName, extendedResourceName, 1)
 			job.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "sleep 30"}
-			job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
-			job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-				corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
-			}
 			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
@@ -1373,15 +1290,8 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 			By("Submitting ER job requesting 1 GPU")
 			builder := testutils.NewTestResourceBuilder(ns.Name, erLocalQueueName)
-			job := builder.NewJob()
-			setDRAJobCPU(job)
-			job.Name = "er-no-mapping-test"
-			job.Labels[testutils.QueueLabel] = erLocalQueueName
+			job := builder.NewDRAExtendedResourceJob("er-no-mapping-test", erLocalQueueName, extendedResourceName, 1)
 			job.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "sleep 30"}
-			job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
-			job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-				corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
-			}
 			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			defer testutils.CleanUpJob(ctx, kubeClient, createdJob.Namespace, createdJob.Name)
@@ -1543,14 +1453,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 			By("Creating Job with extended resource request nvidia.com/gpu")
 			builder := testutils.NewTestResourceBuilder(ns.Name, erLocalQueueName)
-			job := builder.NewJob()
-			setDRAJobCPU(job)
-			job.Name = "er-no-deviceclass"
-			job.Labels[testutils.QueueLabel] = erLocalQueueName
-			job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
-			job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-				corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
-			}
+			job := builder.NewDRAExtendedResourceJob("er-no-deviceclass", erLocalQueueName, extendedResourceName, 1)
 			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func(cleanupCtx context.Context) {
@@ -1694,14 +1597,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 			By("Creating Job with extended resource request nvidia.com/gpu")
 			builder := testutils.NewTestResourceBuilder(ns.Name, erLocalQueueName)
-			job := builder.NewJob()
-			setDRAJobCPU(job)
-			job.Name = "er-late-deviceclass"
-			job.Labels[testutils.QueueLabel] = erLocalQueueName
-			job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
-			job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-				corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
-			}
+			job := builder.NewDRAExtendedResourceJob("er-late-deviceclass", erLocalQueueName, extendedResourceName, 1)
 			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func(cleanupCtx context.Context) {
@@ -1855,14 +1751,7 @@ var _ = Describe("DRA Extended Resources", Label("operator", "dra", "dra-extende
 
 			By("Creating Job with both extended resource request and ResourceClaimTemplate")
 			builder := testutils.NewTestResourceBuilder(ns.Name, "er-mixed-queue")
-			job := builder.NewJob()
-			setDRAJobCPU(job)
-			job.Name = "er-mixed-job"
-			job.Labels[testutils.QueueLabel] = "er-mixed-queue"
-			job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] = resource.MustParse("1")
-			job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-				corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
-			}
+			job := builder.NewDRAExtendedResourceJob("er-mixed-job", "er-mixed-queue", extendedResourceName, 1)
 			job.Spec.Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
 				{Name: gpuDeviceType, ResourceClaimTemplateName: ptr.To("gpu-template-mixed")},
 			}

--- a/test/e2e/e2e_dra_test.go
+++ b/test/e2e/e2e_dra_test.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/gomega"
 	ssv1 "github.com/openshift/kueue-operator/pkg/apis/kueueoperator/v1"
 	"github.com/openshift/kueue-operator/test/e2e/testutils"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -45,12 +44,6 @@ const (
 	draLocalQueueName      = "dra-test-queue"
 )
 
-// setDRAJobCPU reduces CPU request for DRA test jobs to fit on GPU nodes
-// where NVIDIA operator daemonsets consume most of the CPU budget.
-func setDRAJobCPU(job *batchv1.Job) {
-	job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("100m")
-}
-
 var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered, func() {
 	var (
 		gpuCount             int
@@ -62,18 +55,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 	})
 
 	BeforeAll(func(ctx context.Context) {
-		// Check if DRA APIs are available
-		draSupported := false
-		apiResourceLists, err := kubeClient.Discovery().ServerResourcesForGroupVersion("resource.k8s.io/v1")
-		if err == nil {
-			for _, apiResource := range apiResourceLists.APIResources {
-				if apiResource.Kind == testutils.DeviceClassKind {
-					draSupported = true
-					break
-				}
-			}
-		}
-		if !draSupported {
+		if !testutils.IsDRASupported(kubeClient) {
 			Skip("DRA APIs (resource.k8s.io/v1) not available on this cluster")
 		}
 
@@ -165,44 +147,21 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 	When("basic DRA quota is configured", func() {
 		It("should admit job with ResourceClaimTemplate and account DRA quota correctly", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
 			kueueClient := clients.UpstreamKueueClient
-
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
+			_, ns := testutils.SetupTestEnv(ctx, kubeClient, clients.UpstreamKueueClient,
+				draTestNamespacePrefix, draLocalQueueName,
+				func(cq *testutils.ClusterQueueWrapper) {
+					cq.WithDRAResource(draLogicalResource, "1")
+				})
 
 			By("Creating ResourceClaimTemplate for gpu.nvidia.com")
-			rct := newDRAResourceClaimTemplate("gpu-template-basic", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewResourceClaimTemplate("gpu-template-basic", ns.Name, draDeviceClassName, 1, "")
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating Job referencing ResourceClaimTemplate")
 			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
-			job := newDRAJob(builder, "dra-basic-job", "gpu-template-basic", draLocalQueueName)
+			job := builder.NewDRAJob("dra-basic-job", draLocalQueueName, "gpu-template-basic")
 			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
@@ -236,44 +195,20 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 		})
 
 		It("should suspend job when DRA quota is exceeded", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
-			kueueClient := clients.UpstreamKueueClient
-
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
+			_, ns := testutils.SetupTestEnv(ctx, kubeClient, clients.UpstreamKueueClient,
+				draTestNamespacePrefix, draLocalQueueName,
+				func(cq *testutils.ClusterQueueWrapper) {
+					cq.WithDRAResource(draLogicalResource, "1")
+				})
 
 			By("Creating ResourceClaimTemplate requesting more GPUs than quota allows")
-			rct := newDRAResourceClaimTemplate("gpu-template-exceed", ns.Name, 5) // quota is 1
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewResourceClaimTemplate("gpu-template-exceed", ns.Name, draDeviceClassName, 5, "") // quota is 1
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating Job that exceeds DRA quota")
 			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
-			job := newDRAJob(builder, "dra-exceed-job", "gpu-template-exceed", draLocalQueueName)
+			job := builder.NewDRAJob("dra-exceed-job", draLocalQueueName, "gpu-template-exceed")
 			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
@@ -285,44 +220,21 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 		})
 
 		It("should admit waiting job after DRA quota is freed", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
 			kueueClient := clients.UpstreamKueueClient
-
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
+			cq, ns := testutils.SetupTestEnv(ctx, kubeClient, kueueClient,
+				draTestNamespacePrefix, draLocalQueueName,
+				func(cq *testutils.ClusterQueueWrapper) {
+					cq.WithDRAResource(draLogicalResource, "1")
+				})
 
 			By("Creating shared ResourceClaimTemplate requesting 1 GPU")
-			rct := newDRAResourceClaimTemplate("gpu-template-shared", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewResourceClaimTemplate("gpu-template-shared", ns.Name, draDeviceClassName, 1, "")
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating first job referencing shared template (fills 1/1 quota)")
 			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
-			job1 := newDRAJob(builder, "dra-fill-job-1", "gpu-template-shared", draLocalQueueName)
+			job1 := builder.NewDRAJob("dra-fill-job-1", draLocalQueueName, "gpu-template-shared")
 			createdJob1, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job1, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob1.Namespace, createdJob1.Name)
@@ -354,7 +266,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Creating second job referencing same shared template (quota full, should be suspended)")
-			job2 := newDRAJob(builder, "dra-fill-job-2", "gpu-template-shared", draLocalQueueName)
+			job2 := builder.NewDRAJob("dra-fill-job-2", draLocalQueueName, "gpu-template-shared")
 			createdJob2, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job2, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob2.Namespace, createdJob2.Name)
@@ -379,44 +291,21 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 		})
 
 		It("should verify ClusterQueue shows correct DRA resource usage", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
 			kueueClient := clients.UpstreamKueueClient
-
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
+			cq, ns := testutils.SetupTestEnv(ctx, kubeClient, kueueClient,
+				draTestNamespacePrefix, draLocalQueueName,
+				func(cq *testutils.ClusterQueueWrapper) {
+					cq.WithDRAResource(draLogicalResource, "1")
+				})
 
 			By("Creating ResourceClaimTemplate for 1 GPU")
-			rct := newDRAResourceClaimTemplate("gpu-template-usage", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewResourceClaimTemplate("gpu-template-usage", ns.Name, draDeviceClassName, 1, "")
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating Job")
 			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
-			job := newDRAJob(builder, "dra-usage-job", "gpu-template-usage", draLocalQueueName)
+			job := builder.NewDRAJob("dra-usage-job", draLocalQueueName, "gpu-template-usage")
 			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
@@ -449,44 +338,21 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 	When("two containers share a single GPU", func() {
 		It("should admit job with two containers sharing a single GPU", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
 			kueueClient := clients.UpstreamKueueClient
-
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
+			_, ns := testutils.SetupTestEnv(ctx, kubeClient, kueueClient,
+				draTestNamespacePrefix, draLocalQueueName,
+				func(cq *testutils.ClusterQueueWrapper) {
+					cq.WithDRAResource(draLogicalResource, "1")
+				})
 
 			By("Creating ResourceClaimTemplate for a single GPU")
-			rct := newDRAResourceClaimTemplate("gpu-template-shared-ctr", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewResourceClaimTemplate("gpu-template-shared-ctr", ns.Name, draDeviceClassName, 1, "")
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating Job with two containers sharing the same GPU claim")
 			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
-			job := newDRAJob(builder, "dra-shared-gpu-job", "gpu-template-shared-ctr", draLocalQueueName)
+			job := builder.NewDRAJob("dra-shared-gpu-job", draLocalQueueName, "gpu-template-shared-ctr")
 			job.Spec.Template.Spec.Containers = append(job.Spec.Template.Spec.Containers, corev1.Container{
 				Name:    "ctr1",
 				Image:   testutils.GetContainerImageForWorkloads(),
@@ -542,39 +408,16 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 	When("different workload types use DRA resources", func() {
 		It("should admit DRA workloads for Pod type", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
 			kueueClient := clients.UpstreamKueueClient
-
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
+			_, ns := testutils.SetupTestEnv(ctx, kubeClient, kueueClient,
+				draTestNamespacePrefix, draLocalQueueName,
+				func(cq *testutils.ClusterQueueWrapper) {
+					cq.WithDRAResource(draLogicalResource, "1")
+				})
 
 			By("Creating ResourceClaimTemplate requesting 1 GPU")
-			rct := newDRAResourceClaimTemplate("gpu-template-workload-types", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewResourceClaimTemplate("gpu-template-workload-types", ns.Name, draDeviceClassName, 1, "")
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
@@ -599,39 +442,16 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 		})
 
 		It("should admit DRA workloads for Deployment type", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
 			kueueClient := clients.UpstreamKueueClient
-
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
+			_, ns := testutils.SetupTestEnv(ctx, kubeClient, kueueClient,
+				draTestNamespacePrefix, draLocalQueueName,
+				func(cq *testutils.ClusterQueueWrapper) {
+					cq.WithDRAResource(draLogicalResource, "1")
+				})
 
 			By("Creating ResourceClaimTemplate requesting 1 GPU")
-			rct := newDRAResourceClaimTemplate("gpu-template-workload-types", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewResourceClaimTemplate("gpu-template-workload-types", ns.Name, draDeviceClassName, 1, "")
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
@@ -657,39 +477,16 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 		})
 
 		It("should admit DRA workloads for StatefulSet type", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
 			kueueClient := clients.UpstreamKueueClient
-
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
+			_, ns := testutils.SetupTestEnv(ctx, kubeClient, kueueClient,
+				draTestNamespacePrefix, draLocalQueueName,
+				func(cq *testutils.ClusterQueueWrapper) {
+					cq.WithDRAResource(draLogicalResource, "1")
+				})
 
 			By("Creating ResourceClaimTemplate requesting 1 GPU")
-			rct := newDRAResourceClaimTemplate("gpu-template-workload-types", ns.Name, 1)
-			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
+			rct := testutils.NewResourceClaimTemplate("gpu-template-workload-types", ns.Name, draDeviceClassName, 1, "")
+			_, err := kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
@@ -718,35 +515,11 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 	When("deviceClassMappings are misconfigured", func() {
 		It("should not admit DRA workloads when deviceClassMappings point to wrong DeviceClass", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
-			kueueClient := clients.UpstreamKueueClient
-
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			cq, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithDRAResource(draLogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
-
-			lq := testutils.NewLocalQueue(ns.Name, draLocalQueueName).WithClusterQueue(cq.Name)
-			_, cleanupLQ, err := lq.CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
+			_, ns := testutils.SetupTestEnv(ctx, kubeClient, clients.UpstreamKueueClient,
+				draTestNamespacePrefix, draLocalQueueName,
+				func(cq *testutils.ClusterQueueWrapper) {
+					cq.WithDRAResource(draLogicalResource, "1")
+				})
 
 			By("Saving current Kueue config before modifying deviceClassMappings")
 			kueueInstance, err := clients.KueueClient.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
@@ -774,14 +547,14 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed())
 
 			By("Creating ResourceClaimTemplate for DRA job")
-			rct := newDRAResourceClaimTemplate("gpu-template-wrong-class", ns.Name, 1)
+			rct := testutils.NewResourceClaimTemplate("gpu-template-wrong-class", ns.Name, draDeviceClassName, 1, "")
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating DRA job with wrong DeviceClass mapping")
 			wrongClassStart := metav1.Now()
 			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
-			job := newDRAJob(builder, "dra-wrong-class", "gpu-template-wrong-class", draLocalQueueName)
+			job := builder.NewDRAJob("dra-wrong-class", draLocalQueueName, "gpu-template-wrong-class")
 			createdJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, job, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJob.Namespace, createdJob.Name)
@@ -798,22 +571,12 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 	When("preemption is enabled", func() {
 		It("should preempt low-priority DRA workload when high-priority DRA workload is submitted", func(ctx context.Context) {
-			By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
-			kueueClient := clients.UpstreamKueueClient
-
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupResourceFlavor)
-
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: draTestNamespacePrefix,
-					Labels:       map[string]string{testutils.OpenShiftManagedLabel: "true"},
-				},
-			}
-			cleanupNs, err := testutils.CreateNamespace(kubeClient, ns)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupNs)
+			_, ns := testutils.SetupTestEnv(ctx, kubeClient, clients.UpstreamKueueClient,
+				draTestNamespacePrefix, draLocalQueueName,
+				func(cq *testutils.ClusterQueueWrapper) {
+					cq.WithPreemption(kueuev1beta2.PreemptionPolicyLowerPriority).
+						WithDRAResource(draLogicalResource, "1")
+				})
 
 			By("Creating PriorityClasses")
 			lowPC, cleanupLowPC, err := createPriorityClass(ctx, 100, "Low priority for DRA preemption")
@@ -823,29 +586,14 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanupHighPC)
 
-			By("Creating ClusterQueue with preemption enabled and DRA quota")
-			preemptCQ, cleanupCQ, err := testutils.NewClusterQueue().
-				WithGenerateName().
-				WithFlavorName(resourceFlavor.Name).
-				WithPreemption(kueuev1beta2.PreemptionPolicyLowerPriority).
-				WithDRAResource(draLogicalResource, "1").
-				CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupCQ)
-
-			By("Creating LocalQueue for preemption test")
-			preemptLQ, cleanupLQ, err := testutils.NewLocalQueue(ns.Name, "").WithGenerateName().WithClusterQueue(preemptCQ.Name).CreateWithObject(ctx, kueueClient)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanupLQ)
-
 			By("Creating ResourceClaimTemplate")
-			rct := newDRAResourceClaimTemplate("gpu-template-preempt", ns.Name, 1)
+			rct := testutils.NewResourceClaimTemplate("gpu-template-preempt", ns.Name, draDeviceClassName, 1, "")
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Submitting low-priority DRA job that fills the 1-GPU quota")
-			builder := testutils.NewTestResourceBuilder(ns.Name, preemptLQ.Name)
-			lowJob := newDRAJob(builder, "dra-low-prio", "gpu-template-preempt", preemptLQ.Name)
+			builder := testutils.NewTestResourceBuilder(ns.Name, draLocalQueueName)
+			lowJob := builder.NewDRAJob("dra-low-prio", draLocalQueueName, "gpu-template-preempt")
 			lowJob.Spec.Template.Spec.PriorityClassName = lowPC.Name
 			createdLowJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, lowJob, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
@@ -860,7 +608,8 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Submitting high-priority DRA job that triggers preemption")
-			highJob := newDRAJob(builder, "dra-high-prio", "gpu-template-preempt", preemptLQ.Name)
+			highJob := builder.NewDRAJob("dra-high-prio", draLocalQueueName, "gpu-template-preempt")
+			highJob.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "sleep 10"}
 			highJob.Spec.Template.Spec.PriorityClassName = highPC.Name
 			createdHighJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, highJob, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
@@ -934,13 +683,13 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			DeferCleanup(cleanupLQ)
 
 			By("Creating ResourceClaimTemplate")
-			rct := newDRAResourceClaimTemplate("gpu-template-gang", ns.Name, 1)
+			rct := testutils.NewResourceClaimTemplate("gpu-template-gang", ns.Name, draDeviceClassName, 1, "")
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Submitting single-pod DRA job that fills 1 of 2 GPUs")
 			builder := testutils.NewTestResourceBuilder(ns.Name, gangLQ.Name)
-			singleJob := newDRAJob(builder, "dra-single-gpu", "gpu-template-gang", gangLQ.Name)
+			singleJob := builder.NewDRAJob("dra-single-gpu", gangLQ.Name, "gpu-template-gang")
 			createdSingleJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, singleJob, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdSingleJob.Namespace, createdSingleJob.Name)
@@ -952,7 +701,8 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(BeTrue())
 
 			By("Submitting gang DRA job (parallelism=2, needs 2 GPUs, only 1 free)")
-			gangJob := newDRAJob(builder, "dra-gang-job", "gpu-template-gang", gangLQ.Name)
+			gangJob := builder.NewDRAJob("dra-gang-job", gangLQ.Name, "gpu-template-gang")
+			gangJob.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "sleep 10"}
 			gangJob.Spec.Parallelism = ptr.To(int32(2))
 			gangJob.Spec.Completions = ptr.To(int32(2))
 			createdGangJob, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, gangJob, metav1.CreateOptions{})
@@ -1047,18 +797,20 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			DeferCleanup(cleanupLQCPU)
 
 			By("Creating ResourceClaimTemplate for 1 GPU")
-			rct := newDRAResourceClaimTemplate("gpu-template-afs", ns.Name, 1)
+			rct := testutils.NewResourceClaimTemplate("gpu-template-afs", ns.Name, draDeviceClassName, 1, "")
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Submitting GPU+CPU DRA jobs to lq-gpu")
 			builder := testutils.NewTestResourceBuilder(ns.Name, lqGPU.Name)
-			jobGPU1 := newDRAJob(builder, "job-gpu-afs-1", "gpu-template-afs", lqGPU.Name)
+			jobGPU1 := builder.NewDRAJob("job-gpu-afs-1", lqGPU.Name, "gpu-template-afs")
+			jobGPU1.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "sleep 10"}
 			createdJobGPU1, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, jobGPU1, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJobGPU1.Namespace, createdJobGPU1.Name)
 
-			jobGPU2 := newDRAJob(builder, "job-gpu-afs-2", "gpu-template-afs", lqGPU.Name)
+			jobGPU2 := builder.NewDRAJob("job-gpu-afs-2", lqGPU.Name, "gpu-template-afs")
+			jobGPU2.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "sleep 10"}
 			createdJobGPU2, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, jobGPU2, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJobGPU2.Namespace, createdJobGPU2.Name)
@@ -1066,7 +818,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			By("Submitting CPU-only job to lq-cpu")
 			cpuBuilder := testutils.NewTestResourceBuilder(ns.Name, lqCPU.Name)
 			jobCPU := cpuBuilder.NewJob()
-			setDRAJobCPU(jobCPU)
+			jobCPU.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("100m")
 			jobCPU.Name = "job-cpu-afs"
 			jobCPU.Labels[testutils.QueueLabel] = lqCPU.Name
 			jobCPU.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "echo Hello Kueue; sleep 10"}
@@ -1165,18 +917,20 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			DeferCleanup(cleanupLQCPU)
 
 			By("Creating ResourceClaimTemplate for 1 GPU")
-			rct := newDRAResourceClaimTemplate("gpu-template-afs-order", ns.Name, 1)
+			rct := testutils.NewResourceClaimTemplate("gpu-template-afs-order", ns.Name, draDeviceClassName, 1, "")
 			_, err = kubeClient.ResourceV1().ResourceClaimTemplates(ns.Name).Create(ctx, rct, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Submitting GPU+CPU DRA jobs to lq-gpu to build usage history")
 			builder := testutils.NewTestResourceBuilder(ns.Name, lqGPU.Name)
-			jobGPU1 := newDRAJob(builder, "job-gpu-order-1", "gpu-template-afs-order", lqGPU.Name)
+			jobGPU1 := builder.NewDRAJob("job-gpu-order-1", lqGPU.Name, "gpu-template-afs-order")
+			jobGPU1.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "sleep 10"}
 			createdJobGPU1, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, jobGPU1, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJobGPU1.Namespace, createdJobGPU1.Name)
 
-			jobGPU2 := newDRAJob(builder, "job-gpu-order-2", "gpu-template-afs-order", lqGPU.Name)
+			jobGPU2 := builder.NewDRAJob("job-gpu-order-2", lqGPU.Name, "gpu-template-afs-order")
+			jobGPU2.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "sleep 10"}
 			createdJobGPU2, err := kubeClient.BatchV1().Jobs(ns.Name).Create(ctx, jobGPU2, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(testutils.CleanUpJob, kubeClient, createdJobGPU2.Namespace, createdJobGPU2.Name)
@@ -1184,7 +938,7 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 			By("Submitting CPU-only job to lq-cpu to build usage history")
 			cpuBuilder := testutils.NewTestResourceBuilder(ns.Name, lqCPU.Name)
 			jobCPU := cpuBuilder.NewJob()
-			setDRAJobCPU(jobCPU)
+			jobCPU.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("100m")
 			jobCPU.Name = "job-cpu-order"
 			jobCPU.Labels[testutils.QueueLabel] = lqCPU.Name
 			jobCPU.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "echo Hello Kueue; sleep 10"}
@@ -1319,32 +1073,6 @@ var _ = Describe("DRA Structured Parameters", Label("operator", "dra"), Ordered,
 
 })
 
-// newDRAResourceClaimTemplate creates a ResourceClaimTemplate that requests the given number of GPUs
-// from the gpu.nvidia.com DeviceClass.
-func newDRAResourceClaimTemplate(name, namespace string, gpuCount int64) *resourcev1.ResourceClaimTemplate {
-	return &resourcev1.ResourceClaimTemplate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: resourcev1.ResourceClaimTemplateSpec{
-			Spec: resourcev1.ResourceClaimSpec{
-				Devices: resourcev1.DeviceClaim{
-					Requests: []resourcev1.DeviceRequest{
-						{
-							Name: "gpu-req",
-							Exactly: &resourcev1.ExactDeviceRequest{
-								DeviceClassName: draDeviceClassName,
-								Count:           gpuCount,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
 // waitForPodWorkloadAdmitted waits until a pod matching the label selector has
 // a corresponding admitted Kueue workload, correlating via OwnerReferences.
 func waitForPodWorkloadAdmitted(ctx context.Context, kubeClient *kubernetes.Clientset, kueueClient *upstreamkueueclient.Clientset, namespace, labelSelector string) {
@@ -1410,20 +1138,6 @@ func verifyNoResourceClaims(ctx context.Context, kubeClient *kubernetes.Clientse
 		}
 		g.Expect(filtered).To(BeEmpty(), "expected no ResourceClaims after %v in namespace %s", createdAfter.Time, namespace)
 	}, testutils.ConsistentlyLongTimeout, testutils.ConsistentlyLongPoll).Should(Succeed())
-}
-
-// newDRAJob creates a Job with DRA ResourceClaim configuration for the given template.
-func newDRAJob(builder *testutils.TestResourceBuilder, name, templateName, queueName string) *batchv1.Job {
-	job := builder.NewJob()
-	setDRAJobCPU(job)
-	job.Name = name
-	job.Labels[testutils.QueueLabel] = queueName
-	job.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "echo Hello Kueue; sleep 10"}
-	job.Spec.Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
-		{Name: "gpu", ResourceClaimTemplateName: ptr.To(templateName)},
-	}
-	job.Spec.Template.Spec.Containers[0].Resources.Claims = []corev1.ResourceClaim{{Name: "gpu"}}
-	return job
 }
 
 // restoreKueueConfig restores a Kueue CR config with retry on resourceVersion conflicts.

--- a/test/e2e/e2e_gangscheduling_test.go
+++ b/test/e2e/e2e_gangscheduling_test.go
@@ -36,8 +36,7 @@ import (
 var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 	var (
 		initialKueueInstance *ssv1.Kueue
-		labelKey             = testutils.OpenShiftManagedLabel
-		labelValue           = trueLabelValue
+		gangLocalQueueName   = "local-queue"
 	)
 
 	When("Policy is ByWorkload and Admission is Sequential", func() {
@@ -79,36 +78,14 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 		})
 
 		It("should apply all-or-nothing admission for workloads", func(ctx context.Context) {
-			By("Creating Cluster Resources")
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create resource flavor")
-			DeferCleanup(cleanupResourceFlavor)
-			clusterQueue, cleanupClusterQueue, err := testutils.NewClusterQueue().
-				WithGenerateName().WithCPU("500m").WithMemory("512Mi").
-				WithFlavorName(resourceFlavor.Name).
-				CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create cluster queue")
-			DeferCleanup(cleanupClusterQueue)
-
-			By("Creating Namespaces and LocalQueues")
-			namespace, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "gangscheduling-",
-					Labels: map[string]string{
-						labelKey: labelValue,
-					},
-				},
-			}, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespace)
-			})
-			localQueue, cleanupLocalQueue, err := testutils.NewLocalQueue(namespace.Name, "local-queue").WithClusterQueue(clusterQueue.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create local queue")
-			DeferCleanup(cleanupLocalQueue)
+			_, namespace := testutils.SetupTestEnv(ctx, kubeClient, clients.UpstreamKueueClient,
+				"gangscheduling-", gangLocalQueueName,
+				func(cq *testutils.ClusterQueueWrapper) {
+					cq.WithCPU("500m").WithMemory("512Mi")
+				})
 
 			By("Admitting a Job that consumes partial quota")
-			cleanupJob1, job1, err := createJobGang(ctx, "job-1", namespace.Name, localQueue.Name, "250m", "128Mi", 1)
+			cleanupJob1, job1, err := createJobGang(ctx, "job-1", namespace.Name, gangLocalQueueName, "250m", "128Mi", 1)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create first job")
 			DeferCleanup(cleanupJob1)
 
@@ -116,7 +93,7 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 			verifyWorkloadCreated(clients.UpstreamKueueClient, namespace.Name, string(job1.UID))
 
 			By("Creating a gang job (parallelism=2) that exceeds remaining quota")
-			cleanupJob2, job2, err := createJobGang(ctx, "job-gang", namespace.Name, localQueue.Name, "150m", "128Mi", 2)
+			cleanupJob2, job2, err := createJobGang(ctx, "job-gang", namespace.Name, gangLocalQueueName, "150m", "128Mi", 2)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create gang job")
 			DeferCleanup(cleanupJob2)
 
@@ -155,39 +132,14 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 		})
 
 		It("should admit workloads sequentially even when quota is available", func(ctx context.Context) {
-
-			By("Creating Cluster Resources with enough quota for multiple jobs")
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create resource flavor")
-			DeferCleanup(cleanupResourceFlavor)
-
-			clusterQueue, cleanupClusterQueue, err := testutils.NewClusterQueue().
-				WithGenerateName().WithCPU("500m").WithMemory("512Mi").
-				WithFlavorName(resourceFlavor.Name).
-				CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create cluster queue")
-			DeferCleanup(cleanupClusterQueue)
-
-			By("Creating Namespace and LocalQueue")
-			namespace, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "sequential-",
-					Labels: map[string]string{
-						labelKey: labelValue,
-					},
-				},
-			}, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespace)
-			})
-
-			localQueue, cleanupLocalQueue, err := testutils.NewLocalQueue(namespace.Name, "local-queue").WithClusterQueue(clusterQueue.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create local queue")
-			DeferCleanup(cleanupLocalQueue)
+			_, namespace := testutils.SetupTestEnv(ctx, kubeClient, clients.UpstreamKueueClient,
+				"sequential-", gangLocalQueueName,
+				func(cq *testutils.ClusterQueueWrapper) {
+					cq.WithCPU("500m").WithMemory("512Mi")
+				})
 
 			By("Creating the first gang job (parallelism=2) with delayed pod readiness")
-			cleanupJob1, createdJob1, err := createJobGang(ctx, "job-sequential-1", namespace.Name, localQueue.Name, "100m", "100Mi", 2)
+			cleanupJob1, createdJob1, err := createJobGang(ctx, "job-sequential-1", namespace.Name, gangLocalQueueName, "100m", "100Mi", 2)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create first gang job")
 			DeferCleanup(cleanupJob1)
 
@@ -195,7 +147,7 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 			verifyWorkloadCreated(clients.UpstreamKueueClient, namespace.Name, string(createdJob1.UID))
 
 			By("Creating the second gang job (parallelism=2) while first gang job pods are not yet ready")
-			cleanupJob2, createdJob2, err := createJobGang(ctx, "job-sequential-2", namespace.Name, localQueue.Name, "100m", "100Mi", 2)
+			cleanupJob2, createdJob2, err := createJobGang(ctx, "job-sequential-2", namespace.Name, gangLocalQueueName, "100m", "100Mi", 2)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create second gang job")
 			DeferCleanup(cleanupJob2)
 
@@ -271,38 +223,14 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 		})
 
 		It("should admit workloads in parallel without waiting for pods to be ready", func(ctx context.Context) {
-			By("Creating Cluster Resources with enough quota for multiple jobs")
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create resource flavor")
-			DeferCleanup(cleanupResourceFlavor)
-
-			clusterQueue, cleanupClusterQueue, err := testutils.NewClusterQueue().
-				WithGenerateName().WithCPU("500m").WithMemory("512Mi").
-				WithFlavorName(resourceFlavor.Name).
-				CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create cluster queue")
-			DeferCleanup(cleanupClusterQueue)
-
-			By("Creating Namespace and LocalQueue")
-			namespace, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "parallel-",
-					Labels: map[string]string{
-						labelKey: labelValue,
-					},
-				},
-			}, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespace)
-			})
-
-			localQueue, cleanupLocalQueue, err := testutils.NewLocalQueue(namespace.Name, "local-queue").WithClusterQueue(clusterQueue.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create local queue")
-			DeferCleanup(cleanupLocalQueue)
+			_, namespace := testutils.SetupTestEnv(ctx, kubeClient, clients.UpstreamKueueClient,
+				"parallel-", gangLocalQueueName,
+				func(cq *testutils.ClusterQueueWrapper) {
+					cq.WithCPU("500m").WithMemory("512Mi")
+				})
 
 			By("Creating the first gang job (parallelism=2) with delayed pod readiness")
-			cleanupJob1, createdJob1, err := createJobGang(ctx, "job-parallel-1", namespace.Name, localQueue.Name, "100m", "100Mi", 2)
+			cleanupJob1, createdJob1, err := createJobGang(ctx, "job-parallel-1", namespace.Name, gangLocalQueueName, "100m", "100Mi", 2)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create first gang job")
 			DeferCleanup(cleanupJob1)
 
@@ -310,7 +238,7 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 			verifyWorkloadCreated(clients.UpstreamKueueClient, namespace.Name, string(createdJob1.UID))
 
 			By("Creating the second gang job (parallelism=2) while first gang job pods are not yet ready")
-			cleanupJob2, createdJob2, err := createJobGang(ctx, "job-parallel-2", namespace.Name, localQueue.Name, "100m", "100Mi", 2)
+			cleanupJob2, createdJob2, err := createJobGang(ctx, "job-parallel-2", namespace.Name, gangLocalQueueName, "100m", "100Mi", 2)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create second gang job")
 			DeferCleanup(cleanupJob2)
 
@@ -337,50 +265,29 @@ var _ = Describe("Gangscheduling", Label("gangscheduling"), Ordered, func() {
 // Parallelism specifies how many pods should run in parallel (for gang scheduling tests).
 // CPU and memory specify the resource requests per pod.
 func createJobGang(ctx context.Context, name, namespace, queueName, cpu, memory string, parallelism int32) (func(context.Context), *batchv1.Job, error) {
-	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels: map[string]string{
-				testutils.QueueLabel: queueName,
-			},
-		},
-		Spec: batchv1.JobSpec{
-			Parallelism: ptr.To(parallelism),
-			Completions: ptr.To(parallelism),
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyNever,
-					InitContainers: []corev1.Container{
-						{
-							Name:    "delay-ready",
-							Image:   "quay.io/prometheus/busybox:latest",
-							Command: []string{"sh", "-c", "echo 'Delaying readiness...'; sleep 30"},
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("100m"),
-									corev1.ResourceMemory: resource.MustParse("64Mi"),
-								},
-							},
-						},
-					},
-					Containers: []corev1.Container{
-						{
-							Name:    "main",
-							Image:   "quay.io/prometheus/busybox:latest",
-							Command: []string{"sh", "-c", "echo 'Running main container'"},
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse(cpu),
-									corev1.ResourceMemory: resource.MustParse(memory),
-								},
-							},
-						},
-					},
+	builder := testutils.NewTestResourceBuilder(namespace, queueName)
+	job := builder.NewJob()
+	job.Name = name
+	job.Labels[testutils.QueueLabel] = queueName
+	job.Spec.Parallelism = ptr.To(parallelism)
+	job.Spec.Completions = ptr.To(parallelism)
+	job.Spec.Template.Spec.InitContainers = []corev1.Container{
+		{
+			Name:    "delay-ready",
+			Image:   "quay.io/prometheus/busybox:latest",
+			Command: []string{"sh", "-c", "echo 'Delaying readiness...'; sleep 30"},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("64Mi"),
 				},
 			},
 		},
 	}
+	job.Spec.Template.Spec.Containers[0].Image = "quay.io/prometheus/busybox:latest"
+	job.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "echo 'Running main container'"}
+	job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse(cpu)
+	job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory] = resource.MustParse(memory)
 
 	createdJob, err := kubeClient.BatchV1().Jobs(namespace).Create(ctx, job, metav1.CreateOptions{})
 	if err != nil {

--- a/test/e2e/e2e_visibility_on_demand_test.go
+++ b/test/e2e/e2e_visibility_on_demand_test.go
@@ -42,8 +42,9 @@ import (
 )
 
 const (
-	priorityName   = "kueue-visibility"
-	trueLabelValue = "true"
+	priorityName     = "kueue-visibility"
+	trueLabelValue   = "true"
+	visibilityLQName = "local-queue"
 )
 
 var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, func() {
@@ -577,38 +578,13 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 	})
 
 	When("PendingWorkloads Endpoints should be checked", func() {
-		labelKey := testutils.OpenShiftManagedLabel
-		labelValue := trueLabelValue
 
 		It("Should use the correct PriorityLevelConfiguration and FlowSchema for ClusterQueue and LocalQueue", func(ctx context.Context) {
 			// capturedHeaders stores HTTP response headers captured by headerCaptureRoundTripper during API calls.
 			var capturedHeaders = make(http.Header)
 
-			By("Creating Cluster Resources")
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create resource flavor")
-			DeferCleanup(cleanupResourceFlavor)
-			clusterQueue, cleanupClusterQueue, err := testutils.NewClusterQueue().WithGenerateName().WithFlavorName(resourceFlavor.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create cluster queue")
-			DeferCleanup(cleanupClusterQueue)
-
-			By("Creating Namespaces and LocalQueues")
-			namespace, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "namespace-",
-					Labels: map[string]string{
-						labelKey: labelValue,
-					},
-				},
-			}, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespace)
-			})
-
-			localQueue, cleanupLocalQueue, err := testutils.NewLocalQueue(namespace.Name, "local-queue").WithClusterQueue(clusterQueue.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create local queue")
-			DeferCleanup(cleanupLocalQueue)
+			clusterQueue, namespace := testutils.SetupTestEnv(ctx, kubeClient, clients.UpstreamKueueClient,
+				"namespace-", "local-queue")
 
 			By("Creating RBAC kueue-batch-admin-role for Visibility API")
 			cleanupClusterRoleBinding, err := createClusterRoleBinding(ctx, "default", namespace.Name, "kueue-batch-admin-role")
@@ -659,9 +635,9 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 
 			By("Getting the pending workloads for the LocalQueue API response")
 			Eventually(func() error {
-				_, err = testUserVisibilityClient.LocalQueues(namespace.Name).GetPendingWorkloadsSummary(ctx, localQueue.Name, metav1.GetOptions{})
+				_, err = testUserVisibilityClient.LocalQueues(namespace.Name).GetPendingWorkloadsSummary(ctx, visibilityLQName, metav1.GetOptions{})
 				return err
-			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "Failed to get pending workloads for LocalQueue %s", localQueue.Name)
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "Failed to get pending workloads for LocalQueue %s", visibilityLQName)
 
 			By("Extracting response headers from API call")
 			priorityLevelUIDHeaderLocalQueue := capturedHeaders.Get("X-Kubernetes-Pf-Prioritylevel-Uid")
@@ -1020,31 +996,12 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 		It("Should show on pending workloads list for local queue and cluster queue", func(ctx context.Context) {
 			var clusterPendingWorkloads *visibilityv1beta2.PendingWorkloadsSummary
 			var localPendingWorkloads *visibilityv1beta2.PendingWorkloadsSummary
-			By("Creating Cluster Resources")
-			resourceFlavor, cleanupResourceFlavor, err := testutils.NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create resource flavor")
-			DeferCleanup(cleanupResourceFlavor)
-			clusterQueue, cleanupClusterQueue, err := testutils.NewClusterQueue().WithGenerateName().WithCPU("40m").WithMemory("512Mi").WithFlavorName(resourceFlavor.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create cluster queue")
-			DeferCleanup(cleanupClusterQueue)
 
-			By("Creating Namespaces and LocalQueues")
-			namespace, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-namespace-",
-					Labels: map[string]string{
-						testutils.OpenShiftManagedLabel: trueLabelValue,
-					},
-				},
-			}, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(func(ctx context.Context) {
-				deleteNamespace(ctx, namespace)
-			})
-
-			localQueue, cleanupLocalQueue, err := testutils.NewLocalQueue(namespace.Name, "local-queue").WithClusterQueue(clusterQueue.Name).CreateWithObject(ctx, clients.UpstreamKueueClient)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create local queue")
-			DeferCleanup(cleanupLocalQueue)
+			clusterQueue, namespace := testutils.SetupTestEnv(ctx, kubeClient, clients.UpstreamKueueClient,
+				"test-namespace-", visibilityLQName,
+				func(cq *testutils.ClusterQueueWrapper) {
+					cq.WithCPU("40m").WithMemory("512Mi")
+				})
 
 			By("Creating RBAC kueue-batch-admin-role for Visibility API")
 			serviceAccountAdmin, err := createServiceAccount(ctx, namespace.Name)
@@ -1071,7 +1028,7 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			Expect(err).NotTo(HaveOccurred(), "Failed to create visibility client for system:serviceaccount:%s:%s", namespace.Name, serviceAccountUser.Name)
 
 			By("Creating custom jobset")
-			builder := testutils.NewTestResourceBuilder(namespace.Name, localQueue.Name)
+			builder := testutils.NewTestResourceBuilder(namespace.Name, visibilityLQName)
 			jobset := builder.NewJobSet()
 			Expect(genericClient.Create(ctx, jobset)).To(Succeed(), "Failed to create jobset")
 			defer testutils.CleanUpObject(ctx, genericClient, jobset)
@@ -1079,14 +1036,14 @@ var _ = Describe("VisibilityOnDemand", Label("visibility-on-demand"), Ordered, f
 			By("Verifying all pending workloads are created")
 			verifyWorkloadCreatedNotAdmitted(clients.UpstreamKueueClient, namespace.Name, jobset.GetUID())
 
-			Byf("Checking the pending workloads for local queue %s in namespace %s", localQueue.Name, namespace.Name)
+			Byf("Checking the pending workloads for local queue %s in namespace %s", visibilityLQName, namespace.Name)
 			Eventually(func() error {
-				localPendingWorkloads, err = userVisibilityClient.LocalQueues(namespace.Name).GetPendingWorkloadsSummary(ctx, localQueue.Name, metav1.GetOptions{})
+				localPendingWorkloads, err = userVisibilityClient.LocalQueues(namespace.Name).GetPendingWorkloadsSummary(ctx, visibilityLQName, metav1.GetOptions{})
 				return err
-			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "Failed to get pending workloads for LocalQueue %s", localQueue.Name)
+			}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "Failed to get pending workloads for LocalQueue %s", visibilityLQName)
 
 			By("Verifying pending workloads for LocalQueue")
-			Expect(localPendingWorkloads.Items).To(HaveLen(1), fmt.Sprintf("Expected 1 pending workloads on LocalQueue %s", localQueue.Name))
+			Expect(localPendingWorkloads.Items).To(HaveLen(1), fmt.Sprintf("Expected 1 pending workloads on LocalQueue %s", visibilityLQName))
 
 			Byf("Checking the pending workloads for cluster queue %s", clusterQueue.Name)
 			Eventually(func() error {

--- a/test/e2e/testutils/builders.go
+++ b/test/e2e/testutils/builders.go
@@ -17,9 +17,12 @@
 package testutils
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -359,4 +362,66 @@ func (b *TestResourceBuilder) NewLeaderWorkerSet(opts LeaderWorkerSetOptions) *l
 	}
 
 	return lws
+}
+
+// NewResourceClaimTemplate creates a ResourceClaimTemplate for DRA e2e tests.
+// If celExpression is empty, no CEL selector is added.
+func NewResourceClaimTemplate(name, namespace, deviceClass string, count int64, celExpression string) *resourcev1.ResourceClaimTemplate {
+	rct := &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: resourcev1.ResourceClaimTemplateSpec{
+			Spec: resourcev1.ResourceClaimSpec{
+				Devices: resourcev1.DeviceClaim{
+					Requests: []resourcev1.DeviceRequest{
+						{
+							Name: "gpu-req",
+							Exactly: &resourcev1.ExactDeviceRequest{
+								DeviceClassName: deviceClass,
+								Count:           count,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if celExpression != "" {
+		rct.Spec.Spec.Devices.Requests[0].Exactly.Selectors = []resourcev1.DeviceSelector{
+			{CEL: &resourcev1.CELDeviceSelector{Expression: celExpression}},
+		}
+	}
+	return rct
+}
+
+// NewDRAExtendedResourceJob creates a Job with an extended resource request for DRA e2e tests.
+func (b *TestResourceBuilder) NewDRAExtendedResourceJob(name, queueName, extendedResource string, count int) *batchv1.Job {
+	job := b.NewJob()
+	job.Name = name
+	job.Labels[QueueLabel] = queueName
+	job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("100m")
+	job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory] = resource.MustParse("100Mi")
+	job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResource)] = resource.MustParse(fmt.Sprintf("%d", count))
+	job.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+		corev1.ResourceName(extendedResource): resource.MustParse(fmt.Sprintf("%d", count)),
+	}
+	job.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "echo DRA ER test; sleep 120"}
+	return job
+}
+
+// NewDRAJob creates a Job with a DRA ResourceClaim for e2e tests.
+func (b *TestResourceBuilder) NewDRAJob(name, queueName, templateName string) *batchv1.Job {
+	job := b.NewJob()
+	job.Name = name
+	job.Labels[QueueLabel] = queueName
+	job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("100m")
+	job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory] = resource.MustParse("100Mi")
+	job.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", "echo DRA test; sleep 120"}
+	job.Spec.Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
+		{Name: "gpu", ResourceClaimTemplateName: ptr.To(templateName)},
+	}
+	job.Spec.Template.Spec.Containers[0].Resources.Claims = []corev1.ResourceClaim{{Name: "gpu"}}
+	return job
 }

--- a/test/e2e/testutils/utils.go
+++ b/test/e2e/testutils/utils.go
@@ -933,3 +933,49 @@ func AddLabelAndPatch(ctx context.Context, kubeClient *kubernetes.Clientset, nam
 	}
 	return nil
 }
+
+// IsDRASupported checks if DRA APIs (resource.k8s.io/v1) are available on the cluster.
+func IsDRASupported(kubeClient *kubernetes.Clientset) bool {
+	apiResourceLists, err := kubeClient.Discovery().ServerResourcesForGroupVersion("resource.k8s.io/v1")
+	if err != nil {
+		return false
+	}
+	for _, apiResource := range apiResourceLists.APIResources {
+		if apiResource.Kind == DeviceClassKind {
+			return true
+		}
+	}
+	return false
+}
+
+// SetupTestEnv creates a ResourceFlavor, ClusterQueue, Namespace, and LocalQueue
+// for e2e tests. All resources are registered with DeferCleanup.
+// cqModifiers are applied to the ClusterQueueWrapper before creation to configure
+// resources like DRA, preemption, cohorts, etc.
+func SetupTestEnv(ctx context.Context, kubeClient *kubernetes.Clientset, kueueClient *upstreamkueueclient.Clientset,
+	namespacePrefix, localQueueName string, cqModifiers ...func(*ClusterQueueWrapper)) (*kueuev1beta2.ClusterQueue, *corev1.Namespace) {
+
+	By("Creating ResourceFlavor, ClusterQueue, Namespace and LocalQueue")
+	resourceFlavor, cleanupRF, err := NewResourceFlavor().WithGenerateName().CreateWithObject(ctx, kueueClient)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(cleanupRF)
+
+	cqBuilder := NewClusterQueue().WithGenerateName().WithFlavorName(resourceFlavor.Name)
+	for _, mod := range cqModifiers {
+		mod(cqBuilder)
+	}
+	cq, cleanupCQ, err := cqBuilder.CreateWithObject(ctx, kueueClient)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(cleanupCQ)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: namespacePrefix, Labels: map[string]string{OpenShiftManagedLabel: "true"}}}
+	cleanupNs, err := CreateNamespace(kubeClient, ns)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(cleanupNs)
+
+	_, cleanupLQ, err := NewLocalQueue(ns.Name, localQueueName).WithClusterQueue(cq.Name).CreateWithObject(ctx, kueueClient)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(cleanupLQ)
+
+	return cq, ns
+}


### PR DESCRIPTION
Signed-off-by: Pannaga Rao Bhoja Ramamanohara
Assisted by: Claude
 
Summary

- Add shared e2e test helpers (`SetupTestEnv`, `IsDRASupported`, `NewResourceClaimTemplate`, `NewDRAJob`, `NewDRAExtendedResourceJob`) to `test/e2e/testutils/`
- Migrate DRA, DRA ER, gang scheduling, visibility, and AFS tests to use them
- Tests with multi-CQ, weighted LQ, or custom BeforeEach/AfterEach setups are left as-is

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored multiple E2E suites to use shared setup helpers, standardizing test environment creation and reducing per-scenario boilerplate.
  * Added DRA-aware test helpers: device class/resource claim template builders and job builders for both extended-resource and ResourceClaimTemplate-based workloads.
  * Introduced DRA capability detection to skip DRA-focused test blocks when unsupported.
  * Updated E2E scenarios to use consistent local-queue naming and improved setup for admission, gang scheduling, and visibility assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->