### PR TITLE
bump must-gather to 4.22

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/openshift4/ose-must-gather-rhel9:v4.21 as builder
+FROM registry.redhat.io/openshift4/ose-must-gather-rhel9@sha256:058e4cf1b57a7e5f5d4204bc0f258acf1fd3c5b787af566288bd350331663618 as builder
 
 FROM registry.redhat.io/ubi9/ubi-minimal@sha256:1bc3c5c15720506a0cf48adfdf8b623dfe704377e007d7bbae8d14876392ca6a
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the must-gather image to use a digest-pinned reference for improved reproducibility and security, avoiding reliance on a version tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->