### PR TITLE
[release-1.4] Fix operator reconciler stale config after upgrade

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -223,7 +223,7 @@ func NewTargetConfigReconciler(
 	}
 
 	// Detect platform type (OpenShift vs kind/vanilla k8s)
-	c.isOpenShift = c.detectOpenShift()
+	c.isOpenShift = c.detectOpenShift(ctx)
 
 	informerList := []factory.Informer{
 		kueueClient.Informer(),
@@ -525,6 +525,20 @@ func (c *TargetConfigReconciler) sync(ctx context.Context, syncCtx factory.SyncC
 	if err != nil {
 		klog.Warningf("Kueue Visibility certificate not ready yet: %v - will retry on next reconciliation", err)
 		return err
+	}
+
+	// Re-read the Kueue CR after certificate waits, which can block for
+	// minutes. The CR spec may have been updated in the meantime.
+	obj, exists, err = c.kueueClient.Informer().GetIndexer().GetByKey(operatorclient.OperatorConfigName)
+	if err != nil {
+		return fmt.Errorf("failed to re-read operator configuration after certificate wait: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("operator configuration %q not found after certificate wait", operatorclient.OperatorConfigName)
+	}
+	kueue, ok = obj.(*kueuev1.Kueue)
+	if !ok {
+		return fmt.Errorf("unable to convert cached object to Kueue type after certificate wait")
 	}
 
 	// Resolve TLS security profile from APIServer cluster-wide config
@@ -2435,17 +2449,28 @@ func (c *TargetConfigReconciler) isResourceRegisteredCached(gvk schema.GroupVers
 	return true, nil
 }
 
-// detectOpenShift detects whether the operator is running on OpenShift or vanilla Kubernetes (kind, etc.).
-// It checks for the presence of OpenShift-specific API groups using the discovery client.
-// This method should be fast and non-blocking (called at startup).
-func (c *TargetConfigReconciler) detectOpenShift() bool {
-	_, err := c.discoveryClient.ServerResourcesForGroupVersion(
-		schema.GroupVersion{
-			Group:   "project.openshift.io",
-			Version: "v1",
-		}.String(),
-	)
-	return err == nil
+// detectOpenShift detects whether the operator is running on OpenShift
+// or vanilla Kubernetes. It retries transient discovery errors because
+// after an upgrade the API server may not serve results immediately.
+// A NotFound error means the API group doesn't exist (vanilla K8s) and
+// is not retried.
+func (c *TargetConfigReconciler) detectOpenShift(ctx context.Context) bool {
+	gv := schema.GroupVersion{Group: "project.openshift.io", Version: "v1"}.String()
+	for i := 0; i < 6; i++ {
+		_, err := c.discoveryClient.ServerResourcesForGroupVersion(gv)
+		if err == nil {
+			return true
+		}
+		if errors.IsNotFound(err) {
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(5 * time.Second):
+		}
+	}
+	return false
 }
 
 // isOperatorAvailability checks if a given operator is installed and configured.


### PR DESCRIPTION
## Summary

Two fixes for upgrade test failures where the operator fails to propagate Kueue CR changes to the `kueue-manager-config` ConfigMap:

1. **`detectOpenShift` retry**: After an upgrade, the API server may not serve discovery results immediately when the operator pod starts. The single-shot check latches `isOpenShift=false`, permanently disabling TLS profile handling. Now retries up to 30s.

2. **CR re-read after certificate waits**: `sync()` reads the Kueue CR once at the top, then blocks for up to 6 minutes on `WaitForCertificateReady`. If the CR is updated during this window, the ConfigMap is built from the stale copy. Now re-reads from the informer cache after cert waits.

Evidence from upgrade CI runs:
- [Run with 46/49 passed](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/80689/rehearse-80689-pull-ci-openshift-kueue-operator-release-1.4-upgrade-from-4.22-e2e-operator-upgrade-4-22-kueue-1-3-to-1-4/2070524808960937984) — operand loaded default config without TLS/AFS/DRA despite successful bundle install
- Operand config at `16:51:05` shows no `usageHalfLifeTime`, no `deviceClassMappings`, no `tls:` — default config only

/kind bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenShift environment detection with bounded retries and cancellation handling, reducing setup failures during transient discovery issues.
  * Re-checks the latest configuration state before continuing reconciliation, preventing progress with stale or missing cached data after certificate resources become ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->