### PR TITLE
OCPKUEUE-748: enable hierarchical cohort e2e tests in downstream CI

### DIFF
--- a/upstream/kueue/e2e-test-ocp.sh
+++ b/upstream/kueue/e2e-test-ocp.sh
@@ -47,7 +47,7 @@ function ginkgo_label_filter() {
   local folder="$1"
   case "$folder" in
     singlecluster)
-      echo "feature:certs,feature:deployment,feature:e2e_v1beta1,feature:job,feature:jobset,feature:leaderworkerset,feature:metrics,feature:statefulset,feature:visibility"
+      echo "feature:certs,feature:cohort,feature:deployment,feature:e2e_v1beta1,feature:job,feature:jobset,feature:leaderworkerset,feature:metrics,feature:statefulset,feature:visibility"
       ;;
     certmanager)
       echo "!feature:prometheus"


### PR DESCRIPTION
Add feature:cohort to the singlecluster ginkgo label filter so that upstream hierarchical cohort tests run in the kueue-operator e2e CI job.

JIRA: https://redhat.atlassian.net/browse/OCPKUEUE-748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated single-cluster end-to-end test selection to include cohort-related scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->