### PR TITLE
convert ubi-minimal to ubi-micro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ WORKDIR /go/src/github.com/openshift/kueue-operator
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.redhat.io/ubi9/ubi-minimal@sha256:48fa5d8cda7fc00d270d8747c3eaa54ae196f0820d8540074a9c8c61d5e3056f
-RUN microdnf install -y lsof && microdnf clean all && rm -rf /var/cache/{dnf,yum}
+FROM registry.redhat.io/ubi9/ubi-micro@sha256:b1e86b97028b8fcfb6d85f997c39e6b6b67496163ef8d80d243220a4918e8bef
 COPY --from=builder /go/src/github.com/openshift/kueue-operator/kueue-operator /usr/bin/
 RUN mkdir /licenses
 COPY --from=builder /go/src/github.com/openshift/kueue-operator/LICENSE /licenses/.

--- a/Dockerfile.kueue
+++ b/Dockerfile.kueue
@@ -9,8 +9,7 @@ COPY . .
 WORKDIR /workspace/upstream/kueue
 RUN ./build.sh
 
-FROM registry.redhat.io/ubi9/ubi-minimal@sha256:48fa5d8cda7fc00d270d8747c3eaa54ae196f0820d8540074a9c8c61d5e3056f
-RUN microdnf install -y lsof && microdnf clean all && rm -rf /var/cache/{dnf,yum}
+FROM registry.redhat.io/ubi9/ubi-micro@sha256:b1e86b97028b8fcfb6d85f997c39e6b6b67496163ef8d80d243220a4918e8bef
 WORKDIR /
 COPY --from=build /workspace/upstream/kueue/src/bin/manager /
 USER 65532:65532

--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.redhat.io/openshift4/ose-must-gather-rhel9@sha256:1101c3491186096e60ad91c2bd8bc1978622cbc018750312f810616af0928570 as builder
 
-FROM registry.redhat.io/ubi9/ubi-minimal@sha256:48fa5d8cda7fc00d270d8747c3eaa54ae196f0820d8540074a9c8c61d5e3056f
+FROM registry.redhat.io/ubi9/ubi-micro@sha256:b1e86b97028b8fcfb6d85f997c39e6b6b67496163ef8d80d243220a4918e8bef
 
 COPY --from=builder /usr/bin/oc /usr/bin/oc
 COPY --from=builder /usr/bin/gather /usr/bin/gather_original


### PR DESCRIPTION
Operator teams will be asked to switch to ubi-micro in the future.

https://redhat.atlassian.net/browse/OCPSTRAT-3522

We are asked to try and switch to ubi-micro. Going to open this up and see if everything fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated runtime container images to use pinned UBI Micro bases.
  * Streamlined runtime image contents by removing an unnecessary diagnostic utility.
  * Preserved existing application binaries, labels, user configuration, and runtime behavior.
  * Applied these container image updates consistently across standard, Kueue, and must-gather images.
  * Reduced the runtime image footprint while maintaining the existing deployment configuration and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->