### PR TITLE
Update Kueue submodule to latest release-0.18 (6c382a84)

### DIFF
--- a/bindata/assets/kueue-operator/clusterroles/clusterrole-manager-role.yaml
+++ b/bindata/assets/kueue-operator/clusterroles/clusterrole-manager-role.yaml
@@ -56,23 +56,58 @@ rules:
   - watch
 - apiGroups:
   - admissionregistration.k8s.io
+  resourceNames:
+  - kueue-mutating-webhook-configuration
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
-  - get
   - list
-  - update
   - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - kueue-validating-webhook-configuration
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - update
 - apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   verbs:
-  - get
   - list
-  - update
   - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
+  - clusterprofiles.multicluster.x-k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+- apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
+  - clusterqueues.kueue.x-k8s.io
+  - cohorts.kueue.x-k8s.io
+  - localqueues.kueue.x-k8s.io
+  - multikueueclusters.kueue.x-k8s.io
+  - workloads.kueue.x-k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - update
 - apiGroups:
   - apps
   resources:

--- a/bindata/assets/kueue-operator/crds/crd-workloads.kueue.x-k8s.io-v1beta2.yaml
+++ b/bindata/assets/kueue-operator/crds/crd-workloads.kueue.x-k8s.io-v1beta2.yaml
@@ -9453,12 +9453,12 @@ spec:
             && has(self.spec.priorityClassName)) ? (oldSelf.spec.priorityClassName
             == self.spec.priorityClassName) : true'
         - message: queueName is immutable while workload quota reserved
-          rule: '(has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c,
+          rule: '((has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c,
             c.type == ''QuotaReserved'' && c.status == ''True'')) && (has(self.status)
             && has(self.status.conditions) && self.status.conditions.exists(c, c.type
-            == ''QuotaReserved'' && c.status == ''True'')) && has(oldSelf.spec.queueName)
-            && has(self.spec.queueName) ? oldSelf.spec.queueName == self.spec.queueName
-            : true'
+            == ''QuotaReserved'' && c.status == ''True''))) ? ((has(oldSelf.spec.queueName)
+            == has(self.spec.queueName)) && (!has(oldSelf.spec.queueName) || oldSelf.spec.queueName
+            == self.spec.queueName)) : true'
         - message: maximumExecutionTimeSeconds is immutable while workload quota reserved
           rule: ((has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c,
             c.type == 'Admitted' && c.status == 'True')) && (has(self.status) && has(self.status.conditions)
@@ -19141,12 +19141,12 @@ spec:
             ? oldSelf.spec.priorityClassRef.name == self.spec.priorityClassRef.name
             : true'
         - message: queueName is immutable while workload quota reserved
-          rule: '(has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c,
+          rule: '((has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c,
             c.type == ''QuotaReserved'' && c.status == ''True'')) && (has(self.status)
             && has(self.status.conditions) && self.status.conditions.exists(c, c.type
-            == ''QuotaReserved'' && c.status == ''True'')) && has(oldSelf.spec.queueName)
-            && has(self.spec.queueName) ? oldSelf.spec.queueName == self.spec.queueName
-            : true'
+            == ''QuotaReserved'' && c.status == ''True''))) ? ((has(oldSelf.spec.queueName)
+            == has(self.spec.queueName)) && (!has(oldSelf.spec.queueName) || oldSelf.spec.queueName
+            == self.spec.queueName)) : true'
         - message: maximumExecutionTimeSeconds is immutable while workload quota reserved
           rule: ((has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c,
             c.type == 'Admitted' && c.status == 'True')) && (has(self.status) && has(self.status.conditions)


### PR DESCRIPTION
## Summary

Updates the `upstream/kueue/src` submodule (tracking `release-0.18`) from `e4ce3bcc` to `6c382a84` (185 commits) and re-syncs generated manifests via `make submodule-workflow`. Targets the `release-1.4` branch.

**Updated submodule commit SHA:** `6c382a8411f4899a504374c2b8e959d4f8886fe7`

## Manifest changes

- `clusterrole-manager-role.yaml` — scope webhook/CRD ClusterRole permissions with `resourceNames` (upstream #13611)
- `crd-workloads.kueue.x-k8s.io-v1beta2.yaml` — refine the `queueName` immutability CEL rule so it correctly handles adding/removing the field on quota-reserved workloads (upstream #14080)

## Notable upstream commits

- `6c382a841` [release-0.18] TAS: account for domains a second pass reassignment moves onto (#14646)
- `b52de939d` fix(pod): refuse adopting and finalizing foreign Workloads by pod group name (#14617)
- `d8d7e976e` Fix time-to-readiness metrics being reported after failure recovery (#14637)
- `1d36a3337` Backfill queue-name onto LeaderWorkerSet pods (#14603)
- `cc7b9955a` Correct Flavor Assignment in Pod Importer (#14582)
- `d0817cd09` fix(multikueue): prevent establishWatch from blocking on timeout (#14559)
- `f3bfd58fc` Prepare release v0.18.5 (#14303)
- `92f4134c2` Refuse a quota reservation with no admission, and let an existing one drain (#14193)
- `56ef6f1b8` Reject changing queueName on admitted workload (#14080)
- `e86db4480` fix: scope ClusterRole webhook and CRD permissions with resourceNames (#13611)

_185 commits total; see the submodule range `e4ce3bcc..6c382a84` for the full list._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated workload validation so `queueName` may remain unset when quota is reserved, while still preventing changes when a value is provided.
  * Improved consistency of workload validation across supported resource definitions.

* **Security**
  * Tightened operator access controls by limiting permissions to only the required resources, actions, and named configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->