### PR TITLE
OCPBUGS-99316: Register core Kueue validating webhooks

### DIFF
--- a/pkg/webhook/pod_webhook.go
+++ b/pkg/webhook/pod_webhook.go
@@ -254,5 +254,13 @@ func buildEnabledFrameworks(kueueCfg kueue.KueueConfiguration) map[string]bool {
 		enabledFrameworks[string(kueue.KueueIntegrationPod)] = true
 	}
 
+	// Core Kueue webhooks use annotation-based keys (kueue.x-k8s.io/*)
+	// that never appear in Integrations.Frameworks, so always enable them.
+	for key := range webhooksList {
+		if strings.HasPrefix(key, "kueue.x-k8s.io/") {
+			enabledFrameworks[key] = true
+		}
+	}
+
 	return enabledFrameworks
 }

--- a/pkg/webhook/pod_webhook_test.go
+++ b/pkg/webhook/pod_webhook_test.go
@@ -55,6 +55,18 @@ func TestModifyPodBasedValidatingWebhook(t *testing.T) {
 					{
 						Name: "vstatefulset.kb.io",
 					},
+					{
+						Name: "vcohort.kb.io",
+					},
+					{
+						Name: "vclusterqueue.kb.io",
+					},
+					{
+						Name: "vworkload.kb.io",
+					},
+					{
+						Name: "vresourceflavor.kb.io",
+					},
 				},
 			},
 			newWebhook: &admissionregistrationv1.ValidatingWebhookConfiguration{
@@ -95,6 +107,19 @@ func TestModifyPodBasedValidatingWebhook(t *testing.T) {
 								},
 							},
 						},
+					},
+					{
+						Name: "vcohort.kb.io",
+					},
+					{
+						Name: "vclusterqueue.kb.io",
+					},
+					{
+						Name:              "vworkload.kb.io",
+						NamespaceSelector: defaultLabelSelector(),
+					},
+					{
+						Name: "vresourceflavor.kb.io",
 					},
 				},
 			},
@@ -275,6 +300,32 @@ func TestModifyPodBasedValidatingWebhook(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+		},
+		"core webhooks always included even with no frameworks enabled": {
+			configuration: kueue.KueueConfiguration{
+				Integrations: kueue.Integrations{
+					Frameworks: []kueue.KueueIntegration{},
+				},
+			},
+			oldWebhook: &admissionregistrationv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregistrationv1.ValidatingWebhook{
+					{Name: "vcohort.kb.io"},
+					{Name: "vclusterqueue.kb.io"},
+					{Name: "vworkload.kb.io"},
+					{Name: "vresourceflavor.kb.io"},
+				},
+			},
+			newWebhook: &admissionregistrationv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregistrationv1.ValidatingWebhook{
+					{Name: "vcohort.kb.io"},
+					{Name: "vclusterqueue.kb.io"},
+					{
+						Name:              "vworkload.kb.io",
+						NamespaceSelector: defaultLabelSelector(),
+					},
+					{Name: "vresourceflavor.kb.io"},
 				},
 			},
 		},
@@ -529,6 +580,32 @@ func TestModifyPodBasedMutatingWebhook(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+		},
+		"core webhooks always included even with no frameworks enabled": {
+			configuration: kueue.KueueConfiguration{
+				Integrations: kueue.Integrations{
+					Frameworks: []kueue.KueueIntegration{},
+				},
+			},
+			oldWebhook: &admissionregistrationv1.MutatingWebhookConfiguration{
+				Webhooks: []admissionregistrationv1.MutatingWebhook{
+					{Name: "mcohort.kb.io"},
+					{Name: "mclusterqueue.kb.io"},
+					{Name: "mworkload.kb.io"},
+					{Name: "mresourceflavor.kb.io"},
+				},
+			},
+			newWebhook: &admissionregistrationv1.MutatingWebhookConfiguration{
+				Webhooks: []admissionregistrationv1.MutatingWebhook{
+					{Name: "mcohort.kb.io"},
+					{Name: "mclusterqueue.kb.io"},
+					{
+						Name:              "mworkload.kb.io",
+						NamespaceSelector: defaultLabelSelector(),
+					},
+					{Name: "mresourceflavor.kb.io"},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- Fix `buildEnabledFrameworks()` to always include the four core Kueue webhooks (`vcohort.kb.io`, `vclusterqueue.kb.io`, `vworkload.kb.io`, `vresourceflavor.kb.io`), which use annotation-based keys that never appear in `Integrations.Frameworks` and were silently dropped during operator reconciliation
- Add unit test verifying all four core webhooks are preserved even when no integration frameworks are configured

## Root Cause
`buildEnabledFrameworks()` only populates the enabled map from `kueueCfg.Integrations.Frameworks` (integration constants like `BatchJob`, `Pod`). Core Kueue webhooks use annotation-based keys (`kueue.x-k8s.io/cohort`, `kueue.x-k8s.io/clusterqueue`, `kueue.x-k8s.io/workload`, `kueue.x-k8s.io/resourceflavor`) that are never in that config, so they are never marked as enabled and get filtered out by `ModifyPodBasedValidatingWebhook()`.

Without these webhooks registered, the API server skips validation entirely — allowing invalid resources to be persisted to etcd. The impact is most visible for Cohorts (e.g. `lendingLimit` without `parentName`), where no CRD-level schema validation exists as a fallback.

## Verified on cluster
All four webhooks present after deploying the fix:
```
$ oc get validatingwebhookconfiguration kueue-validating-webhook-configuration -o yaml | grep "name: v.*\.kb\.io"
  name: vclusterqueue.kb.io
  name: vcohort.kb.io
  name: vresourceflavor.kb.io
  name: vworkload.kb.io
```

Cohort validation working — invalid Cohort rejected:
```
$ oc apply -f - <<YAML
apiVersion: kueue.x-k8s.io/v1beta1
kind: Cohort
metadata:
  name: invalid-cohort
spec:
  resourceGroups:
  - coveredResources: ["cpu"]
    flavors:
    - name: default
      resources:
      - name: cpu
        nominalQuota: 1
        lendingLimit: "500m"
YAML
Error from server (Forbidden): admission webhook "vcohort.kb.io" denied the request:
spec.resourceGroups[0].flavors[0].resources[0].lendingLimit: Invalid value: "500m": must be nil when parent is empty
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured core cohort/clusterqueue/workload/resourceflavor pod validating and mutating webhooks are always retained, even when no framework integrations are configured.
  * Updated webhook selection to consistently preserve core annotation-based webhook entries, including correct namespace selection for workload webhooks.
* **Tests**
  * Updated existing webhook expectation cases to match the always-included core webhooks behavior.
  * Added new test coverage for scenarios where the frameworks list is empty, verifying core validating and mutating webhooks remain present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->