### PR TITLE
Fix e2e upgrade test failures caused by operator resync timing

### DIFF
--- a/test/e2e/e2e_operator_test.go
+++ b/test/e2e/e2e_operator_test.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
+
 	"slices"
 	"strings"
 	"time"
@@ -1452,36 +1452,33 @@ func applyKueueConfig(ctx context.Context, config ssv1.KueueConfiguration, kClie
 	kueueInstance, err := kueueClientset.KueueV1().Kueues().Get(ctx, "cluster", metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred(), "Failed to fetch Kueue instance")
 
-	// Check if the config is actually changing
-	configChanged := !reflect.DeepEqual(kueueInstance.Spec.Config, config)
-
-	// Get the current resource version of kueue-controller-manager before updating config
-	initialDeployment, err := kClient.AppsV1().Deployments(testutils.OperatorNamespace).Get(ctx, "kueue-controller-manager", metav1.GetOptions{})
-	Expect(err).ToNot(HaveOccurred(), "Failed to fetch kueue-controller-manager deployment")
-	initialResourceVersion := initialDeployment.ResourceVersion
+	oldCM, err := kClient.CoreV1().ConfigMaps(testutils.OperatorNamespace).Get(ctx, "kueue-manager-config", metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred(), "Failed to fetch kueue-manager-config ConfigMap")
+	oldConfigData := oldCM.Data["controller_manager_config.yaml"]
 
 	kueueInstance.Spec.Config = config
 	By("Updating Kueue config")
 	_, err = kueueClientset.KueueV1().Kueues().Update(ctx, kueueInstance, metav1.UpdateOptions{})
 	Expect(err).ToNot(HaveOccurred(), "Failed to update Kueue config")
 
-	// Only wait for deployment update if the config actually changed
-	if configChanged {
-		// Wait for the deployment resource version to change
-		By(fmt.Sprintf("Waiting for kueue-controller-manager resource version to change from %s", initialResourceVersion))
-		Eventually(func() error {
-			managerDeployment, err := kClient.AppsV1().Deployments(testutils.OperatorNamespace).Get(ctx, "kueue-controller-manager", metav1.GetOptions{})
-			if err != nil {
-				return fmt.Errorf("Unable to fetch manager deployment: %v", err)
-			}
-			if managerDeployment.ResourceVersion == initialResourceVersion {
-				return fmt.Errorf("deployment resource version has not changed yet (still %s)", initialResourceVersion)
-			}
-			return nil
-		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "kueue-controller-manager deployment resource version did not change")
-	} else {
-		By("Skipping deployment update wait - config unchanged")
-	}
+	// Wait for the ConfigMap content to reflect the CR update. Compare
+	// rendered ConfigMap content (not CR spec equality) because the operator
+	// normalizes defaults and the ResyncEvery(5m) can delay propagation.
+	By("Waiting for kueue-manager-config ConfigMap content to change")
+	Eventually(func() error {
+		cm, err := kClient.CoreV1().ConfigMaps(testutils.OperatorNamespace).Get(ctx, "kueue-manager-config", metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to fetch ConfigMap: %v", err)
+		}
+		data, ok := cm.Data["controller_manager_config.yaml"]
+		if !ok {
+			return fmt.Errorf("controller_manager_config.yaml key missing from ConfigMap")
+		}
+		if data == oldConfigData {
+			return fmt.Errorf("ConfigMap content has not changed yet")
+		}
+		return nil
+	}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(), "kueue-manager-config ConfigMap did not update after CR change")
 
 	Eventually(func() error {
 		managerDeployment, err := kClient.AppsV1().Deployments(testutils.OperatorNamespace).Get(ctx, "kueue-controller-manager", metav1.GetOptions{})

--- a/test/e2e/e2e_tls_profile_test.go
+++ b/test/e2e/e2e_tls_profile_test.go
@@ -56,11 +56,20 @@ var _ = Describe("TLS Security Profile", Label("tls-profile"), Ordered, func() {
 		Expect(err).NotTo(HaveOccurred(), "failed to get APIServer CR")
 		originalTLSProfile = apiServer.Spec.TLSSecurityProfile
 
-		// Capture current ConfigMap state
-		configMap, err := kubeClient.CoreV1().ConfigMaps(testutils.OperatorNamespace).Get(
-			context.TODO(), "kueue-manager-config", metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred(), "failed to get kueue-manager-config ConfigMap")
-		initialConfigMapData = configMap.Data["controller_manager_config.yaml"]
+		// Wait for the operator to reconcile TLS settings into the ConfigMap.
+		// After an upgrade, the initial sync may be delayed by certificate waits.
+		Eventually(func(g Gomega) {
+			configMap, err := kubeClient.CoreV1().ConfigMaps(testutils.OperatorNamespace).Get(
+				context.TODO(), "kueue-manager-config", metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred(), "failed to get kueue-manager-config ConfigMap")
+			data, ok := configMap.Data["controller_manager_config.yaml"]
+			g.Expect(ok).To(BeTrue(), "controller_manager_config.yaml key missing from ConfigMap")
+			tlsOpts, err := extractTLSOptions(data)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to extract TLS options")
+			g.Expect(tlsOpts).NotTo(BeNil(), "TLS options not yet in ConfigMap")
+			initialConfigMapData = data
+		}, testutils.OperatorReadyTime, testutils.OperatorPoll).Should(Succeed(),
+			"TLS options should appear in ConfigMap after operator reconciliation")
 	})
 
 	AfterAll(func() {

--- a/test/e2e/testutils/constants.go
+++ b/test/e2e/testutils/constants.go
@@ -19,7 +19,7 @@ package testutils
 import "time"
 
 const (
-	OperatorReadyTime       = 3 * time.Minute
+	OperatorReadyTime       = 6 * time.Minute
 	OperatorPoll            = 10 * time.Second
 	OperatorNamespace       = "openshift-kueue-operator"
 	OpenShiftManagedLabel   = "kueue.openshift.io/managed"


### PR DESCRIPTION
The operator's library-go factory controller uses ResyncEvery(5m). When a test updates the Kueue CR, the informer event may be coalesced with an in-flight sync that reads stale CR data from the cache. The next sync that picks up the new CR data doesn't happen until the periodic resync, which is 5 minutes away.

Three fixes:
- applyKueueConfig: replace deployment-ResourceVersion-based wait with a ConfigMap content-based wait. Instead of checking if the deployment version changed (can be triggered by unrelated reconciliation), verify the ConfigMap YAML actually differs from its pre-update content.
- TLS BeforeAll: add Eventually poll for TLS options to appear in the ConfigMap. After an upgrade, the operator's initial sync may be delayed by certificate readiness waits.
- OperatorReadyTime: increase from 3m to 6m to cover the 5m resync period as a safety net.

xref: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/80689/rehearse-80689-pull-ci-openshift-kueue-operator-release-1.4-upgrade-from-4.22-e2e-operator-upgrade-4-22-kueue-1-3-to-1-4/2070524808960937984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end checks to wait for the operator-updated configuration to propagate before validating operator and TLS-related behavior, reducing timing-related flakiness.
  * Increased the operator readiness wait time used by tests to improve stability on slower environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->