### PR TITLE
Update kueue submodule to 92abdcbd33

### DIFF
--- a/bindata/assets/kueue-operator/crds/crd-workloads.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-workloads.kueue.x-k8s.io-v1beta2.yaml
@@ -105,7 +105,7 @@ spec:
                 description: |-
                   podSets is a list of sets of homogeneous pods, each described by a Pod spec
                   and a count.
-                  There must be at least one element and at most 10.
+                  There must be at least one element and at most 18.
                   podSets cannot be changed.
                 items:
                   properties:
@@ -8810,7 +8810,7 @@ spec:
                   x-kubernetes-validations:
                   - message: minCount should be positive and less or equal to count
                     rule: 'has(self.minCount) ? self.minCount <= self.count : true'
-                maxItems: 10
+                maxItems: 18
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
@@ -9030,7 +9030,7 @@ spec:
                       required:
                       - name
                       type: object
-                    maxItems: 10
+                    maxItems: 18
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
@@ -9155,7 +9155,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 10
+                      maxItems: 18
                       type: array
                       x-kubernetes-list-type: atomic
                     requeueAfterSeconds:
@@ -9310,7 +9310,7 @@ spec:
                   - count
                   - name
                   type: object
-                maxItems: 10
+                maxItems: 18
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -9367,7 +9367,7 @@ spec:
                   required:
                   - name
                   type: object
-                maxItems: 10
+                maxItems: 18
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -9540,7 +9540,7 @@ spec:
                 description: |-
                   podSets is a list of sets of homogeneous pods, each described by a Pod spec
                   and a count.
-                  There must be at least one element and at most 10.
+                  There must be at least one element and at most 18.
                   podSets cannot be changed.
                 items:
                   properties:
@@ -18289,7 +18289,7 @@ spec:
                   x-kubernetes-validations:
                   - message: minCount should be positive and less or equal to count
                     rule: 'has(self.minCount) ? self.minCount <= self.count : true'
-                maxItems: 10
+                maxItems: 18
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
@@ -18667,7 +18667,7 @@ spec:
                               number of levels in this TopologyAssignment
                             rule: self.slices.all(x, size(x.valuesPerLevel) == size(self.levels))
                       type: object
-                    maxItems: 10
+                    maxItems: 18
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
@@ -18791,7 +18791,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 10
+                      maxItems: 18
                       type: array
                       x-kubernetes-list-type: atomic
                     requeueAfterSeconds:
@@ -18982,7 +18982,7 @@ spec:
                   - count
                   - name
                   type: object
-                maxItems: 10
+                maxItems: 18
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -19039,7 +19039,7 @@ spec:
                   required:
                   - name
                   type: object
-                maxItems: 10
+                maxItems: 18
                 type: array
                 x-kubernetes-list-map-keys:
                 - name


### PR DESCRIPTION
## Summary
- Bump `upstream/kueue/src` submodule from `ace3d7a2f3` to `92abdcbd33`
- Regenerate manifests via `make submodule-workflow` (`sync-manifests-from-submodule`), which updated the Workload CRD's `podSets` `maxItems` from 10 to 18

## Upstream commits included
- 92abdcbd3 Release team and release automation - sync release notes step. (#12848)
- b39a67710 Increase Workload PodSet limit to 18 (#12819)
- cdc242b3c chart: disable internal cert management when cert-manager is enabled (#12859)
- d65602f14 kueueviz: fix CSWSH by removing permissive CheckOrigin (#12734)
- 45d895f5d Use strong typing for scheduling equivalence hashes (#12871)
- 792e21303 Don't admit workload when WaitingForReplacementPods=True. (#12768)
- 61c3245af [Cleanup] Use structured errors in TAS Flavorassigner (#12679)
- fd65bcdc5 Replace connecting/disconnected with single enum (#12837)
- f5fea343a Mention incr dispatcher config in docs. (#12853)
- e9ca10e50 KueueViz: Fix missing http server timeouts (#12590)
- c77a0966a cleanup tls config unit tests (#12861)
- bd2b4f75f Remove @tenzen-y CyberAgent, Inc contact information (#12860)
- 0ab6a8c33 add curve support to kueue (#11832)
- bf7118ca0 kueueviz: avoid per-workload pod lists in dashboard (#12777)
- 239291343 Handle SchedulingEquivalenceHashing skipped workloads in UnadmittedWorkloadsObservability (#12821)
- 8bf23d956 Fix the flaky perf tas test (#12840)
- 7a83d66eb Deleting an entire block in job_test.go (#12850)
- 5781b5763 add OnHold reason (#12812)
- d3f122956 Test: Converting the remaining priorityclass with workloadpriorityclass in visibility_test.go (#12842)
- da1706fba set empty underlying_cause for non QuotaReserved admission issues (#12814)
- 9ed4d7dbc Increase CI build times (#12839)
- 6473bbe19 Fix race condition in multikueue watcher establishment (#12824)
- b133b72b5 Fix flaky LeaderWorkerSet restart policy tests by increasing timeout (#12831)
- 1050ee04c build(deps-dev): bump vitest (#12816)
- fc4a09f27 fix(test): ignore multiKueue teardown cleanup errors to prevent flakiness (#12811)
- 1091f9286 Add e2e regression test for elasticJob ResourceFlavor injection (#12421)
- e688ba1f5 feat: try to measure timings for individual bash commands (#12693)

## Test plan
- [x] `make build`
- [x] `make test-unit`
- [ ] CI e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the allowed size for several list fields in the workload configuration schema, including `podSets`, from 10 to 18 items.
  * Updated validation messages to reflect the new limit.  

* **Chores**
  * Updated the bundled upstream component reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->