### PR TITLE
update submodule to prepare for 0.19 release

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,8 +5,6 @@ exclude:
   global:
     # sync generation script
     - hack/sync_manifests.py
-    # upstream ignores
-    - upstream/kueue/src/hack/internal/tools/**
     # Disable kueue-viz as openshift does not support.
     - upstream/kueue/src/cmd/experimental/kueue-viz/**
     # Disable kueuectl as openshift does not support.
@@ -14,8 +12,8 @@ exclude:
     - upstream/kueue/src/site/**
     - upstream/kueue/src/vendor/**
     - upstream/kueue/src/"**/*_test.go"
-    # Disable tools
-    - upstream/kueue/src/hack/tools/**
+    # Disable all hack scripts
+    - upstream/kueue/src/hack/**
     # sha1 hash not used for cryptographic purposes
     - upstream/kueue/src/pkg/controller/admissionchecks/provisioning/controller.go
     - upstream/kueue/src/pkg/controller/jobframework/workload_names.go

--- a/bindata/assets/kueue-operator/crds/crd-multikueueconfigs.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-multikueueconfigs.kueue.x-k8s.io-v1beta2.yaml
@@ -86,15 +86,21 @@ spec:
             description: spec is the specification of the MultiKueueConfig.
             properties:
               clusters:
-                description: clusters is a list of MultiKueueClusters names where
-                  the workloads from the ClusterQueue should be distributed.
+                description: |-
+                  clusters is a list of MultiKueueClusters names where the workloads from the ClusterQueue should be distributed.
+                  The order of the list is significant: the Incremental dispatcher nominates clusters
+                  following this order, so the most preferred clusters should be listed first.
                 items:
                   maxLength: 256
                   type: string
                 maxItems: 20
                 minItems: 1
                 type: array
-                x-kubernetes-list-type: set
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: must be unique
+                  rule: size(self.filter(i, size(self.filter(j, j == i)) > 1)) ==
+                    0
               quotaManagement:
                 description: |-
                   quotaManagement specifies the management of ClusterQueue quotas


### PR DESCRIPTION
Update submodule in preparation for kueue 0.19 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced that `MultiKueueConfig` `spec.clusters` contains only unique entries.
  * Preserved and enforced the configured `spec.clusters` preference order for incremental dispatching.
* **Documentation**
  * Clarified that the order of `spec.clusters` is significant and directly affects incremental dispatch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->