### PR TITLE
OCPKUEUE-714: add TAS demo for quick examples

### DIFF
--- a/docs/tas/00-kueue-cr.yaml
+++ b/docs/tas/00-kueue-cr.yaml
@@ -1,0 +1,16 @@
+apiVersion: kueue.openshift.io/v1
+kind: Kueue
+metadata:
+  labels:
+    app.kubernetes.io/name: kueue-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: cluster
+spec:
+  managementState: Managed
+  config:
+    integrations:
+      frameworks:
+      - BatchJob
+      - Pod
+      - Deployment
+      - JobSet

--- a/docs/tas/01-namespace.yaml
+++ b/docs/tas/01-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kueue-tas-demo
+  labels:
+    kueue.openshift.io/managed: "true"

--- a/docs/tas/README.md
+++ b/docs/tas/README.md
@@ -1,0 +1,118 @@
+# Topology Aware Scheduling (TAS) demo
+
+Sample manifests that walk through Kueue's Topology Aware Scheduling feature
+on OpenShift, mirroring the scenarios covered in
+[`test/e2e/e2e_tas_test.go`](../../test/e2e/e2e_tas_test.go). Two independent
+demos are included:
+
+- **`hostname/`** — a single-level `kubernetes.io/hostname` topology. Every
+  worker node is one topology domain. Shows Job, Pod, JobSet, and Deployment
+  workloads all getting admitted with a `TopologyAssignment`.
+- **`datacenter/`** — a 3-level `block` / `rack` / `hostname` topology
+  simulating a real datacenter layout. Shows the difference between a
+  *required* topology (must land in the same block) and a *preferred* one
+  (try to land in the same rack, but admit anyway if it can't).
+
+## Prerequisites
+
+- The kueue-operator is installed and its `Kueue` CR (`metadata.name:
+  cluster`) is `Managed`.
+- You're logged in with `oc` as a user that can label nodes and create
+  cluster-scoped Kueue resources (ClusterQueue, ResourceFlavor, Topology).
+- `hostname/` needs at least 1 worker node; `datacenter/` needs at least 2
+  (4 shows every block/rack combination).
+
+## 1. Enable the integrations used by this demo
+
+```bash
+oc apply -f 00-kueue-cr.yaml
+oc apply -f 01-namespace.yaml
+```
+
+`00-kueue-cr.yaml` turns on the `BatchJob`, `Pod`, `Deployment`, and `JobSet`
+integrations. If your cluster's `Kueue` CR already exists, merge these
+frameworks into it instead of applying this file (it will overwrite your
+existing `spec.config`).
+
+## 2. Run the hostname demo
+
+```bash
+cd hostname
+./00-label-nodes.sh
+oc apply -f 01-topology.yaml
+oc apply -f 02-resourceflavor.yaml
+oc apply -f 03-clusterqueue.yaml
+oc apply -f 04-localqueue.yaml
+
+oc create -f 05-job.yaml
+oc create -f 06-pod.yaml
+oc create -f 07-jobset.yaml
+oc create -f 08-deployment.yaml
+```
+
+Resources with `generateName` (the workloads) are created with `oc create`,
+not `oc apply`, since `apply` doesn't handle generated names well.
+
+Watch the workloads get admitted and their `TopologyAssignment` populated:
+
+```bash
+oc get workloads -n kueue-tas-demo
+oc get workload <name> -n kueue-tas-demo -o jsonpath='{.status.admission.podSetAssignments[*].topologyAssignment}' | jq .
+```
+
+For the Pod and Deployment examples, confirm the scheduling gate was removed
+and a `nodeSelector` was injected:
+
+```bash
+oc get pods -n kueue-tas-demo -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.schedulingGates}{"\t"}{.spec.nodeSelector}{"\n"}{end}'
+```
+
+Clean up:
+
+```bash
+oc delete -f 08-deployment.yaml -f 07-jobset.yaml -f 06-pod.yaml -f 05-job.yaml --ignore-not-found
+oc delete -f 04-localqueue.yaml -f 03-clusterqueue.yaml -f 02-resourceflavor.yaml -f 01-topology.yaml
+./99-unlabel-nodes.sh
+cd ..
+```
+
+## 3. Run the datacenter demo
+
+```bash
+cd datacenter
+./00-label-nodes.sh
+oc apply -f 01-topology.yaml
+oc apply -f 02-resourceflavor.yaml
+oc apply -f 03-clusterqueue.yaml
+oc apply -f 04-localqueue.yaml
+
+oc create -f 05-job-block-required.yaml
+oc create -f 06-job-rack-preferred.yaml
+```
+
+Check the `TopologyAssignment.levels` on each workload — the block-required
+job pins both pods to the same `cloud.provider.com/topology-block` value,
+while the rack-preferred job tries for the same
+`cloud.provider.com/topology-rack` but stays admitted even if it can't:
+
+```bash
+oc get workloads -n kueue-tas-demo -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.admission.podSetAssignments[*].topologyAssignment.levels}{"\n"}{end}'
+```
+
+Clean up:
+
+```bash
+oc delete -f 06-job-rack-preferred.yaml -f 05-job-block-required.yaml --ignore-not-found
+oc delete -f 04-localqueue.yaml -f 03-clusterqueue.yaml -f 02-resourceflavor.yaml -f 01-topology.yaml
+./99-unlabel-nodes.sh
+cd ..
+```
+
+## Tear down
+
+```bash
+oc delete -f 01-namespace.yaml
+```
+
+(Leave `00-kueue-cr.yaml` alone unless you want to disable the integrations
+it enabled.)

--- a/docs/tas/datacenter/00-label-nodes.sh
+++ b/docs/tas/datacenter/00-label-nodes.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Labels up to 4 worker nodes with a 2-level "datacenter" topology
+# (block + rack) plus the node-group label used by the ResourceFlavor.
+# Needs at least 2 worker nodes; 4 nodes shows off every block/rack
+# combination.
+set -euo pipefail
+
+nodes=($(oc get nodes -l node-role.kubernetes.io/worker -o name))
+if [ "${#nodes[@]}" -lt 2 ]; then
+  echo "Need at least 2 worker nodes for the datacenter topology demo, found ${#nodes[@]}" >&2
+  exit 1
+fi
+
+blocks=(b1 b1 b2 b2)
+racks=(r1 r2 r1 r2)
+
+max=${#nodes[@]}
+if [ "$max" -gt 4 ]; then
+  max=4
+fi
+
+for ((i = 0; i < max; i++)); do
+  node="${nodes[$i]}"
+  echo "Labeling ${node} with block=${blocks[$i]} rack=${racks[$i]}"
+  oc label "${node}" \
+    cloud.provider.com/topology-block="${blocks[$i]}" \
+    cloud.provider.com/topology-rack="${racks[$i]}" \
+    cloud.provider.com/node-group=tas-group \
+    --overwrite
+done

--- a/docs/tas/datacenter/01-topology.yaml
+++ b/docs/tas/datacenter/01-topology.yaml
@@ -1,0 +1,9 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: Topology
+metadata:
+  name: datacenter-topology
+spec:
+  levels:
+  - nodeLabel: cloud.provider.com/topology-block
+  - nodeLabel: cloud.provider.com/topology-rack
+  - nodeLabel: kubernetes.io/hostname

--- a/docs/tas/datacenter/02-resourceflavor.yaml
+++ b/docs/tas/datacenter/02-resourceflavor.yaml
@@ -1,0 +1,8 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: tas-datacenter-flavor
+spec:
+  nodeLabels:
+    cloud.provider.com/node-group: tas-group
+  topologyName: datacenter-topology

--- a/docs/tas/datacenter/03-clusterqueue.yaml
+++ b/docs/tas/datacenter/03-clusterqueue.yaml
@@ -1,0 +1,17 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: tas-datacenter-cq
+spec:
+  namespaceSelector:
+    matchLabels:
+      kueue.openshift.io/managed: "true"
+  resourceGroups:
+  - coveredResources: ["cpu", "memory"]
+    flavors:
+    - name: tas-datacenter-flavor
+      resources:
+      - name: "cpu"
+        nominalQuota: 4
+      - name: "memory"
+        nominalQuota: 4Gi

--- a/docs/tas/datacenter/04-localqueue.yaml
+++ b/docs/tas/datacenter/04-localqueue.yaml
@@ -1,0 +1,7 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: tas-datacenter-lq
+  namespace: kueue-tas-demo
+spec:
+  clusterQueue: tas-datacenter-cq

--- a/docs/tas/datacenter/05-job-block-required.yaml
+++ b/docs/tas/datacenter/05-job-block-required.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: tas-dc-block-job-
+  namespace: kueue-tas-demo
+  labels:
+    kueue.x-k8s.io/queue-name: tas-datacenter-lq
+spec:
+  parallelism: 2
+  completions: 2
+  template:
+    metadata:
+      annotations:
+        # Every pod in this job must land in the same block. With only
+        # block+rack+hostname levels and 2 pods requesting 100m/64Mi each,
+        # Kueue can satisfy this by picking 2 hosts in the same block.
+        kueue.x-k8s.io/podset-required-topology: cloud.provider.com/topology-block
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: test-container
+        image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+        command: ["sh", "-c", "echo Hello Kueue; sleep 3600"]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]

--- a/docs/tas/datacenter/06-job-rack-preferred.yaml
+++ b/docs/tas/datacenter/06-job-rack-preferred.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: tas-dc-rack-job-
+  namespace: kueue-tas-demo
+  labels:
+    kueue.x-k8s.io/queue-name: tas-datacenter-lq
+spec:
+  parallelism: 2
+  completions: 2
+  template:
+    metadata:
+      annotations:
+        # Preferred (not required): Kueue tries to co-locate pods in one
+        # rack, but will still admit the workload if it can't.
+        kueue.x-k8s.io/podset-preferred-topology: cloud.provider.com/topology-rack
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: test-container
+        image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+        command: ["sh", "-c", "echo Hello Kueue; sleep 3600"]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]

--- a/docs/tas/datacenter/99-unlabel-nodes.sh
+++ b/docs/tas/datacenter/99-unlabel-nodes.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Removes the labels added by 00-label-nodes.sh.
+set -euo pipefail
+
+nodes=($(oc get nodes -l cloud.provider.com/node-group=tas-group -o name))
+for node in "${nodes[@]}"; do
+  echo "Unlabeling ${node}"
+  oc label "${node}" \
+    cloud.provider.com/topology-block- \
+    cloud.provider.com/topology-rack- \
+    cloud.provider.com/node-group-
+done

--- a/docs/tas/hostname/00-label-nodes.sh
+++ b/docs/tas/hostname/00-label-nodes.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Labels every worker node with instance-type=on-demand so the hostname
+# ResourceFlavor (03-resourceflavor.yaml) can match them and TAS can discover
+# one topology domain per node.
+set -euo pipefail
+
+for node in $(oc get nodes -l node-role.kubernetes.io/worker -o name); do
+  echo "Labeling ${node}"
+  oc label "${node}" instance-type=on-demand --overwrite
+done

--- a/docs/tas/hostname/01-topology.yaml
+++ b/docs/tas/hostname/01-topology.yaml
@@ -1,0 +1,7 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: Topology
+metadata:
+  name: hostname-topology
+spec:
+  levels:
+  - nodeLabel: kubernetes.io/hostname

--- a/docs/tas/hostname/02-resourceflavor.yaml
+++ b/docs/tas/hostname/02-resourceflavor.yaml
@@ -1,0 +1,8 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: tas-hostname-flavor
+spec:
+  nodeLabels:
+    instance-type: on-demand
+  topologyName: hostname-topology

--- a/docs/tas/hostname/03-clusterqueue.yaml
+++ b/docs/tas/hostname/03-clusterqueue.yaml
@@ -1,0 +1,17 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: tas-hostname-cq
+spec:
+  namespaceSelector:
+    matchLabels:
+      kueue.openshift.io/managed: "true"
+  resourceGroups:
+  - coveredResources: ["cpu", "memory"]
+    flavors:
+    - name: tas-hostname-flavor
+      resources:
+      - name: "cpu"
+        nominalQuota: 4
+      - name: "memory"
+        nominalQuota: 4Gi

--- a/docs/tas/hostname/04-localqueue.yaml
+++ b/docs/tas/hostname/04-localqueue.yaml
@@ -1,0 +1,7 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: tas-hostname-lq
+  namespace: kueue-tas-demo
+spec:
+  clusterQueue: tas-hostname-cq

--- a/docs/tas/hostname/05-job.yaml
+++ b/docs/tas/hostname/05-job.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: tas-job-
+  namespace: kueue-tas-demo
+  labels:
+    kueue.x-k8s.io/queue-name: tas-hostname-lq
+spec:
+  # parallelism=2 with a required hostname topology means both pods must
+  # land on the *same* node (the only topology level here is the hostname
+  # itself). This is intentional: it demonstrates that TAS still admits and
+  # schedules the workload even on a single-worker-node cluster, and that
+  # the whole pod set is pinned to one topology domain.
+  parallelism: 2
+  completions: 2
+  template:
+    metadata:
+      annotations:
+        kueue.x-k8s.io/podset-required-topology: kubernetes.io/hostname
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: test-container
+        image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+        command: ["sh", "-c", "echo Hello Kueue; sleep 3600"]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]

--- a/docs/tas/hostname/06-pod.yaml
+++ b/docs/tas/hostname/06-pod.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: tas-pod-
+  namespace: kueue-tas-demo
+  labels:
+    kueue.x-k8s.io/queue-name: tas-hostname-lq
+  annotations:
+    kueue.x-k8s.io/podset-required-topology: kubernetes.io/hostname
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: test-container
+    image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+    command: ["sh", "-c", "echo Hello Kueue; sleep 3600"]
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]

--- a/docs/tas/hostname/07-jobset.yaml
+++ b/docs/tas/hostname/07-jobset.yaml
@@ -1,0 +1,49 @@
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  generateName: tas-jobset-
+  namespace: kueue-tas-demo
+  labels:
+    kueue.x-k8s.io/queue-name: tas-hostname-lq
+spec:
+  replicatedJobs:
+  - name: rj1
+    replicas: 1
+    template:
+      spec:
+        parallelism: 1
+        completions: 1
+        template:
+          metadata:
+            annotations:
+              kueue.x-k8s.io/podset-required-topology: kubernetes.io/hostname
+          spec:
+            restartPolicy: Never
+            containers:
+            - name: test
+              image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+              command: ["sh", "-c", "echo Hello Kueue; sleep 3600"]
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 64Mi
+  - name: rj2
+    replicas: 1
+    template:
+      spec:
+        parallelism: 1
+        completions: 1
+        template:
+          metadata:
+            annotations:
+              kueue.x-k8s.io/podset-required-topology: kubernetes.io/hostname
+          spec:
+            restartPolicy: Never
+            containers:
+            - name: test
+              image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+              command: ["sh", "-c", "echo Hello Kueue; sleep 3600"]
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 64Mi

--- a/docs/tas/hostname/08-deployment.yaml
+++ b/docs/tas/hostname/08-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  generateName: tas-deploy-
+  namespace: kueue-tas-demo
+  labels:
+    kueue.x-k8s.io/queue-name: tas-hostname-lq
+spec:
+  # replicas=2 with a required hostname topology means both pods must land
+  # on the *same* node (the only topology level here is the hostname
+  # itself); see 05-job.yaml for details.
+  replicas: 2
+  selector:
+    matchLabels:
+      app: test-deployment
+  template:
+    metadata:
+      labels:
+        app: test-deployment
+      annotations:
+        kueue.x-k8s.io/podset-required-topology: kubernetes.io/hostname
+    spec:
+      containers:
+      - name: test-container
+        image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+        command: ["sh", "-c", "sleep 3600"]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]

--- a/docs/tas/hostname/99-unlabel-nodes.sh
+++ b/docs/tas/hostname/99-unlabel-nodes.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Removes the instance-type label added by 00-label-nodes.sh.
+set -euo pipefail
+
+for node in $(oc get nodes -l node-role.kubernetes.io/worker -o name); do
+  echo "Unlabeling ${node}"
+  oc label "${node}" instance-type-
+done


### PR DESCRIPTION
Walk through for TAS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete Kubernetes Topology Aware Scheduling demo.
  * Added hostname- and datacenter-based scheduling scenarios with sample workloads, queues, resource configurations, and topology definitions.
  * Added examples for Jobs, Pods, JobSets, and Deployments using topology placement requirements and preferences.
  * Added scripts to configure and restore node labels for both scenarios.
* **Documentation**
  * Added step-by-step setup, verification, cleanup, and teardown instructions for the demos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->